### PR TITLE
Remove track related variables from the HMS Shower class, use ntuples

### DIFF
--- a/examples/output_52949.def
+++ b/examples/output_52949.def
@@ -4,6 +4,7 @@ block H.dc.*
 block H.hod.*
 block H.cal.*
 block H.aero.*
+block H.tr.*
 block g.evtyp
 
 # TDC spectra

--- a/examples/output_mkj.def
+++ b/examples/output_mkj.def
@@ -4,6 +4,7 @@ block H.dc.*
 block H.hod.*
 block H.cal.*
 block H.aero.*
+block H.tr.*
 block g.evtyp
 
 # TDC spectra

--- a/hcal_calib/THcShowerCalib.h
+++ b/hcal_calib/THcShowerCalib.h
@@ -270,11 +270,11 @@ void THcShowerCalib::ReadShRawTrack(THcShTrack &trk, UInt_t ientry) {
   fTree->SetBranchAddress("H.cal.4ta.aneg_p",H_cal_4ta_aneg_p);
   fTree->SetBranchAddress("H.cal.4ta.apos_p",H_cal_4ta_apos_p);
 
-  fTree->SetBranchAddress("H.cal.trp",&H_cal_trp);
   fTree->SetBranchAddress("H.cal.trx",&H_cal_trx);
-  fTree->SetBranchAddress("H.cal.trxp",&H_cal_trxp);
   fTree->SetBranchAddress("H.cal.try",&H_cal_try);
-  fTree->SetBranchAddress("H.cal.tryp",&H_cal_tryp);
+  fTree->SetBranchAddress("H.tr.th",&H_cal_trxp);
+  fTree->SetBranchAddress("H.tr.ph",&H_cal_tryp);
+  fTree->SetBranchAddress("H.tr.p",&H_cal_trp);
 
   fTree->GetEntry(ientry);
 
@@ -623,7 +623,7 @@ void THcShowerCalib::FillHEcal() {
     hEcal->Fill(Enorm);
 
     Double_t delta;
-    fTree->SetBranchAddress("H.cal.trdelta",&delta);
+    fTree->SetBranchAddress("H.tr.tg_dp",&delta);
     hDPvsEcal->Fill(Enorm,delta,1.);
 
     output << Enorm*P/1000. << " " << P/1000. << endl;

--- a/hcal_calib/hcal_replay_cuts.def
+++ b/hcal_calib/hcal_replay_cuts.def
@@ -23,18 +23,18 @@ RawCoarseReconstruct !Pedestal_event
 
 Block: Reconstruct
 
-one_track H.dc.ntrack==1
+one_track H.tr.n==1
 #one_clust H.cal.nclust==1
 one_sh_track H.cal.ntracks==1
-in_delta  H.cal.trdelta>-10.&&H.cal.trdelta<10.
+in_delta  H.tr.tg_dp>-10.&&H.tr.tg_dp<10.
 good_cer H.cer.npesum>3.
-good_beta H.cal.trbeta>0.9&&H.cal.trbeta<1.1
+good_beta H.tr.beta>0.9&&H.tr.beta<1.1
 in_calx   H.cal.trx>-60.&&H.cal.trx<60.
 in_caly   H.cal.try>-30.&&H.cal.try<30.
 in_cal    in_calx&&in_caly
 
-Reconstruct_master one_track&&in_delta
-#Reconstruct_master one_track&&one_sh_track&&in_delta&&good_cer
-#Reconstruct_master one_track&&one_clust&&in_delta&&good_cer
-#Reconstruct_master one_track&&one_clust&&in_delta&&good_cer&&in_cal
-#&&good_beta
+# This version matches engine
+#Reconstruct_master one_track && one_sh_track && in_delta && good_cer && good_beta && in_cal
+
+# Drop beta, which is not present yet
+Reconstruct_master one_track && one_sh_track && in_delta && good_cer && in_cal

--- a/hcal_calib/output_hcal_replay.def
+++ b/hcal_calib/output_hcal_replay.def
@@ -2,17 +2,11 @@
 # Output definition for the HMS calorimeter calibration.
 #
 
-#block H.dc.*
-#block H.hod.*
-#block H.cal.*
-#block H.aero.*
-#block H.cer.*
-#block g.evtyp
-
 block H.cal.*
 variable H.cer.npesum
-variable H.dc.ntrack
-
-#variable H.dc.delta
-#variable H.dc.P
-#variable H.hod.beta
+variable H.tr.beta
+variable H.tr.p
+variable H.tr.tg_dp
+variable H.tr.ph	#tan(phi), wrt Y axis
+variable H.tr.th	#tan(theta), wrt X axis
+variable H.tr.n		#number of tracks

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -444,18 +444,6 @@ Int_t THcShower::DefineVariables( EMode mode )
   };
   DefineVarsFromList( vars, mode );
 
-  // Additional quantities for calibration. Revise later on.
-
-  RVarDef cvars[] = {
-    { "trdelta", "Track momentum deviation, %", "fTRDeltaP" },
-    { "trbeta",  "Track beta from scint's",     "fTRBeta"},
-    { "trp",     "Track momentum",              "fTRP"},
-    { "trxp",    "Track x-slope",               "fTRXp"},
-    { "tryp",    "Track y-slope",                "fTRYp"},
-    { 0 }
-  };
-  return DefineVarsFromList( cvars, mode );
-
 }
 
 //_____________________________________________________________________________
@@ -519,13 +507,6 @@ void THcShower::Clear(Option_t* opt)
     fTREpl_neg_cor[ip] = -0.;
   }
 
-  // Additional quantities for calibration purposes.
-
-  fTRDeltaP = -25.;  //out of acceptance
-  fTRBeta = -1.;
-  fTRP = -1.;
-  fTRXp = -0.5;
-  fTRYp = -0.15;
 }
 
 //_____________________________________________________________________________
@@ -954,19 +935,6 @@ Int_t THcShower::FineProcess( TClonesArray& tracks )
   // Calculation of coordinates of particle track cross point with shower
   // plane in the detector coordinate system. For this, parameters of track 
   // reconstructed in THaVDC::FineTrack() are used.
-
-  // Additional quantities for calibration, taken from the 1-st track currently.
-
-  Int_t Ntracks = tracks.GetLast()+1;   // Number of reconstructed tracks
-
-  if(Ntracks > 0) {
-    THaTrack* theTrack = static_cast<THaTrack*>( tracks[0] );
-    fTRDeltaP = theTrack->GetDp();
-    fTRBeta   = theTrack->GetBeta();
-    fTRP      = theTrack->GetP();
-    fTRXp     = theTrack->GetTheta();
-    fTRYp     = theTrack->GetPhi();
-  };
 
   return 0;
 }

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -150,13 +150,6 @@ protected:
   Double_t* fTREpl_pos_cor;  // Y-corrected track positive energy per plane
   Double_t* fTREpl_neg_cor;  // Y-corrected track negative energy per plane
 
-  // Additional quantities for calibration. Revise later on.
-  Double_t fTRDeltaP;          // track delta(P), %.
-  Double_t fTRBeta;            // track beta from scint's.
-  Double_t fTRP;               // Track momentum.
-  Double_t fTRXp;              // Track x slope.
-  Double_t fTRYp;              // Track y slope.
-
   // Potential Hall C parameters.  Mostly here for demonstration
 
   char** fLayerNames;


### PR DESCRIPTION
from the track (H.tr) block instead in the HMS calorimeter calibration
scripts.
- Remove a block of duplicated track related variables from the
  THcShower class which has been added for calorimeter calibration
  purposes.
- In hcal_calib directory, replace those variables with correspondent
  variables from H.tr block in the calorimeter calibration class
  (THcShowerCalib.h), in the cut (hcal_replay_cuts.def) and output
  (output_hcal_replay.def) definitions.
