### PR TITLE
Remove unnecessary TMath::Nint() calls to fix compile error

### DIFF
--- a/src/THcHallCSpectrometer.cxx
+++ b/src/THcHallCSpectrometer.cxx
@@ -474,7 +474,7 @@ Int_t THcHallCSpectrometer::TrackCalc()
 
 	      fHitPos4  = goodTrack->GetY() + goodTrack->GetPhi() * ( fScin2YZpos + 0.5 * fScin2YdZpos );
 	      fHitCnt4  = TMath::Nint( ( fHodo->GetPlaneCenter(3) - fHitPos4 ) / fHodo->GetPlaneSpacing(3) ) + 1;
-	      fHitCnt4  = TMath::Max( TMath::Min(fHitCnt4,TMath::Nint( fHodo->GetNPaddles(3) ) ) , 1); // scin_2y_nr = 10
+	      fHitCnt4  = TMath::Max( TMath::Min(fHitCnt4, fHodo->GetNPaddles(3) ) , 1); // scin_2y_nr = 10
 	      fHitDist4 = fHitPos4 - ( fHodo->GetPlaneCenter(3) - fHodo->GetPlaneSpacing(3) * ( fHitCnt4 - 1 ) );
 	      	      
 	      //----------------------------------------------------------------
@@ -504,7 +504,7 @@ Int_t THcHallCSpectrometer::TrackCalc()
 
 	      fHitPos3  = goodTrack->GetX() + goodTrack->GetTheta() * ( fScin2XZpos + 0.5 * fScin2XdZpos );
 	      fHitCnt3  = TMath::Nint( ( fHitPos3 - fHodo->GetPlaneCenter(2) ) / fHodo->GetPlaneSpacing(2) ) + 1;
-	      fHitCnt3  = TMath::Max( TMath::Min(fHitCnt3,TMath::Nint( fHodo->GetNPaddles(2) ) ) , 1); // scin_2x_nr = 16
+	      fHitCnt3  = TMath::Max( TMath::Min(fHitCnt3, fHodo->GetNPaddles(2) ) , 1); // scin_2x_nr = 16
 	      fHitDist3 = fHitPos3 - ( fHodo->GetPlaneSpacing(2) * ( fHitCnt3 - 1 ) + fHodo->GetPlaneCenter(2) );
 
 	      //----------------------------------------------------------------


### PR DESCRIPTION
No need to call Nint() on an integer.  This was generating a compile error on my (debian) machine.

(Actually, it doesn't look like the fHitCnt{3,4} (and associated fHitPos/Dist) variables are actually used anywhere.  Perhaps just staging for a future patchset?)
