### PR TITLE
This is second update for THcCherenkov.cxx class. I have added four more

### DIFF
--- a/examples/hodtest.C
+++ b/examples/hodtest.C
@@ -72,7 +72,7 @@
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events
-  run->SetEventRange(1,5000);//  Physics Event number, does not
+  run->SetEventRange(1,100000);//  Physics Event number, does not
                                 // include scaler or control events
 
   // Define the analysis parameters

--- a/src/THcCherenkov.h
+++ b/src/THcCherenkov.h
@@ -52,14 +52,16 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   Float_t*   fT_Pos;         // [fNelem] Array of TDCs
   Float_t*   fT_Neg;         // [fNelem] Array of TDCs
 
-  Float_t   fA_1;         // Ahmed
-  Float_t   fA_2;         // Ahmed
-  Float_t   fA_p_1;         // Ahmed
-  Float_t   fA_p_2;         // Ahmed
-  Double_t fNpe_1;		// Ahmed
-  Double_t fNpe_2;		// Ahmed
-  Int_t fNHits_1;         // Ahmed
-  Int_t fNHits_2;         // Ahmed
+  Double_t  fA_1;         // Ahmed
+  Double_t  fA_2;         // Ahmed
+  Double_t  fNHits_1;     // Ahmed
+  Double_t  fNHits_2;     // Ahmed
+  Double_t  fNHits;       // Ahmed
+  Double_t  fA_p_1;       // Ahmed
+  Double_t  fA_p_2;       // Ahmed
+  Double_t  fNpe_1;       // Ahmed
+  Double_t  fNpe_2;       // Ahmed
+  Double_t  fNpe;         // Ahmed
 
   Double_t fPosNpeSum;
   Double_t fNegNpeSum;


### PR DESCRIPTION
variables. Total photo electrons, total hits of adc 1, total hits of adc 2
and total hits. With this update we have transformed the FORTRAN code of
file /engine/HTRACKING/h_trans_cer.f to /hcana/ser/THcCherenkov.cxx

NOTE: The pedestal value in ENGINE is an integer but in hcana it is a
flaoting number. So it changes the pedestal substracted vlues of adc 1
and adc 2 and the number of photo electrons of adc 1 and 2 by very small
fraction. The difference of total photo electrons between ENGINE and hcana
is not more than 0.005.
