### PR TITLE
Update hit clustering and calibration code of the HMS calorimeter.

### DIFF
--- a/hcal_calib/THcShowerCalib.h
+++ b/hcal_calib/THcShowerCalib.h
@@ -16,6 +16,8 @@
 #include "TFile.h"
 #include "TTree.h"
 
+#define D_CALO_FP 338.69    //distance from FP to the calorimeter face
+
 using namespace std;
 
 //
@@ -250,11 +252,11 @@ void THcShowerCalib::ReadShRawTrack(THcShTrack &trk, UInt_t ientry) {
 
   // Track parameters.
 
-  Double_t        H_cal_trp;
-  Double_t        H_cal_trx;
-  Double_t        H_cal_trxp;
-  Double_t        H_cal_try;
-  Double_t        H_cal_tryp;
+  Double_t        H_tr_p;
+  Double_t        H_tr_x;   //X FP
+  Double_t        H_tr_xp;
+  Double_t        H_tr_y;   //Y FP
+  Double_t        H_tr_yp;
 
   // Set branch addresses.
 
@@ -270,15 +272,16 @@ void THcShowerCalib::ReadShRawTrack(THcShTrack &trk, UInt_t ientry) {
   fTree->SetBranchAddress("H.cal.4ta.aneg_p",H_cal_4ta_aneg_p);
   fTree->SetBranchAddress("H.cal.4ta.apos_p",H_cal_4ta_apos_p);
 
-  fTree->SetBranchAddress("H.cal.trx",&H_cal_trx);
-  fTree->SetBranchAddress("H.cal.try",&H_cal_try);
-  fTree->SetBranchAddress("H.tr.th",&H_cal_trxp);
-  fTree->SetBranchAddress("H.tr.ph",&H_cal_tryp);
-  fTree->SetBranchAddress("H.tr.p",&H_cal_trp);
+  fTree->SetBranchAddress("H.tr.x",&H_tr_x);
+  fTree->SetBranchAddress("H.tr.y",&H_tr_y);
+  fTree->SetBranchAddress("H.tr.th",&H_tr_xp);
+  fTree->SetBranchAddress("H.tr.ph",&H_tr_yp);
+  fTree->SetBranchAddress("H.tr.p",&H_tr_p);
 
   fTree->GetEntry(ientry);
 
-  trk.Reset(H_cal_trp, H_cal_trx, H_cal_trxp, H_cal_try, H_cal_tryp);
+  trk.Reset(H_tr_p, H_tr_x+D_CALO_FP*H_tr_xp, H_tr_xp,
+	    H_tr_y+D_CALO_FP*H_tr_yp, H_tr_yp);
 
   for (UInt_t j=0; j<THcShTrack::fNrows; j++) {
     for (UInt_t k=0; k<THcShTrack::fNcols; k++) {

--- a/hcal_calib/hcal_replay_cuts.def
+++ b/hcal_calib/hcal_replay_cuts.def
@@ -28,19 +28,22 @@ one_clust H.cal.nclust==1
 one_sh_track H.cal.ntracks==1
 in_delta  H.tr.tg_dp>-10.&&H.tr.tg_dp<10.
 good_cer H.cer.npesum>3.
-#good_beta H.tr.beta>0.9&&H.tr.beta<1.1
-good_beta H.hod.fpBeta>0.740&&H.hod.fpBeta<0.935   # 3sigma cut for run 52949
-in_calx   H.cal.trx>-65.4&&H.cal.trx<54.6    #top+5cm, bottom-5cm (see hcal.pos)
-in_caly   H.cal.try>-30.&&H.cal.try<30.      #left+5cm, right-5cm.(see hcal.pos)
-in_cal    in_calx&&in_caly
+
+#good_beta H.hod.fpBeta>0.740&&H.hod.fpBeta<0.935   # 3sigma cut for run 52949
+good_beta H.tr.beta>0.740&&H.tr.beta<0.935
+
+# 338.69 = 350.0-11.31, distance from FP to the face of calorimeter
+
+#in_calx   H.tr.x+H.tr.th*338.69>-65.4&&H.tr.x+H.tr.th*338.69<54.6    #top+5cm, bottom-5cm (see hcal.pos)
+#in_caly   H.tr.y+H.tr.ph*338.69>-30.&&H.tr.y+H.tr.ph*338.69<30.      #left+5cm, right-5cm.(see hcal.pos)
+#in_cal    in_calx&&in_caly
+
+Reconstruct_master one_track && in_delta && good_cer && one_clust && good_beta
 
 # This version is for calibration from scratch (no calibration constants exist,
 # first time calibration).
-Reconstruct_master one_track && one_clust && in_delta && good_cer && good_beta && in_cal
+##Reconstruct_master one_track && one_clust && in_delta && good_cer && good_beta
 
 # This version can be used for iterative calibration (improve existing
 # constants).
-#Reconstruct_master one_track && one_sh_track && in_delta && good_cer && good_beta && in_cal
-
-
-
+#Reconstruct_master one_track && one_sh_track && in_delta && good_cer && good_beta

--- a/hcal_calib/output_hcal_replay.def
+++ b/hcal_calib/output_hcal_replay.def
@@ -4,10 +4,16 @@
 
 block H.cal.*
 variable H.cer.npesum
-#variable H.tr.beta
-variable H.hod.fpBeta
+variable H.tr.beta
+#variable H.hod.fpBeta
 variable H.tr.p
 variable H.tr.tg_dp
+variable H.tr.y 	#Y FP
+variable H.tr.x 	#X FP
 variable H.tr.ph	#tan(phi), wrt Y axis
 variable H.tr.th	#tan(theta), wrt X axis
 variable H.tr.n		#number of tracks
+#formula Hcal_trx H.tr.x+338.69*H.tr.th
+#formula Hcal_try H.tr.y+338.69*H.tr.ph
+#variable Hcal_trx
+#variable Hcal_try

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -91,7 +91,9 @@ public:
   bool isNeighbour(THcShowerHit* hit1) {      //Is hit1 neighbouring this hit?
     Int_t dRow = fRow-(*hit1).fRow;
     Int_t dCol = fCol-(*hit1).fCol;
-    return TMath::Abs(dRow)<2 && TMath::Abs(dCol)<2;
+    //    return TMath::Abs(dRow)<2 && TMath::Abs(dCol)<2;
+    return (TMath::Abs(dRow)<2 && TMath::Abs(dCol)<2) ||
+      (dRow==0 && TMath::Abs(dCol)<3);
   }
 
   //Print out hit information


### PR DESCRIPTION
Modify clustering of hits in the HMS calorimeter.
           State hits in a row separated by single block as neighbors in
           THcShower::IsNeighbour method. This allows for inclusion of a
           stand alone hit of low energy deposition (presumably coming
           from noise in a channel) into a big cluster, hence reducing
           differences between engine and hcana.

Make HMS calorimeter calibration code consistent with latest changes in hcana in part of the HMS calorimeter.
       Consistently use variables of the track proper in the HMS calibartion code.
