### PR TITLE
Two changes.

### DIFF
--- a/src/THcDriftChamber.cxx
+++ b/src/THcDriftChamber.cxx
@@ -289,7 +289,7 @@ Int_t THcDriftChamber::FindSpacePoints( void )
       PlanePInd=XPlanePInd;
     }
     if(fPlanes[PlaneInd]->GetNHits() == 1 && fPlanes[PlanePInd]->GetNHits() == 1
-       && TMath::Abs(fHits[plane_hitind]->GetPos() - fHits[planep_hitind]->GetPos())
+       && pow( (fHits[plane_hitind]->GetPos() - fHits[planep_hitind]->GetPos()),2)
        < fSpacePointCriterion
        && fNhits <= 6) {	// An easy case, probably one hit per plane
       if(fHMSStyleChambers) fEasySpacePoint = FindEasySpacePoint_HMS(plane_hitind, planep_hitind);

--- a/src/THcDriftChamber.h
+++ b/src/THcDriftChamber.h
@@ -15,7 +15,7 @@
 #include <map>
 #include <vector>
 
-#define MAX_SPACE_POINTS 50
+#define MAX_SPACE_POINTS 100
 #define MAX_HITS_PER_POINT 20
 
 //#include "TMath.h"


### PR DESCRIPTION
 First, in h_pattern_recognition.f we have:

https://github.com/zahmed9/engine/blob/mkj/HTRACKING/h_pattern_recognition.f#L139
(hdc_wire_center(yy)-hdc_wire_center(yyprime))**2 .lt. (hspace_point_criterion(ich))

So I changed
https://github.com/zahmed9/hcana/blob/develop/src/THcDriftChamber.cxx#L292
TMath::Abs(fHits[plane_hitind]->GetPos() - fHits[planep_hitind]->GetPos()) < fSpacePointCriterion

to

pow((fHits[plane_hitind]->GetPos() - fHits[planep_hitind]->GetPos()),2) < fSpacePointCriterion

Second, the value of MAX_SPACE_POINTS in ENGINE is 100 so in hcana I changed it from 50 to 100.
