### PR TITLE
Fixed the wrong raster channel assignments in the map files.

### DIFF
--- a/examples/MAPS/raster_july04.map
+++ b/examples/MAPS/raster_july04.map
@@ -1989,9 +1989,9 @@ Slot= 5 ! ADC  Second set of tubes on first two layers
 !              3-->ADC Y-signal
 
   14, 1, 1, 0 !ADC ROC#1 Sl#13 Ch#12 Fast Raster X-sync
-  15, 2, 1, 1 !ADC ROC#1 Sl#13 Ch#13 Fast Raster X-signal
-  12, 3, 1, 2 !ADC ROC#1 Sl#13 Ch#14 Fast Raster Y-sync
-  13, 4, 1, 3 !ADC ROC#1 Sl#13 Ch#15 Fast Raster Y-signal
+  15, 1, 1, 1 !ADC ROC#1 Sl#13 Ch#13 Fast Raster X-signal
+  12, 1, 1, 2 !ADC ROC#1 Sl#13 Ch#14 Fast Raster Y-sync
+  13, 1, 1, 3 !ADC ROC#1 Sl#13 Ch#15 Fast Raster Y-signal
 !
   detector= 6 ! GMISC
 !  16, 2, 17, 0  !ADC ROC#1 Sl#15 Ch#16 H00C X+

--- a/examples/MAPS/raster_jun04.map
+++ b/examples/MAPS/raster_jun04.map
@@ -1988,10 +1988,10 @@ Slot= 5 ! ADC  Second set of tubes on first two layers
 !              2-->ADC Y-sync
 !              3-->ADC Y-signal
 
-  12, 2, 1, 0 !ADC ROC#1 Sl#13 Ch#12 Fast Raster X-sync
-  13, 2, 1, 1 !ADC ROC#1 Sl#13 Ch#13 Fast Raster X-signal
-  14, 2, 1, 2 !ADC ROC#1 Sl#13 Ch#14 Fast Raster Y-sync
-  15, 2, 1, 3 !ADC ROC#1 Sl#13 Ch#15 Fast Raster Y-signal
+  14, 1, 1, 0 !ADC ROC#1 Sl#13 Ch#12 Fast Raster X-sync
+  15, 1, 1, 1 !ADC ROC#1 Sl#13 Ch#13 Fast Raster X-signal
+  12, 1, 1, 2 !ADC ROC#1 Sl#13 Ch#14 Fast Raster Y-sync
+  13, 1, 1, 3 !ADC ROC#1 Sl#13 Ch#15 Fast Raster Y-signal
 !
   detector= 6 ! GMISC
 !


### PR DESCRIPTION
In raster_july04.map I had the wrong channel assignments for raster X and Y. Theses needed to be switched according to july04.map.

In both map files, changed the plane assignments of all the raster channels to be 1 instead of 1,2,3,4. This then follows the ENGINE convention.
