### PR TITLE
Restore compiler warning work

### DIFF
--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -198,12 +198,12 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
   fNegPedMean = new Double_t[fNelem];
 
   DBRequest list[]={
-    {"aero_pos_gain", fPosGain, kDouble, fNelem},
-    {"aero_neg_gain", fNegGain, kDouble, fNelem},
-    {"aero_pos_ped_limit", fPosPedLimit, kInt, fNelem},
-    {"aero_neg_ped_limit", fNegPedLimit, kInt, fNelem},
-    {"aero_pos_ped_mean", fPosPedMean, kDouble, fNelem,optional},
-    {"aero_neg_ped_mean", fNegPedMean, kDouble, fNelem,optional},
+    {"aero_pos_gain", fPosGain, kDouble, (UInt_t) fNelem},
+    {"aero_neg_gain", fNegGain, kDouble, (UInt_t) fNelem},
+    {"aero_pos_ped_limit", fPosPedLimit, kInt, (UInt_t) fNelem},
+    {"aero_neg_ped_limit", fNegPedLimit, kInt, (UInt_t) fNelem},
+    {"aero_pos_ped_mean", fPosPedMean, kDouble, (UInt_t) fNelem,optional},
+    {"aero_neg_ped_mean", fNegPedMean, kDouble, (UInt_t) fNelem,optional},
     {0}
   };
   gHcParms->LoadParmValues((DBRequest*)&list,prefix);

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -179,9 +179,9 @@ Int_t THcCherenkov::ReadDatabase( const TDatime& date )
   fPedMean = new Double_t[fNelem];
   
   DBRequest list[]={
-    {"cer_adc_to_npe", fGain,     kDouble, fNelem},              // Ahmed
-    {"cer_ped_limit",  fPedLimit, kInt,    fNelem},              // Ahmed
-    {"cer_width",      fCerWidth, kDouble, fNelem},              // Ahmed
+    {"cer_adc_to_npe", fGain,     kDouble, (UInt_t) fNelem},              // Ahmed
+    {"cer_ped_limit",  fPedLimit, kInt,    (UInt_t) fNelem},              // Ahmed
+    {"cer_width",      fCerWidth, kDouble, (UInt_t) fNelem},              // Ahmed
     {0}
   };
 

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -122,7 +122,7 @@ void THcDC::Setup(const char* name, const char* description)
     // Should quit.  Is there an official way to quit?
   }
   fPlaneNames = new char* [fNPlanes];
-  for(UInt_t i=0;i<fNPlanes;i++) {
+  for(Int_t i=0;i<fNPlanes;i++) {
     fPlaneNames[i] = new char[plane_names[i].length()+1];
     strcpy(fPlaneNames[i], plane_names[i].c_str());
   }
@@ -131,7 +131,7 @@ void THcDC::Setup(const char* name, const char* description)
   char *desc1= new char[strlen(description)+100];
   fPlanes.clear();
 
-  for(UInt_t i=0;i<fNPlanes;i++) {
+  for(Int_t i=0;i<fNPlanes;i++) {
     strcpy(desc, description);
     strcat(desc, " Plane ");
     strcat(desc, fPlaneNames[i]);
@@ -185,7 +185,7 @@ THaAnalysisObject::EStatus THcDC::Init( const TDatime& date )
     return fStatus=status;
 
   // Initialize planes and add them to chambers
-  for(UInt_t ip=0;ip<fNPlanes;ip++) {
+  for(Int_t ip=0;ip<fNPlanes;ip++) {
     if((status = fPlanes[ip]->Init( date ))) {
       return fStatus=status;
     } else {
@@ -201,7 +201,7 @@ THaAnalysisObject::EStatus THcDC::Init( const TDatime& date )
   }
   // Retrieve the fiting coefficients
   fPlaneCoeffs = new Double_t* [fNPlanes];
-  for(UInt_t ip=0; ip<fNPlanes;ip++) {
+  for(Int_t ip=0; ip<fNPlanes;ip++) {
     fPlaneCoeffs[ip] = fPlanes[ip]->GetPlaneCoef();
   }
 
@@ -288,22 +288,22 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
     {"min_combos", fMinCombos, kInt, fNChambers},
     {"space_point_criterion", fSpace_Point_Criterion, kDouble, fNChambers},
 
-    {"dc_tdc_min_win", fTdcWinMin, kInt, fNPlanes},
-    {"dc_tdc_max_win", fTdcWinMax, kInt, fNPlanes},
-    {"dc_central_time", fCentralTime, kDouble, fNPlanes},
-    {"dc_nrwire", fNWires, kInt, fNPlanes},
-    {"dc_chamber_planes", fNChamber, kInt, fNPlanes},
-    {"dc_wire_counting", fWireOrder, kInt, fNPlanes},
-    {"dc_drifttime_sign", fDriftTimeSign, kInt, fNPlanes},
+    {"dc_tdc_min_win", fTdcWinMin, kInt, (UInt_t)fNPlanes},
+    {"dc_tdc_max_win", fTdcWinMax, kInt, (UInt_t)fNPlanes},
+    {"dc_central_time", fCentralTime, kDouble, (UInt_t)fNPlanes},
+    {"dc_nrwire", fNWires, kInt, (UInt_t)fNPlanes},
+    {"dc_chamber_planes", fNChamber, kInt, (UInt_t)fNPlanes},
+    {"dc_wire_counting", fWireOrder, kInt, (UInt_t)fNPlanes},
+    {"dc_drifttime_sign", fDriftTimeSign, kInt, (UInt_t)fNPlanes},
 
-    {"dc_zpos", fZPos, kDouble, fNPlanes},
-    {"dc_alpha_angle", fAlphaAngle, kDouble, fNPlanes},
-    {"dc_beta_angle", fBetaAngle, kDouble, fNPlanes},
-    {"dc_gamma_angle", fGammaAngle, kDouble, fNPlanes},
-    {"dc_pitch", fPitch, kDouble, fNPlanes},
-    {"dc_central_wire", fCentralWire, kDouble, fNPlanes},
-    {"dc_plane_time_zero", fPlaneTimeZero, kDouble, fNPlanes},
-    {"dc_sigma", fSigma, kDouble, fNPlanes},
+    {"dc_zpos", fZPos, kDouble, (UInt_t)fNPlanes},
+    {"dc_alpha_angle", fAlphaAngle, kDouble, (UInt_t)fNPlanes},
+    {"dc_beta_angle", fBetaAngle, kDouble, (UInt_t)fNPlanes},
+    {"dc_gamma_angle", fGammaAngle, kDouble, (UInt_t)fNPlanes},
+    {"dc_pitch", fPitch, kDouble, (UInt_t)fNPlanes},
+    {"dc_central_wire", fCentralWire, kDouble, (UInt_t)fNPlanes},
+    {"dc_plane_time_zero", fPlaneTimeZero, kDouble, (UInt_t)fNPlanes},
+    {"dc_sigma", fSigma, kDouble, (UInt_t)fNPlanes},
     {"single_stub",&fSingleStub, kInt},
     {"ntracks_max_fp", &fNTracksMaxFP, kInt},
     {"xt_track_criterion", &fXtTrCriterion, kDouble},
@@ -324,7 +324,7 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
   if(fNTracksMaxFP <= 0) fNTracksMaxFP = 10;
   // if(fNTracksMaxFP > HNRACKS_MAX) fNTracksMaxFP = NHTRACKS_MAX;
   cout << "Plane counts:";
-  for(UInt_t i=0;i<fNPlanes;i++) {
+  for(Int_t i=0;i<fNPlanes;i++) {
     cout << " " << fNWires[i];
   }
   cout << endl;
@@ -429,7 +429,7 @@ void THcDC::ClearEvent()
     fChambers[i]->Clear();
   }
 
-  for(UInt_t i=0;i<fNPlanes;i++) {
+  for(Int_t i=0;i<fNPlanes;i++) {
     fResiduals[i] = 1000.0;
   }
   
@@ -449,7 +449,7 @@ Int_t THcDC::Decode( const THaEvData& evdata )
   if(!gHaCuts->Result("Pedestal_event")) {
     // Let each plane get its hits
     Int_t nexthit = 0;
-    for(UInt_t ip=0;ip<fNPlanes;ip++) {
+    for(Int_t ip=0;ip<fNPlanes;ip++) {
       nexthit = fPlanes[ip]->ProcessHits(fRawHitList, nexthit);
       fN_True_RawHits += fPlanes[ip]->GetNRawhits();
       
@@ -895,7 +895,7 @@ void THcDC::TrackFit()
       // calculations
 
       // Make sure fCoords, fResiduals, and fDoubleResiduals are clear
-      for(UInt_t iplane=0;iplane < fNPlanes; iplane++) {
+      for(Int_t iplane=0;iplane < fNPlanes; iplane++) {
 	Double_t coord=0.0;
 	for(Int_t ir=0;ir<NUM_FPRAY;ir++) {
 	  coord += fPlaneCoeffs[iplane][raycoeffmap[ir]]*dray[ir];
@@ -996,7 +996,7 @@ void THcDC::TrackFit()
     }
   }
   if(fNDCTracks>0) {
-    for(UInt_t ip=0;ip<fNPlanes;ip++) {
+    for(Int_t ip=0;ip<fNPlanes;ip++) {
       THcDCTrack *theDCTrack = static_cast<THcDCTrack*>( fDCTracks->At(0));
       fResiduals[ip] = theDCTrack->GetResidual(ip);
     }
@@ -1101,7 +1101,7 @@ void THcDC::EffInit()
   for(UInt_t i=0;i<fNChambers;i++) {
     fNChamHits[i] = 0;
   }
-  for(UInt_t i=0;i<fNPlanes;i++) {
+  for(Int_t i=0;i<fNPlanes;i++) {
     fPlaneEvents[i] = 0;
   }
   gHcParms->Define(Form("%sdc_tot_events",fPrefix),"Total DC Events",fTotEvents);
@@ -1118,7 +1118,7 @@ void THcDC::Eff()
   for(UInt_t i=0;i<fNChambers;i++) {
     if(fChambers[i]->GetNHits()>0) fNChamHits[i]++;
   }
-  for(UInt_t i=0;i<fNPlanes;i++) {
+  for(Int_t i=0;i<fNPlanes;i++) {
     if(fPlanes[i]->GetNHits() > 0) fPlaneEvents[i]++;
   }
   return;

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -122,7 +122,7 @@ void THcDC::Setup(const char* name, const char* description)
     // Should quit.  Is there an official way to quit?
   }
   fPlaneNames = new char* [fNPlanes];
-  for(Int_t i=0;i<fNPlanes;i++) {
+  for(UInt_t i=0;i<fNPlanes;i++) {
     fPlaneNames[i] = new char[plane_names[i].length()+1];
     strcpy(fPlaneNames[i], plane_names[i].c_str());
   }
@@ -131,7 +131,7 @@ void THcDC::Setup(const char* name, const char* description)
   char *desc1= new char[strlen(description)+100];
   fPlanes.clear();
 
-  for(Int_t i=0;i<fNPlanes;i++) {
+  for(UInt_t i=0;i<fNPlanes;i++) {
     strcpy(desc, description);
     strcat(desc, " Plane ");
     strcat(desc, fPlaneNames[i]);
@@ -149,7 +149,7 @@ void THcDC::Setup(const char* name, const char* description)
   }
 
   fChambers.clear();
-  for(Int_t i=0;i<fNChambers;i++) {
+  for(UInt_t i=0;i<fNChambers;i++) {
     sprintf(desc1,"Ch%d",i+1);
 
     // Should construct a better chamber name
@@ -185,7 +185,7 @@ THaAnalysisObject::EStatus THcDC::Init( const TDatime& date )
     return fStatus=status;
 
   // Initialize planes and add them to chambers
-  for(Int_t ip=0;ip<fNPlanes;ip++) {
+  for(UInt_t ip=0;ip<fNPlanes;ip++) {
     if((status = fPlanes[ip]->Init( date ))) {
       return fStatus=status;
     } else {
@@ -194,14 +194,14 @@ THaAnalysisObject::EStatus THcDC::Init( const TDatime& date )
     }
   }
   // Initialize chambers
-  for(Int_t ic=0;ic<fNChambers;ic++) {
+  for(UInt_t ic=0;ic<fNChambers;ic++) {
     if((status = fChambers[ic]->Init ( date ))) {
       return fStatus=status;
     }
   }
   // Retrieve the fiting coefficients
   fPlaneCoeffs = new Double_t* [fNPlanes];
-  for(Int_t ip=0; ip<fNPlanes;ip++) {
+  for(UInt_t ip=0; ip<fNPlanes;ip++) {
     fPlaneCoeffs[ip] = fPlanes[ip]->GetPlaneCoef();
   }
 
@@ -324,7 +324,7 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
   if(fNTracksMaxFP <= 0) fNTracksMaxFP = 10;
   // if(fNTracksMaxFP > HNRACKS_MAX) fNTracksMaxFP = NHTRACKS_MAX;
   cout << "Plane counts:";
-  for(Int_t i=0;i<fNPlanes;i++) {
+  for(UInt_t i=0;i<fNPlanes;i++) {
     cout << " " << fNWires[i];
   }
   cout << endl;
@@ -425,11 +425,11 @@ void THcDC::ClearEvent()
   fNthits = 0;
   fN_True_RawHits=0;
 
-  for(Int_t i=0;i<fNChambers;i++) {
+  for(UInt_t i=0;i<fNChambers;i++) {
     fChambers[i]->Clear();
   }
 
-  for(Int_t i=0;i<fNPlanes;i++) {
+  for(UInt_t i=0;i<fNPlanes;i++) {
     fResiduals[i] = 1000.0;
   }
   
@@ -449,14 +449,14 @@ Int_t THcDC::Decode( const THaEvData& evdata )
   if(!gHaCuts->Result("Pedestal_event")) {
     // Let each plane get its hits
     Int_t nexthit = 0;
-    for(Int_t ip=0;ip<fNPlanes;ip++) {
+    for(UInt_t ip=0;ip<fNPlanes;ip++) {
       nexthit = fPlanes[ip]->ProcessHits(fRawHitList, nexthit);
       fN_True_RawHits += fPlanes[ip]->GetNRawhits();
       
     }
 
     // Let each chamber get its hits
-    for(Int_t ic=0;ic<fNChambers;ic++) {
+    for(UInt_t ic=0;ic<fNChambers;ic++) {
       fChambers[ic]->ProcessHits();
       fNthits += fChambers[ic]->GetNHits();
     }
@@ -465,9 +465,9 @@ Int_t THcDC::Decode( const THaEvData& evdata )
     if (fdebugprintrawdc) {
       cout << " RAW_TOT_HITS = " <<  fNRawHits << endl;
       cout << " Hit #  " << "Plane  " << " Wire " <<  " Raw TDC " << endl; 
-      for(Int_t ihit = 0; ihit < fNRawHits ; ihit++) {
+      for(UInt_t ihit = 0; ihit < fNRawHits ; ihit++) {
 	THcRawDCHit* hit = (THcRawDCHit *) fRawHitList->At(ihit);
-	for(Int_t imhit = 0; imhit < hit->fNHits; imhit++) {
+	for(UInt_t imhit = 0; imhit < hit->fNHits; imhit++) {
 	  counter++;
 	  cout << counter << "      " << hit->fPlane << "     " << hit->fCounter << "     " << hit->fTDC[imhit]	   << endl;
 	}
@@ -496,11 +496,11 @@ Int_t THcDC::CoarseTrack( TClonesArray& tracks )
   //
   //  static const Double_t sqrt2 = TMath::Sqrt(2.);
   if (fdebugprintdecodeddc) {
-   for(Int_t i=0;i<fNChambers;i++) {
+   for(UInt_t i=0;i<fNChambers;i++) {
     fChambers[i]->PrintDecode();
    }
   }
-  for(Int_t i=0;i<fNChambers;i++) {
+  for(UInt_t i=0;i<fNChambers;i++) {
     fChambers[i]->FindSpacePoints();
     fChambers[i]->CorrectHitTimes();
     fChambers[i]->LeftRight();
@@ -512,7 +512,7 @@ Int_t THcDC::CoarseTrack( TClonesArray& tracks )
   if(fNDCTracks > 0) {
     TrackFit();
     // Copy tracks into podd tracks list
-    for(Int_t itrack=0;itrack<fNDCTracks;itrack++) {
+    for(UInt_t itrack=0;itrack<fNDCTracks;itrack++) {
       THaTrack* theTrack = NULL;
       theTrack = AddTrack(tracks, 0.0, 0.0, 0.0, 0.0); // Leaving off trackID
       // Should we add stubs with AddCluster?  Could we do this
@@ -568,7 +568,7 @@ Int_t THcDC::FineTrack( TClonesArray& tracks )
 //
 void THcDC::PrintSpacePoints()
 {
-  for(Int_t ich=0;ich<fNChambers;ich++) {
+  for(UInt_t ich=0;ich<fNChambers;ich++) {
     printf("%s %2d %s %3d %s %3d \n"," chamber = ",fChambers[ich]->GetChamberNum()," number of hits = ",fChambers[ich]->GetNHits()," number of spacepoints = ",fChambers[ich]->GetNSpacePoints());
     printf("%6s %-8s %-8s %6s %6s %10s \n","     "," "," ","Number","Number","Plane Wire");
     printf("%6s %-8s %-8s %6s %6s %10s \n","Point","x","y"," hits ","combos"," for each hit");
@@ -588,7 +588,7 @@ void THcDC::PrintSpacePoints()
 //
 void THcDC::PrintStubs()
 {
-  for(Int_t ich=0;ich<fNChambers;ich++) {
+  for(UInt_t ich=0;ich<fNChambers;ich++) {
     printf("%s %3d \n"," Stub fit results Chamber = ",ich+1);
     printf("%-5s %-18s %-18s %-18s %-18s\n","point","x_t","y_t","xp_t","yp_t");
     printf("%-5s %-18s %-18s %-18s %-18s\n","     ","[cm]","[cm]","[cm]","[cm]");
@@ -622,7 +622,7 @@ void THcDC::LinkStubs()
   fSp.clear();
   fSp.reserve(10);
   // Make a vector of pointers to the SpacePoints
-  for(Int_t ich=0;ich<fNChambers;ich++) {
+  for(UInt_t ich=0;ich<fNChambers;ich++) {
     Int_t nchamber=fChambers[ich]->GetChamberNum();
     TClonesArray* spacepointarray = fChambers[ich]->GetSpacePointsP();
     for(Int_t isp=0;isp<fChambers[ich]->GetNSpacePoints();isp++) {
@@ -645,7 +645,7 @@ void THcDC::LinkStubs()
       // Now make sure this sp is not already used in a sp.
       // Could this be done by having a sp point to the track it is in?
       Int_t tryflag=1;
-      for(Int_t itrack=0;itrack<fNDCTracks;itrack++) {
+      for(UInt_t itrack=0;itrack<fNDCTracks;itrack++) {
 	THcDCTrack *theDCTrack = static_cast<THcDCTrack*>( fDCTracks->At(itrack));
 	for(Int_t isp=0;isp<theDCTrack->GetNSpacePoints();isp++) {
 	  // isp is index into list of space points attached to theDCTrack
@@ -787,7 +787,7 @@ void THcDC::LinkStubs()
   if (fdebuglinkstubs) { 
      cout << " Number of tracks from link stubs = " << fNDCTracks << endl;
      printf("%s %s \n","Track","Plane Wire ");
-     for (Int_t itrack=0;itrack<fNDCTracks;itrack++) {
+     for (UInt_t itrack=0;itrack<fNDCTracks;itrack++) {
        THcDCTrack *tempTrack = (THcDCTrack*)( fDCTracks->At(itrack));
        printf("%-5d  ",itrack+1);
         for (Int_t ihit=0;ihit<tempTrack->GetNHits();ihit++) {
@@ -826,7 +826,7 @@ void THcDC::TrackFit()
   
   Double_t dummychi2 = 1.0E4;
 
-  for(Int_t itrack=0;itrack<fNDCTracks;itrack++) {
+  for(UInt_t itrack=0;itrack<fNDCTracks;itrack++) {
     //    Double_t chi2 = dummychi2;
     //    Int_t htrack_fit_num = itrack;
     THcDCTrack *theDCTrack = static_cast<THcDCTrack*>( fDCTracks->At(itrack));
@@ -895,7 +895,7 @@ void THcDC::TrackFit()
       // calculations
 
       // Make sure fCoords, fResiduals, and fDoubleResiduals are clear
-      for(Int_t iplane=0;iplane < fNPlanes; iplane++) {
+      for(UInt_t iplane=0;iplane < fNPlanes; iplane++) {
 	Double_t coord=0.0;
 	for(Int_t ir=0;ir<NUM_FPRAY;ir++) {
 	  coord += fPlaneCoeffs[iplane][raycoeffmap[ir]]*dray[ir];
@@ -922,13 +922,13 @@ void THcDC::TrackFit()
     if(fNDCTracks == 2) {
       THcDCTrack *theDCTrack1 = static_cast<THcDCTrack*>( fDCTracks->At(0));
       THcDCTrack *theDCTrack2 = static_cast<THcDCTrack*>( fDCTracks->At(1));
-      Int_t itrack=0;
+      //      Int_t itrack=0;
       Int_t ihit=0;
       THcDCHit* hit=theDCTrack1->GetHit(ihit);
       Int_t plane=hit->GetPlaneNum()-1;
       Int_t chamber=fNChamber[plane];
       if(chamber==1) {
-	itrack=1;
+	//	itrack=1;
 	hit=theDCTrack2->GetHit(ihit);
 	plane=hit->GetPlaneNum()-1;
 	chamber=fNChamber[plane];
@@ -937,7 +937,7 @@ void THcDC::TrackFit()
 	  Double_t ray2[4];
 	  theDCTrack1->GetRay(ray1);
 	  theDCTrack2->GetRay(ray2);
-	  itrack = 1;
+	  //	  itrack = 1;
 	  // Loop over hits in second chamber
 	  for(Int_t ihit=0;ihit < theDCTrack2->GetNHits();ihit++) {
 	    // Calculate residual in second chamber from first chamber track
@@ -964,7 +964,7 @@ void THcDC::TrackFit()
 	    theDCTrack1->SetDoubleResidual(plane,coord - pos);
 	    //  hdc_dbl_res(pln) = hdc_double_residual(1,pln)  for hists
 	  }
-	  itrack=0;
+	  //	  itrack=0;
 	  // Loop over hits in first chamber
 	  for(Int_t ihit=0;ihit < theDCTrack1->GetNHits();ihit++) {
 	    // Calculate residual in first chamber from second chamber track
@@ -996,7 +996,7 @@ void THcDC::TrackFit()
     }
   }
   if(fNDCTracks>0) {
-    for(Int_t ip=0;ip<fNPlanes;ip++) {
+    for(UInt_t ip=0;ip<fNPlanes;ip++) {
       THcDCTrack *theDCTrack = static_cast<THcDCTrack*>( fDCTracks->At(0));
       fResiduals[ip] = theDCTrack->GetResidual(ip);
     }
@@ -1005,11 +1005,11 @@ void THcDC::TrackFit()
       if (fdebugtrackprint) {
         printf("%5s %-14s %-14s %-14s %-14s  %-10s %-10s \n","Track","x_t","y_t","xp_t","yp_t","chi2","DOF");
         printf("%5s %-14s %-14s %-14s %-14s  %-10s %-10s \n","     ","[cm]","[cm]","[rad]","[rad]"," "," ");
-	for(Int_t itr=0;itr < fNDCTracks;itr++) {
+	for(UInt_t itr=0;itr < fNDCTracks;itr++) {
         THcDCTrack *theDCTrack = static_cast<THcDCTrack*>( fDCTracks->At(itr));
 	printf("%-5d %14.6e %14.6e %14.6e %14.6e %10.3e %3d \n", itr+1,theDCTrack->GetX(),theDCTrack->GetY(),theDCTrack->GetXP(),theDCTrack->GetYP(),theDCTrack->GetChisq(),theDCTrack->GetNFree());
         }
-	for(Int_t itr=0;itr < fNDCTracks;itr++) {
+	for(UInt_t itr=0;itr < fNDCTracks;itr++) {
 	  printf("%s %5d \n","Hit info for track number = ",itr+1);
           printf("%5s %-15s %-15s %-15s \n","Plane","WIRE_COORD","Fit postiion","Residual");
          THcDCTrack *theDCTrack = static_cast<THcDCTrack*>( fDCTracks->At(itr));
@@ -1098,10 +1098,10 @@ void THcDC::EffInit()
   delete [] fPlaneEvents; fPlaneEvents = new Int_t [fNPlanes];
   
   fTotEvents = 0;
-  for(Int_t i=0;i<fNChambers;i++) {
+  for(UInt_t i=0;i<fNChambers;i++) {
     fNChamHits[i] = 0;
   }
-  for(Int_t i=0;i<fNPlanes;i++) {
+  for(UInt_t i=0;i<fNPlanes;i++) {
     fPlaneEvents[i] = 0;
   }
   gHcParms->Define(Form("%sdc_tot_events",fPrefix),"Total DC Events",fTotEvents);
@@ -1115,10 +1115,10 @@ void THcDC::Eff()
   // Accumulate statistics for efficiency calculations
 
   fTotEvents++;
-  for(Int_t i=0;i<fNChambers;i++) {
+  for(UInt_t i=0;i<fNChambers;i++) {
     if(fChambers[i]->GetNHits()>0) fNChamHits[i]++;
   }
-  for(Int_t i=0;i<fNPlanes;i++) {
+  for(UInt_t i=0;i<fNPlanes;i++) {
     if(fPlanes[i]->GetNHits() > 0) fPlaneEvents[i]++;
   }
   return;

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -83,15 +83,15 @@ protected:
   Int_t fdebugprintdecodeddc;
   Int_t fHMSStyleChambers;
 
-  Int_t fNDCTracks;
+  UInt_t fNDCTracks;
   TClonesArray* fDCTracks;     // Tracks found from stubs (THcDCTrack obj)
   // Calibration
 
   // Hall C Parameters
   char fPrefix[2];
-  Int_t fNPlanes;              // Total number of DC planes
+  UInt_t fNPlanes;              // Total number of DC planes
   char** fPlaneNames;
-  Int_t fNChambers;
+  UInt_t fNChambers;
   Int_t fFixLR;			// If 1, allow a given hit to have different LR
                                 // for different space points
   Int_t fFixPropagationCorrection; // If 1, don't reapply (and accumulate) the

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -89,7 +89,7 @@ protected:
 
   // Hall C Parameters
   char fPrefix[2];
-  UInt_t fNPlanes;              // Total number of DC planes
+  Int_t fNPlanes;              // Total number of DC planes
   char** fPlaneNames;
   UInt_t fNChambers;
   Int_t fFixLR;			// If 1, allow a given hit to have different LR

--- a/src/THcDetectorMap.cxx
+++ b/src/THcDetectorMap.cxx
@@ -213,7 +213,7 @@ void THcDetectorMap::Load(const char *fname)
 
   Int_t roc=0;
   Int_t nsubadd=0;
-  Int_t mask=0;
+  //  Int_t mask=0;
   Int_t bsub=0;
   Int_t detector=0;
   Int_t slot=0;
@@ -278,8 +278,8 @@ void THcDetectorMap::Load(const char *fname)
 	roc = value;
       } else if (strcasecmp(varname,"nsubadd")==0) {
 	nsubadd = value;
-      } else if (strcasecmp(varname,"mask")==0) {
-	mask = value;
+      } else if (strcasecmp(varname,"mask")==0) { // mask not used here
+	//mask = value;
       } else if (strcasecmp(varname,"bsub")==0) {
 	bsub = value;
       } else if (strcasecmp(varname,"slot")==0) {

--- a/src/THcDriftChamber.cxx
+++ b/src/THcDriftChamber.cxx
@@ -652,7 +652,7 @@ Int_t THcDriftChamber::SpacePointMultiWire()
   THcDCHit* hits_plane[fNPlanes][MAX_HITS_PER_POINT];
 
   Int_t nsp_check;
-  Int_t nplanes_single;
+  //Int_t nplanes_single;
 
   Int_t nsp_tot=fNSpacePoints;
   Int_t nsp_totl=fNSpacePoints;
@@ -691,7 +691,7 @@ Int_t THcDriftChamber::SpacePointMultiWire()
     }
     --nsp_new;
     nsp_check=nsp_tot + nsp_new;
-    nplanes_single = nplanes_hit - nplanes_mult;
+    //nplanes_single = nplanes_hit - nplanes_mult;
     //if (fhdebugflagpr) cout << " # of new space points = " << nsp_new << " total now = " << nsp_tot<< endl;
     // Check if cloning conditions are met
     Int_t ntot = 0;
@@ -869,15 +869,15 @@ void THcDriftChamber::SelectSpacePoints()
   }
   // if(sp_count < fNSpacePoints)    if (fhdebugflagpr) cout << "Reduced from " << fNSpacePoints << " to " << sp_count << " space points" << endl;
   fNSpacePoints = sp_count;
-  for(Int_t isp=0;isp<fNSpacePoints;isp++) {
-    THcSpacePoint* sp = (THcSpacePoint*)(*fSpacePoints)[isp];
+  //for(Int_t isp=0;isp<fNSpacePoints;isp++) {
+  //  THcSpacePoint* sp = (THcSpacePoint*)(*fSpacePoints)[isp];
     //if (fhdebugflagpr) cout << " sp pt = " << isp+1 << " # of hits = " << sp->GetNHits() << endl;
-    for(Int_t ihit=0;ihit<sp->GetNHits();ihit++) {
-      THcDCHit* hit = sp->GetHit(ihit);
+    //for(Int_t ihit=0;ihit<sp->GetNHits();ihit++) {
+  //THcDCHit* hit = sp->GetHit(ihit);
       //THcDriftChamberPlane* plane=hit->GetWirePlane();
       //        if (fhdebugflagpr) cout << ihit+1 << "selecting " << plane->GetPlaneNum() << " " << plane->GetChamberNum() << " " << hit->GetTime() << " " << hit->GetDist() << " " << plane->GetCentralTime() << " " << plane->GetDriftTimeSign() << endl;
-    }
-  }
+  //    }
+  //  }
 }
 
 void THcDriftChamber::CorrectHitTimes()

--- a/src/THcDriftChamberPlane.cxx
+++ b/src/THcDriftChamberPlane.cxx
@@ -88,7 +88,7 @@ Int_t THcDriftChamberPlane::ReadDatabase( const TDatime& date )
   // See what file it looks for
   
   char prefix[2];
-  Int_t NumDriftMapBins;
+  UInt_t NumDriftMapBins;
   Double_t DriftMapFirstBin;
   Double_t DriftMapBinSize;
   
@@ -311,7 +311,7 @@ Int_t THcDriftChamberPlane::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
     Int_t wireNum = hit->fCounter;
     THcDCWire* wire = GetWire(wireNum);
     Int_t wire_last = -1;
-    for(Int_t mhit=0; mhit<hit->fNHits; mhit++) {
+    for(UInt_t mhit=0; mhit<hit->fNHits; mhit++) {
       fNRawhits++;
       /* Sort into early, late and ontime */
       Int_t rawtdc = hit->fTDC[mhit];

--- a/src/THcHallCSpectrometer.cxx
+++ b/src/THcHallCSpectrometer.cxx
@@ -480,10 +480,10 @@ Int_t THcHallCSpectrometer::TrackCalc()
 	      ( goodTrack->GetEnergy()  < fSelEtMax    ) )  	    	    
 	    {
 	      	      
-	      for (Int_t j = 0; j < fHodo->GetNPaddles(2); j++ ){ 
+	      for (UInt_t j = 0; j < fHodo->GetNPaddles(2); j++ ){ 
 		f2XHits[j] = -1;
 	      }
-	      for (Int_t j = 0; j < fHodo->GetNPaddles(3); j++ ){ 
+	      for (UInt_t j = 0; j < fHodo->GetNPaddles(3); j++ ){ 
 		f2YHits[j] = -1; 
 	      }
 	      
@@ -517,9 +517,9 @@ Int_t THcHallCSpectrometer::TrackCalc()
 		fZap = 0.;
 		ft = 0;
 		
-		for (Int_t i = 0; i < fHodo->GetNPaddles(3); i++ ){
+		for (UInt_t i = 0; i < fHodo->GetNPaddles(3); i++ ){
 		  if ( f2YHits[i] == 0 ) {		    
-		    fY2D[itrack] = TMath::Abs(fHitCnt4-i-1);
+		    fY2D[itrack] = TMath::Abs((Int_t)fHitCnt4-(Int_t)i-1);
 		    ft ++;
 		    		    
 		    if   ( ft == 1 )                              fZap = fY2D[itrack];
@@ -547,9 +547,9 @@ Int_t THcHallCSpectrometer::TrackCalc()
 	      if ( fNtracks > 1 ){     // Plane 3 (2X)
 		fZap = 0.;
 		ft = 0;
-		for (Int_t i = 0; i <  fHodo->GetNPaddles(2); i++ ){
+		for (UInt_t i = 0; i <  fHodo->GetNPaddles(2); i++ ){
 		  if ( f2XHits[i] == 0 ) {
-		    fX2D[itrack] = TMath::Abs(fHitCnt3-i-1);
+		    fX2D[itrack] = TMath::Abs((Int_t)fHitCnt3-(Int_t)i-1);
 		    
 		    ft ++;
 		    if   ( ft == 1 )                              fZap = fX2D[itrack];

--- a/src/THcHallCSpectrometer.h
+++ b/src/THcHallCSpectrometer.h
@@ -20,7 +20,6 @@
 
 //#include "THaTrackingDetector.h"
 //#include "THcHitList.h"
-#include "THcRawDCHit.h"
 #include "THcSpacePoint.h"
 #include "THcDriftChamberPlane.h"
 #include "THcDriftChamber.h"

--- a/src/THcHitList.cxx
+++ b/src/THcHitList.cxx
@@ -53,7 +53,6 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata ) {
   // hits for multihit tdcs.
   // The hit list is sorted (by plane, counter) after filling.
 
-  THcRawHit* rawhit;
   // cout << " Clearing TClonesArray " << endl;
   fRawHitList->Clear( );
   fNRawHits = 0;
@@ -64,6 +63,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata ) {
     // Loop over all channels that have a hit.
     //    cout << "Crate/Slot: " << d->crate << "/" << d->slot << endl;
     for ( Int_t j=0; j < evdata.GetNumChan( d->crate, d->slot); j++) {
+      THcRawHit* rawhit=0;
       
       Int_t chan = evdata.GetNextChan( d->crate, d->slot, j );
       if( chan < d->lo || chan > d->hi ) continue;     // Not one of my channels
@@ -77,7 +77,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata ) {
       // << counter << " " << signal << endl;
       // Search hit list for plane and counter
       // We could do sorting 
-      Int_t thishit = 0;
+      UInt_t thishit = 0;
       while(thishit < fNRawHits) {
 	rawhit = (THcRawHit*) (*fRawHitList)[thishit];
 	if (plane == rawhit->fPlane

--- a/src/THcHitList.h
+++ b/src/THcHitList.h
@@ -32,7 +32,7 @@ public:
 
   TClonesArray* GetHitList() const {return fRawHitList; }
 
-  Int_t         fNRawHits;
+  UInt_t         fNRawHits;
   Int_t         fNMaxRawHits;
   TClonesArray* fRawHitList; // List of raw hits
   TClass* fRawHitClass;		  // Class of raw hit object to use

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -107,7 +107,7 @@ void THcHodoscope::Setup(const char* name, const char* description)
     // Should quit.  Is there an official way to quit?
   }
   fPlaneNames = new char* [fNPlanes];
-  for(Int_t i=0;i<fNPlanes;i++) {
+  for(UInt_t i=0;i<fNPlanes;i++) {
     fPlaneNames[i] = new char[plane_names[i].length()+1];
     strcpy(fPlaneNames[i], plane_names[i].c_str());
   }
@@ -126,7 +126,7 @@ void THcHodoscope::Setup(const char* name, const char* description)
   // Probably shouldn't assume that description is defined
   char* desc = new char[strlen(description)+100];
   fPlanes = new THcScintillatorPlane* [fNPlanes];
-  for(Int_t i=0;i < fNPlanes;i++) {
+  for(UInt_t i=0;i < fNPlanes;i++) {
     strcpy(desc, description);
     strcat(desc, " Plane ");
     strcat(desc, fPlaneNames[i]);
@@ -171,7 +171,7 @@ THaAnalysisObject::EStatus THcHodoscope::Init( const TDatime& date )
   if( (status = THaNonTrackingDetector::Init( date )) )
     return fStatus=status;
 
-  for(Int_t ip=0;ip<fNPlanes;ip++) {
+  for(UInt_t ip=0;ip<fNPlanes;ip++) {
     if((status = fPlanes[ip]->Init( date ))) {
       return fStatus=status;
     }
@@ -200,10 +200,8 @@ THaAnalysisObject::EStatus THcHodoscope::Init( const TDatime& date )
 
   //  Double_t  fHitCnt4 = 0., fHitCnt3 = 0.;
   
-  Int_t m = 0;
-  
   fScinHit = new Double_t*[fNPlanes];         
-  for ( m = 0; m < fNPlanes; m++ ){
+  for (UInt_t m = 0; m < fNPlanes; m++ ){
     fScinHit[m] = new Double_t[fNPaddle[0]];
   }
   
@@ -357,7 +355,7 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
   //  Int_t plen=strlen(parname);
   cout << " readdatabse hodo fnplanes = " << fNPlanes << endl;
 
-  fNPaddle = new Int_t [fNPlanes];
+  fNPaddle = new UInt_t [fNPlanes];
   fFPTime = new Double_t [fNPlanes];
   fPlaneCenter = new Double_t[fNPlanes];
   fPlaneSpacing = new Double_t[fNPlanes];
@@ -366,7 +364,7 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
   //
   prefix[1]='\0';
 
-  for(Int_t i=0;i<fNPlanes;i++) {
+  for(UInt_t i=0;i<fNPlanes;i++) {
     
     DBRequest list[]={
       {Form("scin_%s_nr",fPlaneNames[i]), &fNPaddle[i], kInt},
@@ -378,7 +376,7 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
   // GN added
   // reading variables from *hodo.param
   fMaxScinPerPlane=fNPaddle[0];
-  for (Int_t i=1;i<fNPlanes;i++) {
+  for (UInt_t i=1;i<fNPlanes;i++) {
     fMaxScinPerPlane=(fMaxScinPerPlane > fNPaddle[i])? fMaxScinPerPlane : fNPaddle[i];
   }
 // need this for "padded arrays" i.e. 4x16 lists of parameters (GN)
@@ -453,9 +451,9 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
     cout <<"TdcMin = "<<fScinTdcMin<<" TdcMax = "<<fScinTdcMax<<endl;
     cout <<"TofTolerance = "<<fTofTolerance<<endl;
     cout <<"*** VelLight ***\n";
-    for (int i1=0;i1<fNPlanes;i1++) {
+    for (UInt_t i1=0;i1<fNPlanes;i1++) {
       cout<<"Plane "<<i1<<endl;
-      for (int i2=0;i2<fMaxScinPerPlane;i2++) {
+      for (UInt_t i2=0;i2<fMaxScinPerPlane;i2++) {
 	cout<<fHodoVelLight[GetScinIndex(i1,i2)]<<" ";
       }
       cout <<endl;
@@ -557,9 +555,7 @@ THcHodoscope::~THcHodoscope()
 void THcHodoscope::DeleteArrays()
 {
   // Delete member arrays. Used by destructor.
-  Int_t k;  
-  
-  for( k = 0; k < fNPlanes; k++){
+  for(UInt_t k = 0; k < fNPlanes; k++){
     delete [] fScinHit[k];
   }
   delete [] fScinHit;
@@ -629,7 +625,7 @@ void THcHodoscope::ClearEvent()
   //    fBetaChisq[imaxhit] = 0.;
   //  }
 
-  for(Int_t ip=0;ip<fNPlanes;ip++) {
+  for(UInt_t ip=0;ip<fNPlanes;ip++) {
     fPlanes[ip]->Clear();
     fFPTime[ip]=0.;
     fPlaneCenter[ip]=0.;
@@ -654,7 +650,7 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
 
   if(gHaCuts->Result("Pedestal_event")) {
     Int_t nexthit = 0;
-    for(Int_t ip=0;ip<fNPlanes;ip++) {
+    for(UInt_t ip=0;ip<fNPlanes;ip++) {
             
       nexthit = fPlanes[ip]->AccumulatePedestals(fRawHitList, nexthit);
     }
@@ -662,7 +658,7 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
     return(0);
   }
   if(fAnalyzePedestals) {
-    for(Int_t ip=0;ip<fNPlanes;ip++) {
+    for(UInt_t ip=0;ip<fNPlanes;ip++) {
       
       fPlanes[ip]->CalculatePedestals();
     }
@@ -674,7 +670,7 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
 
   fStartTime=0;
   fNfptimes=0;
-  for(Int_t ip=0;ip<fNPlanes;ip++) {
+  for(UInt_t ip=0;ip<fNPlanes;ip++) {
 
     fPlaneCenter[ip] = fPlanes[ip]->GetPosCenter(0) + fPlanes[ip]->GetPosOffset();
     fPlaneSpacing[ip] = fPlanes[ip]->GetSpacing();
@@ -746,7 +742,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
   Int_t fJMax, fMaxHit;
   Int_t fRawIndex = -1;
   Double_t fScinTrnsCoord, fScinLongCoord, fScinCenter, fSumfpTime;
-  Double_t fP, fXcoord, fYcoord, fTMin, fNfpTime;
+  Double_t fP, fXcoord, fYcoord, fTMin;
   // -------------------------------------------------
 
   Double_t hpartmass=0.00051099; // Fix it
@@ -763,7 +759,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
       THaTrack* theTrack = dynamic_cast<THaTrack*>( tracks.At(itrack) );
       if (!theTrack) return -1;
       
-      for ( Int_t ip = 0; ip < fNPlanes; ip++ ){ 
+      for ( UInt_t ip = 0; ip < fNPlanes; ip++ ){ 
 	fGoodPlaneTime[ip] = kFALSE; 
 	fNScinHits[ip] = 0;
 	fNPlaneTime[ip] = 0;
@@ -772,7 +768,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
       std::vector<Double_t> dedx_temp;
       fdEdX.push_back(dedx_temp); // Create array of dedx per hit
       
-      //      Int_t fNfpTime = 0;
+      Int_t fNfpTime = 0;
       Double_t betaChisq = -3;
       Double_t beta = 0;
       //      fTimeAtFP[itrack] = 0.;
@@ -801,7 +797,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
       
       fTOFCalc.clear();
       Int_t ihhit = 0;		// Hit # overall
-      for( Int_t ip = 0; ip < fNPlanes; ip++ ) {
+      for( UInt_t ip = 0; ip < fNPlanes; ip++ ) {
 	
 	fNScinHits[ip] = fPlanes[ip]->GetNScinHits();
 
@@ -1163,7 +1159,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
 	sumw = 0.;	sumt = 0.;	sumz = 0.;	sumzz = 0.;	sumtz = 0.;
 	
 	ihhit = 0;  
-	for ( Int_t ip = 0; ip < fNPlanes; ip++ ){
+	for ( UInt_t ip = 0; ip < fNPlanes; ip++ ){
 
 	  if (!fPlanes[ip])
 	    return -1;
@@ -1198,7 +1194,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
 	  betaChisq = 0.;
 	  
 	  ihhit = 0;
-	  for ( Int_t ip = 0; ip < fNPlanes; ip++ ){                           // Loop over planes
+	  for ( UInt_t ip = 0; ip < fNPlanes; ip++ ){                           // Loop over planes
 	    if (!fPlanes[ip])
 	      return -1;
 	    
@@ -1263,7 +1259,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
       
       Double_t fptimesum=0.0;
       Int_t n_fptimesum=0;
-      for ( Int_t ip = 0; ip < fNPlanes; ip++ ){
+      for ( UInt_t ip = 0; ip < fNPlanes; ip++ ){
 	if ( fNPlaneTime[ip] != 0 ){
 	  fFPTime[ip] = ( fSumPlaneTime[ip] / fNPlaneTime[ip] );
 	  fptimesum += fSumPlaneTime[ip];

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -107,7 +107,7 @@ void THcHodoscope::Setup(const char* name, const char* description)
     // Should quit.  Is there an official way to quit?
   }
   fPlaneNames = new char* [fNPlanes];
-  for(UInt_t i=0;i<fNPlanes;i++) {
+  for(Int_t i=0;i<fNPlanes;i++) {
     fPlaneNames[i] = new char[plane_names[i].length()+1];
     strcpy(fPlaneNames[i], plane_names[i].c_str());
   }
@@ -126,7 +126,7 @@ void THcHodoscope::Setup(const char* name, const char* description)
   // Probably shouldn't assume that description is defined
   char* desc = new char[strlen(description)+100];
   fPlanes = new THcScintillatorPlane* [fNPlanes];
-  for(UInt_t i=0;i < fNPlanes;i++) {
+  for(Int_t i=0;i < fNPlanes;i++) {
     strcpy(desc, description);
     strcat(desc, " Plane ");
     strcat(desc, fPlaneNames[i]);
@@ -171,7 +171,7 @@ THaAnalysisObject::EStatus THcHodoscope::Init( const TDatime& date )
   if( (status = THaNonTrackingDetector::Init( date )) )
     return fStatus=status;
 
-  for(UInt_t ip=0;ip<fNPlanes;ip++) {
+  for(Int_t ip=0;ip<fNPlanes;ip++) {
     if((status = fPlanes[ip]->Init( date ))) {
       return fStatus=status;
     }
@@ -201,7 +201,7 @@ THaAnalysisObject::EStatus THcHodoscope::Init( const TDatime& date )
   //  Double_t  fHitCnt4 = 0., fHitCnt3 = 0.;
   
   fScinHit = new Double_t*[fNPlanes];         
-  for (UInt_t m = 0; m < fNPlanes; m++ ){
+  for (Int_t m = 0; m < fNPlanes; m++ ){
     fScinHit[m] = new Double_t[fNPaddle[0]];
   }
   
@@ -364,7 +364,7 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
   //
   prefix[1]='\0';
 
-  for(UInt_t i=0;i<fNPlanes;i++) {
+  for(Int_t i=0;i<fNPlanes;i++) {
     
     DBRequest list[]={
       {Form("scin_%s_nr",fPlaneNames[i]), &fNPaddle[i], kInt},
@@ -376,7 +376,7 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
   // GN added
   // reading variables from *hodo.param
   fMaxScinPerPlane=fNPaddle[0];
-  for (UInt_t i=1;i<fNPlanes;i++) {
+  for (Int_t i=1;i<fNPlanes;i++) {
     fMaxScinPerPlane=(fMaxScinPerPlane > fNPaddle[i])? fMaxScinPerPlane : fNPaddle[i];
   }
 // need this for "padded arrays" i.e. 4x16 lists of parameters (GN)
@@ -451,7 +451,7 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
     cout <<"TdcMin = "<<fScinTdcMin<<" TdcMax = "<<fScinTdcMax<<endl;
     cout <<"TofTolerance = "<<fTofTolerance<<endl;
     cout <<"*** VelLight ***\n";
-    for (UInt_t i1=0;i1<fNPlanes;i1++) {
+    for (Int_t i1=0;i1<fNPlanes;i1++) {
       cout<<"Plane "<<i1<<endl;
       for (UInt_t i2=0;i2<fMaxScinPerPlane;i2++) {
 	cout<<fHodoVelLight[GetScinIndex(i1,i2)]<<" ";
@@ -555,7 +555,7 @@ THcHodoscope::~THcHodoscope()
 void THcHodoscope::DeleteArrays()
 {
   // Delete member arrays. Used by destructor.
-  for(UInt_t k = 0; k < fNPlanes; k++){
+  for(Int_t k = 0; k < fNPlanes; k++){
     delete [] fScinHit[k];
   }
   delete [] fScinHit;
@@ -625,7 +625,7 @@ void THcHodoscope::ClearEvent()
   //    fBetaChisq[imaxhit] = 0.;
   //  }
 
-  for(UInt_t ip=0;ip<fNPlanes;ip++) {
+  for(Int_t ip=0;ip<fNPlanes;ip++) {
     fPlanes[ip]->Clear();
     fFPTime[ip]=0.;
     fPlaneCenter[ip]=0.;
@@ -650,7 +650,7 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
 
   if(gHaCuts->Result("Pedestal_event")) {
     Int_t nexthit = 0;
-    for(UInt_t ip=0;ip<fNPlanes;ip++) {
+    for(Int_t ip=0;ip<fNPlanes;ip++) {
             
       nexthit = fPlanes[ip]->AccumulatePedestals(fRawHitList, nexthit);
     }
@@ -658,7 +658,7 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
     return(0);
   }
   if(fAnalyzePedestals) {
-    for(UInt_t ip=0;ip<fNPlanes;ip++) {
+    for(Int_t ip=0;ip<fNPlanes;ip++) {
       
       fPlanes[ip]->CalculatePedestals();
     }
@@ -670,7 +670,7 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
 
   fStartTime=0;
   fNfptimes=0;
-  for(UInt_t ip=0;ip<fNPlanes;ip++) {
+  for(Int_t ip=0;ip<fNPlanes;ip++) {
 
     fPlaneCenter[ip] = fPlanes[ip]->GetPosCenter(0) + fPlanes[ip]->GetPosOffset();
     fPlaneSpacing[ip] = fPlanes[ip]->GetSpacing();
@@ -759,7 +759,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
       THaTrack* theTrack = dynamic_cast<THaTrack*>( tracks.At(itrack) );
       if (!theTrack) return -1;
       
-      for ( UInt_t ip = 0; ip < fNPlanes; ip++ ){ 
+      for ( Int_t ip = 0; ip < fNPlanes; ip++ ){ 
 	fGoodPlaneTime[ip] = kFALSE; 
 	fNScinHits[ip] = 0;
 	fNPlaneTime[ip] = 0;
@@ -797,7 +797,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
       
       fTOFCalc.clear();
       Int_t ihhit = 0;		// Hit # overall
-      for( UInt_t ip = 0; ip < fNPlanes; ip++ ) {
+      for( Int_t ip = 0; ip < fNPlanes; ip++ ) {
 	
 	fNScinHits[ip] = fPlanes[ip]->GetNScinHits();
 
@@ -1159,7 +1159,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
 	sumw = 0.;	sumt = 0.;	sumz = 0.;	sumzz = 0.;	sumtz = 0.;
 	
 	ihhit = 0;  
-	for ( UInt_t ip = 0; ip < fNPlanes; ip++ ){
+	for ( Int_t ip = 0; ip < fNPlanes; ip++ ){
 
 	  if (!fPlanes[ip])
 	    return -1;
@@ -1194,7 +1194,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
 	  betaChisq = 0.;
 	  
 	  ihhit = 0;
-	  for ( UInt_t ip = 0; ip < fNPlanes; ip++ ){                           // Loop over planes
+	  for ( Int_t ip = 0; ip < fNPlanes; ip++ ){                           // Loop over planes
 	    if (!fPlanes[ip])
 	      return -1;
 	    
@@ -1259,7 +1259,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
       
       Double_t fptimesum=0.0;
       Int_t n_fptimesum=0;
-      for ( UInt_t ip = 0; ip < fNPlanes; ip++ ){
+      for ( Int_t ip = 0; ip < fNPlanes; ip++ ){
 	if ( fNPlaneTime[ip] != 0 ){
 	  fFPTime[ip] = ( fSumPlaneTime[ip] / fNPlaneTime[ip] );
 	  fptimesum += fSumPlaneTime[ip];

--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -105,7 +105,8 @@ protected:
 
   // Potential Hall C parameters.  Mostly here for demonstration
 
-  UInt_t fNPlanes,fMaxScinPerPlane,fMaxHodoScin; // number of planes; max number of scin/plane; product of the first two 
+  Int_t fNPlanes;
+  UInt_t fMaxScinPerPlane,fMaxHodoScin; // number of planes; max number of scin/plane; product of the first two 
   Double_t fStartTimeCenter, fStartTimeSlop, fScinTdcToTime;
   Double_t fTofTolerance;
   Double_t fPathLengthCentral;

--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -18,7 +18,6 @@
 
 #include "THaTrackingDetector.h"
 #include "THcHitList.h"
-#include "THcRawDCHit.h"
 #include "THcSpacePoint.h"
 #include "THcDriftChamberPlane.h"
 #include "THcDriftChamber.h"
@@ -71,7 +70,7 @@ public:
   Int_t GetGoodRawPad(Int_t iii){return fTOFCalc[iii].good_raw_pad;}
   Double_t GetNScinHits(Int_t iii){return fNScinHits[iii];}
 
-  Int_t GetNPaddles(Int_t iii) { return fNPaddle[iii];}
+  UInt_t GetNPaddles(Int_t iii) { return fNPaddle[iii];}
   Double_t GetPlaneCenter(Int_t iii) { return fPlaneCenter[iii];}
   Double_t GetPlaneSpacing(Int_t iii) { return fPlaneSpacing[iii];}
 
@@ -105,13 +104,14 @@ protected:
   // Per-event data
 
   // Potential Hall C parameters.  Mostly here for demonstration
-  Int_t fNPlanes,fMaxScinPerPlane,fMaxHodoScin; // number of planes; max number of scin/plane; product of the first two 
+
+  UInt_t fNPlanes,fMaxScinPerPlane,fMaxHodoScin; // number of planes; max number of scin/plane; product of the first two 
   Double_t fStartTimeCenter, fStartTimeSlop, fScinTdcToTime;
   Double_t fTofTolerance;
   Double_t fPathLengthCentral;
   Double_t fScinTdcMin, fScinTdcMax; // min and max TDC values
   char** fPlaneNames;
-  Int_t* fNPaddle;		// Number of paddles per plane
+  UInt_t* fNPaddle;		// Number of paddles per plane
 
   Double_t* fHodoVelLight;
   Double_t* fHodoPosSigma;

--- a/src/THcParmList.cxx
+++ b/src/THcParmList.cxx
@@ -254,8 +254,8 @@ void THcParmList::Load( const char* fname, Int_t RunNumber )
     TObjArray *vararr = values.Tokenize(",");
     Int_t nvals = vararr->GetLast()+1;
     
-    Int_t* ip;
-    Double_t* fp;
+    Int_t* ip=0;
+    Double_t* fp=0;
     // or expressions
     for(Int_t i=0;(ttype==0&&i<nvals);i++) {
       TString valstr = ((TObjString *)vararr->At(i))->GetString();

--- a/src/THcRawDCHit.cxx
+++ b/src/THcRawDCHit.cxx
@@ -26,7 +26,7 @@ Int_t THcRawDCHit::GetData(Int_t signal) {
 }
 
 // Return a requested hit
-Int_t THcRawDCHit::GetData(Int_t signal, Int_t ihit) {
+Int_t THcRawDCHit::GetData(Int_t signal, UInt_t ihit) {
   if(ihit >=0 && ihit< fNHits) {
     return(fTDC[ihit]);
   } else {
@@ -65,7 +65,7 @@ THcRawDCHit& THcRawDCHit::operator=( const THcRawDCHit& rhs )
     fPlane = rhs.fPlane;
     fCounter = rhs.fCounter;
     fNHits = rhs.fNHits;
-    for(Int_t ihit=0;ihit<fNHits;ihit++) {
+    for(UInt_t ihit=0;ihit<fNHits;ihit++) {
       fTDC[ihit] = rhs.fTDC[ihit];
     }
   }

--- a/src/THcRawDCHit.h
+++ b/src/THcRawDCHit.h
@@ -21,14 +21,14 @@ public:
 
   void SetData(Int_t signal, Int_t data);
   Int_t GetData(Int_t signal);
-  Int_t GetData(Int_t signal, Int_t ihit);
+  Int_t GetData(Int_t signal, UInt_t ihit);
 
   virtual Bool_t  IsSortable () const {return kTRUE; }
   virtual Int_t   Compare(const TObject* obj) const;
 
 
 protected:
-  Int_t fNHits;
+  UInt_t fNHits;
   Int_t fTDC[MAXHITS];
 
 private:

--- a/src/THcScintillatorPlane.cxx
+++ b/src/THcScintillatorPlane.cxx
@@ -372,7 +372,8 @@ Int_t THcScintillatorPlane::PulseHeightCorrection()
   Int_t i,j,index;
   Double_t mintdc, maxtdc,tdctotime,toftolerance,tmin;
   Double_t pos_ph[53],neg_ph[53],postime[53],negtime[53],scin_corrected_time[53]; // the 53 should go in a param file (was hmax_scin_hits originally)
-  Bool_t keep_pos[53],keep_neg[53],two_good_times[53]; // are these all really needed?
+  // Bool_t keep_pos[53],keep_neg[53]; // are these all really needed?
+  Bool_t two_good_times[53];
   Double_t dist_from_center,scint_center,hit_position,time_pos[100],time_neg[100],hbeta_pcent;
   Int_t timehist[200],jmax,maxhit,nfound=0; // This seems as a pretty old-fashioned way of doing things. Is there a better way?
 
@@ -387,8 +388,8 @@ Int_t THcScintillatorPlane::PulseHeightCorrection()
     timehist[i]=0;
   }
   for (i=0;i<fMaxHits;i++) {
-    keep_pos[i]=kFALSE;
-    keep_neg[i]=kFALSE;
+    //    keep_pos[i]=kFALSE;
+    //    keep_neg[i]=kFALSE;
     two_good_times[i]=kFALSE;
   }
 
@@ -580,7 +581,7 @@ void THcScintillatorPlane::CalculatePedestals( )
   // Use the accumulated pedestal data to calculate pedestals
   // Later add check to see if pedestals have drifted ("Danger Will Robinson!")
   //  cout << "Plane: " << fPlaneNum << endl;
-  for(Int_t i=0; i<fNelem;i++) {
+  for(UInt_t i=0; i<fNelem;i++) {
     
     // Positive tubes
     fPosPed[i] = ((Double_t) fPosPedSum[i]) / TMath::Max(1, fPosPedCount[i]);
@@ -614,7 +615,7 @@ void THcScintillatorPlane::InitializePedestals( )
   fNegPed = new Double_t [fNelem];
   fPosThresh = new Double_t [fNelem];
   fNegThresh = new Double_t [fNelem];
-  for(Int_t i=0;i<fNelem;i++) {
+  for(UInt_t i=0;i<fNelem;i++) {
     fPosPedSum[i] = 0;
     fPosPedSum2[i] = 0;
     fPosPedLimit[i] = 1000;	// In engine, this are set in parameter file

--- a/src/THcScintillatorPlane.h
+++ b/src/THcScintillatorPlane.h
@@ -80,8 +80,8 @@ class THcScintillatorPlane : public THaSubDetector {
   TClonesArray* fNegADCHits;
 
   Int_t fPlaneNum;		/* Which plane am I 1-4 */
-  Int_t fTotPlanes;             /* so we can read variables that are not indexed by plane id */
-  Int_t fNelem;			/* Need since we don't inherit from 
+  UInt_t fTotPlanes;            /* so we can read variables that are not indexed by plane id */
+  UInt_t fNelem;		/* Need since we don't inherit from 
 				 detector base class */
   Int_t fNScinHits;                 /* Number of hits in this plane */
   Int_t fMaxHits;               /* maximum number of hits to be considered - useful for dimensioning arrays */

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -76,7 +76,7 @@ void THcShower::Setup(const char* name, const char* description)
   }
 
   fLayerNames = new char* [fNLayers];
-  for(Int_t i=0;i<fNLayers;i++) {
+  for(UInt_t i=0;i<fNLayers;i++) {
     fLayerNames[i] = new char[layer_names[i].length()+1];
     strcpy(fLayerNames[i], layer_names[i].c_str());
   }
@@ -84,7 +84,7 @@ void THcShower::Setup(const char* name, const char* description)
   char *desc = new char[strlen(description)+100];
   fPlanes = new THcShowerPlane* [fNLayers];
 
-  for(Int_t i=0;i < fNLayers;i++) {
+  for(UInt_t i=0;i < fNLayers;i++) {
     strcpy(desc, description);
     strcat(desc, " Plane ");
     strcat(desc, fLayerNames[i]);
@@ -96,7 +96,7 @@ void THcShower::Setup(const char* name, const char* description)
 
   cout << "---------------------------------------------------------------\n";
   cout << "From THcShower::Setup: created Shower planes ";
-  for(Int_t i=0;i < fNLayers;i++) {
+  for(UInt_t i=0;i < fNLayers;i++) {
     cout << fLayerNames[i];
     i < fNLayers-1 ? cout << ", " : cout << ".\n";
   }
@@ -119,7 +119,7 @@ THaAnalysisObject::EStatus THcShower::Init( const TDatime& date )
   if( (status = THaNonTrackingDetector::Init( date )) )
     return fStatus=status;
 
-  for(Int_t ip=0;ip<fNLayers;ip++) {
+  for(UInt_t ip=0;ip<fNLayers;ip++) {
     if((status = fPlanes[ip]->Init( date ))) {
       return fStatus=status;
     }
@@ -229,11 +229,11 @@ Int_t THcShower::ReadDatabase( const TDatime& date )
   }
 
   BlockThick = new Double_t [fNLayers];
-  fNBlocks = new Int_t [fNLayers];
+  fNBlocks = new UInt_t [fNLayers];
   fNLayerZPos = new Double_t [fNLayers];
   YPos = new Double_t [2*fNLayers];
 
-  for(Int_t i=0;i<fNLayers;i++) {
+  for(UInt_t i=0;i<fNLayers;i++) {
     DBRequest list[]={
       {Form("cal_%s_thick",fLayerNames[i]), &BlockThick[i], kDouble},
       {Form("cal_%s_nr",fLayerNames[i]), &fNBlocks[i], kInt},
@@ -248,7 +248,7 @@ Int_t THcShower::ReadDatabase( const TDatime& date )
   //Caution! Z positions (fronts) are off in hcal.param! Correct later on.
 
   XPos = new Double_t* [fNLayers];
-  for(Int_t i=0;i<fNLayers;i++) {
+  for(UInt_t i=0;i<fNLayers;i++) {
     XPos[i] = new Double_t [fNBlocks[i]];
     DBRequest list[]={
       {Form("cal_%s_top",fLayerNames[i]),XPos[i], kDouble, fNBlocks[i]},
@@ -259,7 +259,7 @@ Int_t THcShower::ReadDatabase( const TDatime& date )
 
   // Debug output.
   if (fdbg_init_cal) {
-    for(Int_t i=0;i<fNLayers;i++) {
+    for(UInt_t i=0;i<fNLayers;i++) {
       cout << "  Plane " << fLayerNames[i] << ":" << endl;
       cout << "    Block thickness: " << BlockThick[i] << endl;
       cout << "    NBlocks        : " << fNBlocks[i] << endl;
@@ -267,7 +267,7 @@ Int_t THcShower::ReadDatabase( const TDatime& date )
       cout << "    Y Positions    : " << YPos[2*i] << ", " << YPos[2*i+1]
 	   <<endl;
       cout << "    X Positions    :";
-      for(Int_t j=0; j<fNBlocks[i]; j++) {
+      for(UInt_t j=0; j<fNBlocks[i]; j++) {
 	cout << " " << XPos[i][j];
       }
       cout << endl;
@@ -292,7 +292,7 @@ Int_t THcShower::ReadDatabase( const TDatime& date )
   //Calibration related parameters (from hcal.param).
 
   fNtotBlocks=0;              //total number of blocks
-  for (Int_t i=0; i<fNLayers; i++) fNtotBlocks += fNBlocks[i];
+  for (UInt_t i=0; i<fNLayers; i++) fNtotBlocks += fNBlocks[i];
 
   // Debug output.
   if (fdbg_init_cal) 
@@ -340,54 +340,54 @@ Int_t THcShower::ReadDatabase( const TDatime& date )
   if (fdbg_init_cal) {
 
     cout << "  hcal_pos_cal_const:" << endl;
-    for (Int_t j=0; j<fNLayers; j++) {
+    for (UInt_t j=0; j<fNLayers; j++) {
       cout << "    ";
-      for (Int_t i=0; i<fNBlocks[j]; i++) {
+      for (UInt_t i=0; i<fNBlocks[j]; i++) {
 	cout << hcal_pos_cal_const[j*fNBlocks[j]+i] << " ";
       };
       cout <<  endl;
     };
 
     cout << "  fShPosPedLimit:" << endl;
-    for (Int_t j=0; j<fNLayers; j++) {
+    for (UInt_t j=0; j<fNLayers; j++) {
       cout << "    ";
-      for (Int_t i=0; i<fNBlocks[j]; i++) {
+      for (UInt_t i=0; i<fNBlocks[j]; i++) {
 	cout << fShPosPedLimit[j*fNBlocks[j]+i] << " ";
       };
       cout <<  endl;
     };
 
     cout << "  hcal_pos_gain_cor:" << endl;
-    for (Int_t j=0; j<fNLayers; j++) {
+    for (UInt_t j=0; j<fNLayers; j++) {
       cout << "    ";
-      for (Int_t i=0; i<fNBlocks[j]; i++) {
+      for (UInt_t i=0; i<fNBlocks[j]; i++) {
 	cout << hcal_pos_gain_cor[j*fNBlocks[j]+i] << " ";
       };
       cout <<  endl;
     };
 
     cout << "  hcal_neg_cal_const:" << endl;
-    for (Int_t j=0; j<fNLayers; j++) {
+    for (UInt_t j=0; j<fNLayers; j++) {
       cout << "    ";
-      for (Int_t i=0; i<fNBlocks[j]; i++) {
+      for (UInt_t i=0; i<fNBlocks[j]; i++) {
 	cout << hcal_neg_cal_const[j*fNBlocks[j]+i] << " ";
       };
       cout <<  endl;
     };
 
     cout << "  fShNegPedLimit:" << endl;
-    for (Int_t j=0; j<fNLayers; j++) {
+    for (UInt_t j=0; j<fNLayers; j++) {
       cout << "    ";
-      for (Int_t i=0; i<fNBlocks[j]; i++) {
+      for (UInt_t i=0; i<fNBlocks[j]; i++) {
 	cout << fShNegPedLimit[j*fNBlocks[j]+i] << " ";
       };
       cout <<  endl;
     };
 
     cout << "  hcal_neg_gain_cor:" << endl;
-    for (Int_t j=0; j<fNLayers; j++) {
+    for (UInt_t j=0; j<fNLayers; j++) {
       cout << "    ";
-      for (Int_t i=0; i<fNBlocks[j]; i++) {
+      for (UInt_t i=0; i<fNBlocks[j]; i++) {
 	cout << hcal_neg_gain_cor[j*fNBlocks[j]+i] << " ";
       };
       cout <<  endl;
@@ -397,7 +397,7 @@ Int_t THcShower::ReadDatabase( const TDatime& date )
 
   // Calibration constants (GeV / ADC channel).
 
-  for (Int_t i=0; i<fNtotBlocks; i++) {
+  for (UInt_t i=0; i<fNtotBlocks; i++) {
     fPosGain[i] = hcal_pos_cal_const[i] *  hcal_pos_gain_cor[i];
     fNegGain[i] = hcal_neg_cal_const[i] *  hcal_neg_gain_cor[i];
   }
@@ -406,18 +406,18 @@ Int_t THcShower::ReadDatabase( const TDatime& date )
   if (fdbg_init_cal) {
 
     cout << "  fPosGain:" << endl;
-    for (Int_t j=0; j<fNLayers; j++) {
+    for (UInt_t j=0; j<fNLayers; j++) {
       cout << "    ";
-      for (Int_t i=0; i<fNBlocks[j]; i++) {
+      for (UInt_t i=0; i<fNBlocks[j]; i++) {
 	cout << fPosGain[j*fNBlocks[j]+i] << " ";
       };
       cout <<  endl;
     };
 
     cout << "  fNegGain:" << endl;
-    for (Int_t j=0; j<fNLayers; j++) {
+    for (UInt_t j=0; j<fNLayers; j++) {
       cout << "    ";
-      for (Int_t i=0; i<fNBlocks[j]; i++) {
+      for (UInt_t i=0; i<fNBlocks[j]; i++) {
 	cout << fNegGain[j*fNBlocks[j]+i] << " ";
       };
       cout <<  endl;
@@ -507,7 +507,7 @@ void THcShower::Clear(Option_t* opt)
 
 //   Reset per-event data.
 
-  for(Int_t ip=0;ip<fNLayers;ip++) {
+  for(UInt_t ip=0;ip<fNLayers;ip++) {
     fPlanes[ip]->Clear(opt);
   }
 
@@ -532,7 +532,7 @@ Int_t THcShower::Decode( const THaEvData& evdata )
 
   if(gHaCuts->Result("Pedestal_event")) {
     Int_t nexthit = 0;
-    for(Int_t ip=0;ip<fNLayers;ip++) {
+    for(UInt_t ip=0;ip<fNLayers;ip++) {
       nexthit = fPlanes[ip]->AccumulatePedestals(fRawHitList, nexthit);
     }
     fAnalyzePedestals = 1;	// Analyze pedestals first normal events
@@ -540,14 +540,14 @@ Int_t THcShower::Decode( const THaEvData& evdata )
   }
 
   if(fAnalyzePedestals) {
-    for(Int_t ip=0;ip<fNLayers;ip++) {
+    for(UInt_t ip=0;ip<fNLayers;ip++) {
       fPlanes[ip]->CalculatePedestals();
     }
     fAnalyzePedestals = 0;	// Don't analyze pedestals next event
   }
 
   Int_t nexthit = 0;
-  for(Int_t ip=0;ip<fNLayers;ip++) {
+  for(UInt_t ip=0;ip<fNLayers;ip++) {
     nexthit = fPlanes[ip]->ProcessHits(fRawHitList, nexthit);
   }
 
@@ -570,9 +570,9 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
 
   THcShowerHitList HitList;
 
-  for(Int_t j=0; j < fNLayers; j++) {
+  for(UInt_t j=0; j < fNLayers; j++) {
 
-    for (Int_t i=0; i<fNBlocks[j]; i++) {
+    for (UInt_t i=0; i<fNBlocks[j]; i++) {
 
       //May be should be done this way.
       //
@@ -784,7 +784,7 @@ Float_t THcShower::GetShEnergy(THaTrack* Track) {
 
     // Correct track energy depositions for the impact coordinate.
 
-    for (Int_t ip=0; ip<fNLayers; ip++) {
+    for (UInt_t ip=0; ip<fNLayers; ip++) {
 
       // Coordinate correction factors for positive and negative sides,
       // different for single PMT counters in the 1-st two layes and for

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -463,15 +463,15 @@ protected:
   // Geometrical parameters.
 
   char** fLayerNames;
-  Int_t fNLayers;               // Number of layers in the calorimeter
+  UInt_t fNLayers;	        // Number of layers in the calorimeter
   Double_t* fNLayerZPos;	// Z positions of fronts of layers
   Double_t* BlockThick;		// Thickness of blocks
-  Int_t* fNBlocks;              // [fNLayers] number of blocks per layer
-  Int_t fNtotBlocks;            // Total number of shower counter blocks
+  UInt_t* fNBlocks;              // [fNLayers] number of blocks per layer
+  UInt_t fNtotBlocks;            // Total number of shower counter blocks
   Double_t** XPos;		// [fNLayers] X,Y,Z positions of blocks
   Double_t* YPos;
   Double_t* ZPos;
-  Int_t fNegCols;               // # of columns with neg. side PMTs only.
+  UInt_t fNegCols;               // # of columns with neg. side PMTs only.
   Double_t fSlop;               // Track to cluster vertical slop distance.
   Int_t fvTest;                 // fiducial volume test flag for tracking
   Double_t fvDelta;             // Exclusion band width for fiducial volume


### PR DESCRIPTION
Restored the compiler warnings fixes from commit e9ce104092419d56d05f375296253a89b01d33c1.  However, in fNPlanes in the hodoscope and drift chamber were kept as signed integers.   fNPlanes is used to specify the length of arrays passed to the global variables (for root tree).  (Using the [fNPlanes] magic in the .h files).  When fNPlanes was a UInt_t, things didn't work.