### PR TITLE
Rename THcHodoscopeHit class to THcRawHodoHit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SRC  =  src/THcInterface.cxx src/THcParmList.cxx src/THcAnalyzer.cxx \
 	src/THcRawHit.cxx src/THcHitList.cxx \
 	src/THcSignalHit.cxx \
 	src/THcHodoscope.cxx src/THcScintillatorPlane.cxx \
-	src/THcHodoscopeHit.cxx \
+	src/THcRawHodoHit.cxx \
 	src/THcDC.cxx src/THcDriftChamberPlane.cxx \
 	src/THcDriftChamber.cxx \
 	src/THcRawDCHit.cxx src/THcDCHit.cxx \

--- a/SConscript.py
+++ b/SConscript.py
@@ -13,7 +13,7 @@ roothcobj = pbaseenv.subst('$HC_SRC')+'/HallCDict.so'
 hcheaders = Split("""
 	src/THcInterface.h src/THcParmList.h src/THcAnalyzer.h src/THcHallCSpectrometer.h 
 	src/THcDetectorMap.h src/THcRawHit.h src/THcHitList.h src/THcSignalHit.h src/THcHodoscope.h 
-	src/THcScintillatorPlane.h src/THcHodoscopeHit.h src/THcDC.h src/THcDriftChamberPlane.h 
+	src/THcScintillatorPlane.h src/THcRawHodoHit.h src/THcDC.h src/THcDriftChamberPlane.h 
 	src/THcDriftChamber.h src/THcRawDCHit.h src/THcDCHit.h src/THcDCWire.h src/THcSpacePoint.h 
 	src/THcDCLookupTTDConv.h src/THcDCTimeToDistConv.h src/THcShower.h src/THcShowerPlane.h 
 	src/THcRawShowerHit.h src/THcAerogel.h src/THcAerogelHit.h src/THcCherenkov.h src/THcCherenkovHit.h

--- a/src/HallC_LinkDef.h
+++ b/src/HallC_LinkDef.h
@@ -29,7 +29,7 @@
 #pragma link C++ class THcSignalHit+;
 #pragma link C++ class THcHodoscope+;
 #pragma link C++ class THcScintillatorPlane+;
-#pragma link C++ class THcHodoscopeHit+;
+#pragma link C++ class THcRawHodoHit+;
 #pragma link C++ class THcDC+;
 #pragma link C++ class THcDriftChamber+;
 #pragma link C++ class THcDriftChamberPlane+;

--- a/src/THcAerogelHit.h
+++ b/src/THcAerogelHit.h
@@ -1,9 +1,9 @@
 #ifndef ROOT_THcAerogelHit
 #define ROOT_THcAerogelHit
 
-#include "THcHodoscopeHit.h"
+#include "THcRawHodoHit.h"
 
-class THcAerogelHit : public THcHodoscopeHit {
+class THcAerogelHit : public THcRawHodoHit {
 
  public:
   friend class THcAerogel;

--- a/src/THcCherenkovHit.h
+++ b/src/THcCherenkovHit.h
@@ -1,9 +1,9 @@
 #ifndef ROOT_THcCherenkovHit
 #define ROOT_THcCherenkovHit
 
-#include "THcHodoscopeHit.h"
+#include "THcRawHodoHit.h"
 
-class THcCherenkovHit : public THcHodoscopeHit {
+class THcCherenkovHit : public THcRawHodoHit {
 
  public:
   friend class THcCherenkov;

--- a/src/THcHallCSpectrometer.h
+++ b/src/THcHallCSpectrometer.h
@@ -14,7 +14,7 @@
 #include "TClonesArray.h"
 #include "THaNonTrackingDetector.h"
 #include "THcHitList.h"
-#include "THcHodoscopeHit.h"
+#include "THcRawHodoHit.h"
 #include "THcScintillatorPlane.h"
 #include "THcShower.h"
 

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -164,7 +164,7 @@ THaAnalysisObject::EStatus THcHodoscope::Init( const TDatime& date )
   // --------------- To get energy from THcShower ----------------------
 
 
-  InitHitList(fDetMap, "THcHodoscopeHit", 100);
+  InitHitList(fDetMap, "THcRawHodoHit", 100);
 
   EStatus status;
   // This triggers call of ReadDatabase and DefineVariables
@@ -770,7 +770,7 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
   }
 #if 0
   for(Int_t ihit = 0; ihit < fNRawHits ; ihit++) {
-    THcHodoscopeHit* hit = (THcHodoscopeHit *) fRawHitList->At(ihit);
+    THcRawHodoHit* hit = (THcRawHodoHit *) fRawHitList->At(ihit);
     cout << ihit << " : " << hit->fPlane << ":" << hit->fCounter << " : "
 	 << hit->fADC_pos << " " << hit->fADC_neg << " "  <<  hit->fTDC_pos
 	 << " " <<  hit->fTDC_neg << endl;

--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -12,7 +12,7 @@
 #include "TClonesArray.h"
 #include "THaNonTrackingDetector.h"
 #include "THcHitList.h"
-#include "THcHodoscopeHit.h"
+#include "THcRawHodoHit.h"
 #include "THcScintillatorPlane.h"
 #include "THcShower.h"
 

--- a/src/THcRawHodoHit.cxx
+++ b/src/THcRawHodoHit.cxx
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 //                                                                           //
-// THcHodoscopeHit                                                           //
+// THcRawHodoHit                                                           //
 //                                                                           //
 // Class representing a single raw hit for a hodoscope paddle                //
 //                                                                           //
@@ -13,12 +13,12 @@
 #include <cstdlib>
 #include <iostream>
 
-#include "THcHodoscopeHit.h"
+#include "THcRawHodoHit.h"
 
 using namespace std;
 
 
-void THcHodoscopeHit::SetData(Int_t signal, Int_t data) {
+void THcRawHodoHit::SetData(Int_t signal, Int_t data) {
   if(signal==0) {
     fADC_pos = data;
   } else if (signal==1) {
@@ -30,7 +30,7 @@ void THcHodoscopeHit::SetData(Int_t signal, Int_t data) {
   }
 }
 
-Int_t THcHodoscopeHit::GetData(Int_t signal) {
+Int_t THcRawHodoHit::GetData(Int_t signal) {
   if(signal==0) {
     return(fADC_pos);
   } else if (signal==1) {
@@ -44,7 +44,7 @@ Int_t THcHodoscopeHit::GetData(Int_t signal) {
 }
 
 //_____________________________________________________________________________
-THcHodoscopeHit& THcHodoscopeHit::operator=( const THcHodoscopeHit& rhs )
+THcRawHodoHit& THcRawHodoHit::operator=( const THcRawHodoHit& rhs )
 {
   // Assignment operator.
 
@@ -62,5 +62,5 @@ THcHodoscopeHit& THcHodoscopeHit::operator=( const THcHodoscopeHit& rhs )
 
 
 //////////////////////////////////////////////////////////////////////////
-ClassImp(THcHodoscopeHit)
+ClassImp(THcRawHodoHit)
 

--- a/src/THcRawHodoHit.h
+++ b/src/THcRawHodoHit.h
@@ -1,19 +1,19 @@
-#ifndef ROOT_THcHodoscopeHit
-#define ROOT_THcHodoscopeHit
+#ifndef ROOT_THcRawHodoHit
+#define ROOT_THcRawHodoHit
 
 #include "THcRawHit.h"
 
-class THcHodoscopeHit : public THcRawHit {
+class THcRawHodoHit : public THcRawHit {
 
  public:
   friend class THcScintillatorPlane;
 
-  THcHodoscopeHit(Int_t plane=0, Int_t counter=0) : THcRawHit(plane, counter), 
+  THcRawHodoHit(Int_t plane=0, Int_t counter=0) : THcRawHit(plane, counter), 
     fADC_pos(-1), fADC_neg(-1),
     fTDC_pos(-1), fTDC_neg(-1) {
   }
-  THcHodoscopeHit& operator=( const THcHodoscopeHit& );
-  virtual ~THcHodoscopeHit() {}
+  THcRawHodoHit& operator=( const THcRawHodoHit& );
+  virtual ~THcRawHodoHit() {}
 
   virtual void Clear( Option_t* opt="" )
     { fADC_pos = -1; fADC_neg = -1; fTDC_pos = -1; fTDC_neg = -1; }
@@ -32,7 +32,7 @@ class THcHodoscopeHit : public THcRawHit {
 
  private:
 
-  ClassDef(THcHodoscopeHit, 0);	// Raw Hodoscope hit
+  ClassDef(THcRawHodoHit, 0);	// Raw Hodoscope hit
 };  
 
 #endif

--- a/src/THcScintillatorPlane.cxx
+++ b/src/THcScintillatorPlane.cxx
@@ -310,7 +310,7 @@ Int_t THcScintillatorPlane::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
   //  cout << "THcScintillatorPlane: raw htis = " << nrawhits << endl;
   
   while(ihit < nrawhits) {
-    THcHodoscopeHit* hit = (THcHodoscopeHit *) rawhits->At(ihit);
+    THcRawHodoHit* hit = (THcRawHodoHit *) rawhits->At(ihit);
     if(hit->fPlane > fPlaneNum) {
       break;
     }
@@ -542,7 +542,7 @@ Int_t THcScintillatorPlane::AccumulatePedestals(TClonesArray* rawhits, Int_t nex
 
   Int_t ihit = nexthit;
   while(ihit < nrawhits) {
-    THcHodoscopeHit* hit = (THcHodoscopeHit *) rawhits->At(ihit);
+    THcRawHodoHit* hit = (THcRawHodoHit *) rawhits->At(ihit);
     if(hit->fPlane > fPlaneNum) {
       break;
     }


### PR DESCRIPTION
This change is anticipation of dealing with Issue #73.  A hit class (like THcDCHit) will be create to deal with all the parallel arrays in the hodoscope.  THcHodoscopeHit is being renamed so that it is clear that it holds the raw information straight out of the hitlist decoder.
