### PR TITLE
Don't access time_pos[i] and time_neg[i] if not defined.

### DIFF
--- a/src/THcScintillatorPlane.cxx
+++ b/src/THcScintillatorPlane.cxx
@@ -463,26 +463,19 @@ Int_t THcScintillatorPlane::PulseHeightCorrection()
       maxhit=timehist[i];
     }
   }
-  if (jmax>=0) {
-    tmin=0.5*jmax;
-    for (i=0;i<fNScinHits;i++) {
-      if ((time_pos[i]>tmin) && (time_pos[i]<tmin+toftolerance)) {
-	keep_pos[i]=kTRUE;
-      }
-      if ((time_neg[i]>tmin) && (time_neg[i]<tmin+toftolerance)) {
-	keep_neg[i]=kTRUE;
-      }
-    }
-  }
   // Resume regular tof code, now using time filer(?) from above
   // Check for TWO good TDC hits
   for (i=0;i<fNScinHits;i++) {
     if ((((THcSignalHit*) fPosTDCHits->At(i))->GetData()>=mintdc) &&
 	(((THcSignalHit*) fPosTDCHits->At(i))->GetData()<=maxtdc) &&
 	(((THcSignalHit*) fNegTDCHits->At(i))->GetData()>=mintdc) &&
-	(((THcSignalHit*) fNegTDCHits->At(i))->GetData()<=maxtdc) &&
-	keep_pos[i] && keep_neg[i]) {
-      two_good_times[i]=kTRUE;
+	(((THcSignalHit*) fNegTDCHits->At(i))->GetData()<=maxtdc)) {
+      if(jmax>=0) {
+	tmin = 0.5*jmax;
+	if ((time_pos[i]>tmin) && (time_pos[i]<tmin+toftolerance) &&
+	    (time_neg[i]>tmin) && (time_neg[i]<tmin+toftolerance))
+	  two_good_times[i]=kTRUE;
+      }
     }
   } // end of loop that finds tube setting time
   for (i=0;i<fNScinHits;i++) {


### PR DESCRIPTION
valgrind revealed that time_pos[i] and time_neg[i] were being accessed when not necessarily set.  Since they are only used to decide wether to set keep_pos[i] and keep_neg[i], and those in turn are only used when time_pos[i] and time_neg[i] to help set two_good_times[i], I moved things around so that they don't get accessed if not set.

This is all part of some hack that I don't understand, I want someone else to agree to this change.
