### PR TITLE
Eliminate inheritance of the HMS calorimeter classes from the STL containers.

### DIFF
--- a/examples/PARAM/52949/hcal.param.vt.52949
+++ b/examples/PARAM/52949/hcal.param.vt.52949
@@ -4,7 +4,7 @@ hcal_slop = 7.5
 
 ;Turn on HMS cal. fiducial volume cut. 0="no cut"
 ;Default hcal_fv_test=0
-hcal_fv_test = 0
+hcal_fv_test = 1
 
 hcal_pos_cal_const =0.001,0.001,0.001,0.001,0.001,0.001,0.001,0.001,0.001,0.001,0.001,0.001,0.001
                     0.001,0.001,0.001,0.001,0.001,0.001,0.001,0.001,0.001,0.001,0.001,0.001,0.001

--- a/hcal_calib/THcShowerCalib.h
+++ b/hcal_calib/THcShowerCalib.h
@@ -16,6 +16,8 @@
 #include "TFile.h"
 #include "TTree.h"
 
+#define D_CALO_FP 338.69    //distance from FP to the calorimeter face
+
 using namespace std;
 
 //
@@ -250,11 +252,11 @@ void THcShowerCalib::ReadShRawTrack(THcShTrack &trk, UInt_t ientry) {
 
   // Track parameters.
 
-  Double_t        H_cal_trp;
-  Double_t        H_cal_trx;
-  Double_t        H_cal_trxp;
-  Double_t        H_cal_try;
-  Double_t        H_cal_tryp;
+  Double_t        H_tr_p;
+  Double_t        H_tr_x;   //X FP
+  Double_t        H_tr_xp;
+  Double_t        H_tr_y;   //Y FP
+  Double_t        H_tr_yp;
 
   // Set branch addresses.
 
@@ -270,15 +272,16 @@ void THcShowerCalib::ReadShRawTrack(THcShTrack &trk, UInt_t ientry) {
   fTree->SetBranchAddress("H.cal.4ta.aneg_p",H_cal_4ta_aneg_p);
   fTree->SetBranchAddress("H.cal.4ta.apos_p",H_cal_4ta_apos_p);
 
-  fTree->SetBranchAddress("H.cal.trx",&H_cal_trx);
-  fTree->SetBranchAddress("H.cal.try",&H_cal_try);
-  fTree->SetBranchAddress("H.tr.th",&H_cal_trxp);
-  fTree->SetBranchAddress("H.tr.ph",&H_cal_tryp);
-  fTree->SetBranchAddress("H.tr.p",&H_cal_trp);
+  fTree->SetBranchAddress("H.tr.x",&H_tr_x);
+  fTree->SetBranchAddress("H.tr.y",&H_tr_y);
+  fTree->SetBranchAddress("H.tr.th",&H_tr_xp);
+  fTree->SetBranchAddress("H.tr.ph",&H_tr_yp);
+  fTree->SetBranchAddress("H.tr.p",&H_tr_p);
 
   fTree->GetEntry(ientry);
 
-  trk.Reset(H_cal_trp, H_cal_trx, H_cal_trxp, H_cal_try, H_cal_tryp);
+  trk.Reset(H_tr_p, H_tr_x+D_CALO_FP*H_tr_xp, H_tr_xp,
+	    H_tr_y+D_CALO_FP*H_tr_yp, H_tr_yp);
 
   for (UInt_t j=0; j<THcShTrack::fNrows; j++) {
     for (UInt_t k=0; k<THcShTrack::fNcols; k++) {

--- a/hcal_calib/hcal_replay_cuts.def
+++ b/hcal_calib/hcal_replay_cuts.def
@@ -28,19 +28,22 @@ one_clust H.cal.nclust==1
 one_sh_track H.cal.ntracks==1
 in_delta  H.tr.tg_dp>-10.&&H.tr.tg_dp<10.
 good_cer H.cer.npesum>3.
-#good_beta H.tr.beta>0.9&&H.tr.beta<1.1
-good_beta H.hod.fpBeta>0.740&&H.hod.fpBeta<0.935   # 3sigma cut for run 52949
-in_calx   H.cal.trx>-65.4&&H.cal.trx<54.6    #top+5cm, bottom-5cm (see hcal.pos)
-in_caly   H.cal.try>-30.&&H.cal.try<30.      #left+5cm, right-5cm.(see hcal.pos)
-in_cal    in_calx&&in_caly
+
+#good_beta H.hod.fpBeta>0.740&&H.hod.fpBeta<0.935   # 3sigma cut for run 52949
+good_beta H.tr.beta>0.740&&H.tr.beta<0.935
+
+# 338.69 = 350.0-11.31, distance from FP to the face of calorimeter
+
+#in_calx   H.tr.x+H.tr.th*338.69>-65.4&&H.tr.x+H.tr.th*338.69<54.6    #top+5cm, bottom-5cm (see hcal.pos)
+#in_caly   H.tr.y+H.tr.ph*338.69>-30.&&H.tr.y+H.tr.ph*338.69<30.      #left+5cm, right-5cm.(see hcal.pos)
+#in_cal    in_calx&&in_caly
+
+Reconstruct_master one_track && in_delta && good_cer && one_clust && good_beta
 
 # This version is for calibration from scratch (no calibration constants exist,
 # first time calibration).
-Reconstruct_master one_track && one_clust && in_delta && good_cer && good_beta && in_cal
+##Reconstruct_master one_track && one_clust && in_delta && good_cer && good_beta
 
 # This version can be used for iterative calibration (improve existing
 # constants).
-#Reconstruct_master one_track && one_sh_track && in_delta && good_cer && good_beta && in_cal
-
-
-
+#Reconstruct_master one_track && one_sh_track && in_delta && good_cer && good_beta

--- a/hcal_calib/output_hcal_replay.def
+++ b/hcal_calib/output_hcal_replay.def
@@ -4,10 +4,16 @@
 
 block H.cal.*
 variable H.cer.npesum
-#variable H.tr.beta
-variable H.hod.fpBeta
+variable H.tr.beta
+#variable H.hod.fpBeta
 variable H.tr.p
 variable H.tr.tg_dp
+variable H.tr.y 	#Y FP
+variable H.tr.x 	#X FP
 variable H.tr.ph	#tan(phi), wrt Y axis
 variable H.tr.th	#tan(theta), wrt X axis
 variable H.tr.n		#number of tracks
+#formula Hcal_trx H.tr.x+338.69*H.tr.th
+#formula Hcal_try H.tr.y+338.69*H.tr.ph
+#variable Hcal_trx
+#variable Hcal_try

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -561,7 +561,7 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
 
   // Fill list of unclustered hits.
 
-  THcShowerHitList HitList;
+  THcShowerHitSet HitSet;
 
   for(Int_t j=0; j < fNLayers; j++) {
 
@@ -590,13 +590,13 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
 
 	THcShowerHit* hit = new THcShowerHit(i,j,x,z,Edep,Epos,Eneg);
 
-	HitList.insert(hit);   //<set> version
+	HitSet.insert(hit);   //<set> version
       }
 
     }
   }
 
-  fNhits = HitList.size();
+  fNhits = HitSet.size();
 
   //Debug output, print out hits before clustering.
 
@@ -604,7 +604,7 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
     cout << "---------------------------------------------------------------\n";
     cout << "Debug output from THcShower::CoarseProcess\n";
     cout << "  List of unclustered hits. Total hits:     " << fNhits << endl;
-    THcShowerHitIt it = HitList.begin();    //<set> version
+    THcShowerHitIt it = HitSet.begin();    //<set> version
     for (Int_t i=0; i!=fNhits; i++) {
       cout << "  hit " << i << ": ";
       (*(it++))->show();
@@ -613,7 +613,7 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
 
   // Create list of clusters and fill it.
 
-  fClusterList->ClusterHits(HitList);
+  fClusterList->ClusterHits(HitSet);
 
   fNclust = (*fClusterList).NbClusters();   //number of clusters
 
@@ -720,7 +720,7 @@ Double_t clEplane(THcShowerCluster* cluster, Int_t iplane, Int_t side) {
     return -1;
   }
 
-  THcShowerHitList pcluster;
+  THcShowerHitSet pcluster;
   for (THcShowerHitIt it=(*cluster).begin(); it!=(*cluster).end(); ++it) {
     if ((*it)->hitColumn() == iplane) pcluster.insert(*it);
   }

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -559,7 +559,7 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
   // Clustering of hits.
   //
 
-  // Fill list of unclustered hits.
+  // Fill set of unclustered hits.
 
   THcShowerHitSet HitSet;
 

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -590,7 +590,8 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
 
 	THcShowerHit* hit = new THcShowerHit(i,j,x,z,Edep,Epos,Eneg);
 
-	HitList.push_back(hit);
+	//	HitList.push_back(hit);
+	HitList.insert(hit);   //<set> version
       }
 
     }
@@ -604,9 +605,15 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
     cout << "---------------------------------------------------------------\n";
     cout << "Debug output from THcShower::CoarseProcess\n";
     cout << "  List of unclustered hits. Total hits:     " << fNhits << endl;
+    //    for (Int_t i=0; i!=fNhits; i++) {
+    //      cout << "  hit " << i << ": ";
+    //      (*(HitList.begin()+i))->show();
+    //    }
+    //<set> version
+    THcShowerHitIt it = HitList.begin();
     for (Int_t i=0; i!=fNhits; i++) {
       cout << "  hit " << i << ": ";
-      (*(HitList.begin()+i))->show();
+      (*(++it))->show();
     }
   }
 

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -590,7 +590,6 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
 
 	THcShowerHit* hit = new THcShowerHit(i,j,x,z,Edep,Epos,Eneg);
 
-	//	HitList.push_back(hit);
 	HitList.insert(hit);   //<set> version
       }
 
@@ -605,12 +604,7 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
     cout << "---------------------------------------------------------------\n";
     cout << "Debug output from THcShower::CoarseProcess\n";
     cout << "  List of unclustered hits. Total hits:     " << fNhits << endl;
-    //    for (Int_t i=0; i!=fNhits; i++) {
-    //      cout << "  hit " << i << ": ";
-    //      (*(HitList.begin()+i))->show();
-    //    }
-    //<set> version
-    THcShowerHitIt it = HitList.begin();
+    THcShowerHitIt it = HitList.begin();    //<set> version
     for (Int_t i=0; i!=fNhits; i++) {
       cout << "  hit " << i << ": ";
       (*(++it))->show();

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -618,7 +618,7 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
     }
   }
 
-  // Create list of clusters and fill it.
+  // Fill list of clusters.
 
   ClusterHits(HitSet);
 
@@ -662,7 +662,7 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
 void THcShower::ClusterHits(THcShowerHitSet& HitSet) {
 
   // Collect hits from the HitSet into the clusters. The resultant clusters
-  // of hits are saved in the ClusterList.
+  // of hits are saved in the fClusterList.
 
   while (HitSet.size() != 0) {
 
@@ -706,6 +706,8 @@ void THcShower::ClusterHits(THcShowerHitSet& HitSet) {
 };
 
 //-----------------------------------------------------------------------------
+
+// Various helper functions to accumulate hit related quantities.
 
 Double_t addE(Double_t x, THcShowerHit* h) {
   return x + h->hitE();
@@ -762,7 +764,6 @@ Double_t clE(THcShowerCluster* cluster) {
 Double_t clEpr(THcShowerCluster* cluster) {
     return accumulate((*cluster).begin(),(*cluster).end(),0.,addEpr);
 }
-
 
 //Cluster energy deposition in plane iplane=0,..,3:
 // side=0 -- from positive PMTs only;

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -104,6 +104,13 @@ public:
 	 << "  E=" << fE << "  Epos=" << fEpos << "  Eneg=" << fEneg << endl;
   }
 
+  bool operator<(THcShowerHit rhs) const {
+    if (fCol != rhs.fCol)
+      return fCol < rhs.fCol;
+    else
+      fRow < rhs.fRow;
+  }
+
 };
 
 

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -104,7 +104,7 @@ public:
 	 << "  E=" << fE << "  Epos=" << fEpos << "  Eneg=" << fEneg << endl;
   }
 
-  // Define < operator in order to fill in hit sets in a sorted manner.
+  // Define < operator in order to fill in set of hits in a sorted manner.
   //
   bool operator<(THcShowerHit rhs) const {
     if (fCol != rhs.fCol)
@@ -303,12 +303,15 @@ protected:
 
 ///////////////////////////////////////////////////////////////////////////////
 
-// Auxiliary methods to be used with the hit and cluster containers.
+// Various helper functions to accumulate hit related quantities.
 
 Double_t addE(Double_t x, THcShowerHit* h);
 Double_t addX(Double_t x, THcShowerHit* h);
 Double_t addZ(Double_t x, THcShowerHit* h);
 Double_t addEpr(Double_t x, THcShowerHit* h);
+
+// Methods to calculate coordinates and energy depositions for a given cluster.
+
 Double_t clX(THcShowerCluster* cluster);
 Double_t clZ(THcShowerCluster* cluster);
 Double_t clE(THcShowerCluster* cluster);

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -87,12 +87,12 @@ public:
   }
 
   // Decide if a hit is neighbouring the current hit.
-  // Two hits are neighbours if share a side or a corner.
+  // Two hits are neighbours if share a side or a corner,
+  // or in the same row but separated by no more than a block.
   //
   bool isNeighbour(THcShowerHit* hit1) {      //Is hit1 neighbouring this hit?
     Int_t dRow = fRow-(*hit1).fRow;
     Int_t dCol = fCol-(*hit1).fCol;
-    //    return TMath::Abs(dRow)<2 && TMath::Abs(dCol)<2;
     return (TMath::Abs(dRow)<2 && TMath::Abs(dCol)<2) ||
       (dRow==0 && TMath::Abs(dCol)<3);
   }
@@ -107,14 +107,12 @@ public:
 
 };
 
+//____________________________________________________________________________
 
 // Container (collection) of hits and its iterator.
 //
-//typedef vector<THcShowerHit*> THcShowerHitList;
 typedef set<THcShowerHit*> THcShowerHitList;
 typedef THcShowerHitList::iterator THcShowerHitIt;
-
-//____________________________________________________________________________
 
 //HMS calorimeter hit cluster
 //
@@ -137,17 +135,10 @@ class THcShowerCluster : THcShowerHitList {
   // Add a hit to the cluster hit list
   //
   void grow(THcShowerHit* hit) {
-    //    THcShowerHitList::push_back(hit);
     THcShowerHitList::insert(hit);   //<set> version
   }
 
   //Pointer to the hit #i in the cluster hit list
-  //
-  //  THcShowerHit* ClusteredHit(UInt_t i) {
-  //    return * (THcShowerHitList::begin()+i);
-  //  }
-
-  //<set> version
   THcShowerHit* ClusteredHit(UInt_t i) {
     THcShowerHitIt it = THcShowerHitList::begin();
     for (UInt_t j=0; j<i; j++) it++;
@@ -156,11 +147,6 @@ class THcShowerCluster : THcShowerHitList {
 
   //Print out a hit in the cluster
   //
-  //  void showHit(UInt_t num) {
-  //    (*(THcShowerHitList::begin()+num))->show();
-  //  }
-
-  //<set> version
   void showHit(UInt_t num) {
     THcShowerHitIt it = THcShowerHitList::begin();
     for (UInt_t j=0; j<num; j++) it++;
@@ -180,7 +166,6 @@ class THcShowerCluster : THcShowerHitList {
       x_sum += (*it)->hitX() * (*it)->hitE();
       Etot += (*it)->hitE();
     }
-    //    cout << "x_sum=" << x_sum << "  Etot=" << Etot << endl;
     return (Etot != 0. ? x_sum/Etot : -75.);
   }
 
@@ -197,14 +182,12 @@ class THcShowerCluster : THcShowerHitList {
       z_sum += (*it)->hitZ() * (*it)->hitE();
       Etot += (*it)->hitE();
     }
-    //    cout << "z_sum=" << z_sum << "  Etot=" << Etot << endl;
     return (Etot != 0. ? z_sum/Etot : 0.);
   }
 
   //Energy depostion in a cluster
   //
   Double_t clE() {
-    //    cout << "In ECl:" << endl;
     Double_t Etot=0.;
     for (THcShowerHitIt it=THcShowerHitList::begin();
 	 it!=THcShowerHitList::end(); ++it) {
@@ -269,7 +252,7 @@ class THcShowerCluster : THcShowerHitList {
 
 };
 
-//-----------------------------------------------------------------------------
+//______________________________________________________________________________
 
 //Alias for container of clusters and for its iterator
 //
@@ -319,8 +302,6 @@ class THcShowerClusterList : private THcShClusterList {
     return THcShClusterList::size();
   }
 
-  //____________________________________________________________________________
-
   void ClusterHits(THcShowerHitList HitList) {
 
     // Collect hits from the HitList into the clusters. The resultant clusters
@@ -330,9 +311,6 @@ class THcShowerClusterList : private THcShClusterList {
 
       THcShowerCluster* cluster = new THcShowerCluster;
 
-      //(*cluster).grow(*(HitList.end()-1)); //Move the last hit from the hit list
-      //HitList.erase(HitList.end()-1);      //into the 1st cluster
-      //<set> version
       THcShowerHitIt it = HitList.end();
       (*cluster).grow(*(--it)); //Move the last hit from the hit list
       HitList.erase(it);        //into the 1st cluster
@@ -371,7 +349,7 @@ class THcShowerClusterList : private THcShClusterList {
 
 };
 
-
+//______________________________________________________________________________
 
 class THcShower : public THaNonTrackingDetector, public THcHitList {
 

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -111,10 +111,10 @@ public:
 
 // Container (collection) of hits and its iterator.
 //
-typedef set<THcShowerHit*> THcShowerHitList;
-typedef THcShowerHitList::iterator THcShowerHitIt;
+typedef set<THcShowerHit*> THcShowerHitSet;
+typedef THcShowerHitSet::iterator THcShowerHitIt;
 
-typedef THcShowerHitList THcShowerCluster;
+typedef THcShowerHitSet THcShowerCluster;
 typedef THcShowerCluster::iterator THcShowerClusterIt;
 
 //______________________________________________________________________________
@@ -167,18 +167,18 @@ class THcShowerClusterList : private THcShClusterList {
     return THcShClusterList::size();
   }
 
-  void ClusterHits(THcShowerHitList HitList) {
+  void ClusterHits(THcShowerHitSet HitSet) {
 
-    // Collect hits from the HitList into the clusters. The resultant clusters
+    // Collect hits from the HitSet into the clusters. The resultant clusters
     // of hits are saved in the ClusterList.
 
-    while (HitList.size() != 0) {
+    while (HitSet.size() != 0) {
 
       THcShowerCluster* cluster = new THcShowerCluster;
 
-      THcShowerHitIt it = HitList.end();
+      THcShowerHitIt it = HitSet.end();
       (*cluster).insert(*(--it));   //Move the last hit from the hit list
-      HitList.erase(it);            //into the 1st cluster
+      HitSet.erase(it);            //into the 1st cluster
 
       bool clustered = true;
 
@@ -186,7 +186,7 @@ class THcShowerClusterList : private THcShClusterList {
 
 	clustered = false;
 
-	for (THcShowerHitIt i=HitList.begin(); i!=HitList.end(); ++i) {
+	for (THcShowerHitIt i=HitSet.begin(); i!=HitSet.end(); ++i) {
 
 	  for (THcShowerClusterIt k=(*cluster).begin(); k!=(*cluster).end();
 	       k++) {
@@ -194,7 +194,7 @@ class THcShowerClusterList : private THcShClusterList {
 	    if ((**i).isNeighbour(*k)) {
 
 	      (*cluster).insert(*i);      //If the hit #i is neighbouring a hit
-	      HitList.erase(i);           //in the cluster, then move it
+	      HitSet.erase(i);           //in the cluster, then move it
 	                                  //into the cluster.
 	      clustered = true;
 	    }

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -104,11 +104,13 @@ public:
 	 << "  E=" << fE << "  Epos=" << fEpos << "  Eneg=" << fEneg << endl;
   }
 
+  // Define < operator in order to fill in hit sets in a sorted manner.
+  //
   bool operator<(THcShowerHit rhs) const {
     if (fCol != rhs.fCol)
       return fCol < rhs.fCol;
     else
-      fRow < rhs.fRow;
+      return fRow < rhs.fRow;
   }
 
 };
@@ -128,99 +130,8 @@ typedef THcShowerCluster::iterator THcShowerClusterIt;
 
 //Alias for container of clusters and for its iterator
 //
-typedef vector<THcShowerCluster*> THcShClusterList;
-typedef THcShClusterList::iterator THcShClusterIt;
-
-//List of clusters
-//
-class THcShowerClusterList : private THcShClusterList {
-
- public:
-
-  THcShowerClusterList() {
-    //    cout << "Dummy THcShowerClusterList object created" << endl;
-  }
-
-  ~THcShowerClusterList() {
-    purge();
-  }
-
-  // Purge cluster list
-  //
-  void purge() {
-    for (THcShClusterIt i = THcShClusterList::begin();
-	 i != THcShClusterList::end(); ++i) {
-      delete *i;
-      *i = 0;
-    }
-    THcShClusterList::clear();
-  }
-
-  //Put a cluster in the cluster list
-  //
-  void grow(THcShowerCluster* cluster) {
-    THcShClusterList::push_back(cluster);
-  }
-
-  //Pointer to the cluster #i in the cluster list
-  //
-  THcShowerCluster* ListedCluster(UInt_t i) {
-    return *(THcShClusterList::begin()+i);
-  }
-
-  //Cluster list size.
-  //
-  UInt_t NbClusters() {
-    return THcShClusterList::size();
-  }
-
-  void ClusterHits(THcShowerHitSet HitSet) {
-
-    // Collect hits from the HitSet into the clusters. The resultant clusters
-    // of hits are saved in the ClusterList.
-
-    while (HitSet.size() != 0) {
-
-      THcShowerCluster* cluster = new THcShowerCluster;
-
-      THcShowerHitIt it = HitSet.end();
-      (*cluster).insert(*(--it));   //Move the last hit from the hit list
-      HitSet.erase(it);            //into the 1st cluster
-
-      bool clustered = true;
-
-      while (clustered) {                   //Proceed while a hit is clustered
-
-	clustered = false;
-
-	for (THcShowerHitIt i=HitSet.begin(); i!=HitSet.end(); ++i) {
-
-	  for (THcShowerClusterIt k=(*cluster).begin(); k!=(*cluster).end();
-	       k++) {
-
-	    if ((**i).isNeighbour(*k)) {
-
-	      (*cluster).insert(*i);      //If the hit #i is neighbouring a hit
-	      HitSet.erase(i);           //in the cluster, then move it
-	                                  //into the cluster.
-	      clustered = true;
-	    }
-
-	    if (clustered) break;
-	  }                               //k
-
-	  if (clustered) break;
-	}                                 //i
-
-      }                                   //while clustered
-
-      push_back(cluster);         //Put the cluster in the cluster list
-
-    }                                     //While hit_list not exhausted
-
-  }
-
-};
+typedef vector<THcShowerCluster*> THcShowerClusterList;
+typedef THcShowerClusterList::iterator THcShowerClusterListIt;
 
 //______________________________________________________________________________
 
@@ -382,6 +293,8 @@ protected:
 
   // Cluster to track association method.
   Int_t MatchCluster(THaTrack*, Double_t&, Double_t&);
+
+  void ClusterHits(THcShowerHitSet& HitSet);
 
   friend class THcShowerPlane;   //to access debug flags.
 

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -16,7 +16,6 @@
 
 // HMS calorimeter hits, version 2
 
-//#include <vector>
 #include <set>
 #include <iterator>
 #include <iostream>
@@ -107,6 +106,7 @@ public:
 
 };
 
+
 //____________________________________________________________________________
 
 // Container (collection) of hits and its iterator.
@@ -114,143 +114,8 @@ public:
 typedef set<THcShowerHit*> THcShowerHitList;
 typedef THcShowerHitList::iterator THcShowerHitIt;
 
-//HMS calorimeter hit cluster
-//
-class THcShowerCluster : THcShowerHitList {
-
- public:
-
-  THcShowerCluster() {
-    //    cout << "Dummy THcShowerCluster object created" << endl;
-  }
-
-  ~THcShowerCluster() {
-    for (THcShowerHitIt i = THcShowerHitList::begin();
-    	 i != THcShowerHitList::end(); ++i) {
-      delete *i;
-      //      *i = 0; does no work with  set<THcShowerHit*> THcShowerHitList
-    }
-  }
-
-  // Add a hit to the cluster hit list
-  //
-  void grow(THcShowerHit* hit) {
-    THcShowerHitList::insert(hit);   //<set> version
-  }
-
-  //Pointer to the hit #i in the cluster hit list
-  THcShowerHit* ClusteredHit(UInt_t i) {
-    THcShowerHitIt it = THcShowerHitList::begin();
-    for (UInt_t j=0; j<i; j++) it++;
-    return *it;
-  }
-
-  //Print out a hit in the cluster
-  //
-  void showHit(UInt_t num) {
-    THcShowerHitIt it = THcShowerHitList::begin();
-    for (UInt_t j=0; j<num; j++) it++;
-    (*it)->show();
-  }
-
-  // X coordinate of center of gravity of cluster,
-  // calculated as hit energy weighted average.
-  // Put X out of the calorimeter (-75 cm), if there is no energy deposition
-  // in the cluster.
-  //
-  Double_t clX() {
-    Double_t x_sum=0.;
-    Double_t Etot=0.;
-    for (THcShowerHitIt it=THcShowerHitList::begin();
-	 it!=THcShowerHitList::end(); ++it) {
-      x_sum += (*it)->hitX() * (*it)->hitE();
-      Etot += (*it)->hitE();
-    }
-    return (Etot != 0. ? x_sum/Etot : -75.);
-  }
-
-  // Z coordinate of center of gravity of cluster,
-  // calculated as a hit energy weighted average.
-  // Put Z out of the calorimeter (0 cm), if there is no energy deposition
-  // in the cluster.
-  //
-  Double_t clZ() {
-    Double_t z_sum=0.;
-    Double_t Etot=0.;
-    for (THcShowerHitIt it=THcShowerHitList::begin();
-	 it!=THcShowerHitList::end(); ++it) {
-      z_sum += (*it)->hitZ() * (*it)->hitE();
-      Etot += (*it)->hitE();
-    }
-    return (Etot != 0. ? z_sum/Etot : 0.);
-  }
-
-  //Energy depostion in a cluster
-  //
-  Double_t clE() {
-    Double_t Etot=0.;
-    for (THcShowerHitIt it=THcShowerHitList::begin();
-	 it!=THcShowerHitList::end(); ++it) {
-      Etot += (*it)->hitE();
-    }
-    return Etot;
-  }
-
-  //Energy deposition in the Preshower (1st plane) for a cluster
-  //
-  Double_t clEpr() {
-    Double_t Epr=0.;
-    for (THcShowerHitIt it=THcShowerHitList::begin();
-	 it!=THcShowerHitList::end(); ++it) {
-      if ((*it)->hitColumn() == 0) {
-	Epr += (*it)->hitE();
-      }
-    }
-    return Epr;
-  }
-
-  //Cluster energy deposition in plane iplane=0,..,3:
-  // side=0 -- from positive PMTs only;
-  // side=1 -- from negative PMTs only;
-  // side=2 -- from postive and negative PMTs.
-  //
-
-  Double_t clEplane(Int_t iplane, Int_t side) {
-
-    if (side!=0&&side!=1&&side!=2) {
-      cout << "*** Wrong Side in clEplane:" << side << " ***" << endl;
-      return -1;
-    }
-
-    Double_t Eplane=0.;
-    for (THcShowerHitIt it=THcShowerHitList::begin();
-	 it!=THcShowerHitList::end(); ++it) {
-
-      if ((*it)->hitColumn() == iplane) 
-
-	switch (side) {
-	case 0 : Eplane += (*it)->hitEpos();
-	  break;
-	case 1 : Eplane += (*it)->hitEneg();
-	  break;
-	case 2 : Eplane += (*it)->hitE();
-	  break;
-	default : ;
-	}
-
-    }
-
-    return Eplane;
-  }
-
-
-  //Cluster size (number of hits in the cluster).
-  //
-  UInt_t clSize() {
-    return THcShowerHitList::size();
-  }
-
-};
+typedef THcShowerHitList THcShowerCluster;
+typedef THcShowerCluster::iterator THcShowerClusterIt;
 
 //______________________________________________________________________________
 
@@ -312,8 +177,8 @@ class THcShowerClusterList : private THcShClusterList {
       THcShowerCluster* cluster = new THcShowerCluster;
 
       THcShowerHitIt it = HitList.end();
-      (*cluster).grow(*(--it)); //Move the last hit from the hit list
-      HitList.erase(it);        //into the 1st cluster
+      (*cluster).insert(*(--it));   //Move the last hit from the hit list
+      HitList.erase(it);            //into the 1st cluster
 
       bool clustered = true;
 
@@ -323,11 +188,12 @@ class THcShowerClusterList : private THcShClusterList {
 
 	for (THcShowerHitIt i=HitList.begin(); i!=HitList.end(); ++i) {
 
-	  for (UInt_t k=0; k!=(*cluster).clSize(); k++) {
+	  for (THcShowerClusterIt k=(*cluster).begin(); k!=(*cluster).end();
+	       k++) {
 
-	    if ((**i).isNeighbour((*cluster).ClusteredHit(k))) {
+	    if ((**i).isNeighbour(*k)) {
 
-	      (*cluster).grow(*i);        //If the hit #i is neighbouring a hit
+	      (*cluster).insert(*i);      //If the hit #i is neighbouring a hit
 	      HitList.erase(i);           //in the cluster, then move it
 	                                  //into the cluster.
 	      clustered = true;
@@ -341,7 +207,7 @@ class THcShowerClusterList : private THcShClusterList {
 
       }                                   //while clustered
 
-      grow(cluster);                      //Put the cluster in the cluster list
+      push_back(cluster);         //Put the cluster in the cluster list
 
     }                                     //While hit_list not exhausted
 
@@ -516,5 +382,17 @@ protected:
 };
 
 ///////////////////////////////////////////////////////////////////////////////
+
+// Auxiliary methods to be used with the hit and cluster containers.
+
+Double_t addE(Double_t x, THcShowerHit* h);
+Double_t addX(Double_t x, THcShowerHit* h);
+Double_t addZ(Double_t x, THcShowerHit* h);
+Double_t addEpr(Double_t x, THcShowerHit* h);
+Double_t clX(THcShowerCluster* cluster);
+Double_t clZ(THcShowerCluster* cluster);
+Double_t clE(THcShowerCluster* cluster);
+Double_t clEpr(THcShowerCluster* cluster);
+Double_t clEplane(THcShowerCluster* cluster, Int_t iplane, Int_t side);
 
 #endif

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -16,7 +16,8 @@
 
 // HMS calorimeter hits, version 2
 
-#include <vector>
+//#include <vector>
+#include <set>
 #include <iterator>
 #include <iostream>
 #include <memory>
@@ -109,10 +110,11 @@ public:
 
 // Container (collection) of hits and its iterator.
 //
-typedef vector<THcShowerHit*> THcShowerHitList;
+//typedef vector<THcShowerHit*> THcShowerHitList;
+typedef set<THcShowerHit*> THcShowerHitList;
 typedef THcShowerHitList::iterator THcShowerHitIt;
 
-
+//____________________________________________________________________________
 
 //HMS calorimeter hit cluster
 //
@@ -128,26 +130,41 @@ class THcShowerCluster : THcShowerHitList {
     for (THcShowerHitIt i = THcShowerHitList::begin();
     	 i != THcShowerHitList::end(); ++i) {
       delete *i;
-      *i = 0;
+      //      *i = 0; does no work with  set<THcShowerHit*> THcShowerHitList
     }
   }
 
   // Add a hit to the cluster hit list
   //
   void grow(THcShowerHit* hit) {
-    THcShowerHitList::push_back(hit);
+    //    THcShowerHitList::push_back(hit);
+    THcShowerHitList::insert(hit);   //<set> version
   }
 
   //Pointer to the hit #i in the cluster hit list
   //
+  //  THcShowerHit* ClusteredHit(UInt_t i) {
+  //    return * (THcShowerHitList::begin()+i);
+  //  }
+
+  //<set> version
   THcShowerHit* ClusteredHit(UInt_t i) {
-    return * (THcShowerHitList::begin()+i);
+    THcShowerHitIt it = THcShowerHitList::begin();
+    for (UInt_t j=0; j<i; j++) it++;
+    return *it;
   }
 
   //Print out a hit in the cluster
   //
+  //  void showHit(UInt_t num) {
+  //    (*(THcShowerHitList::begin()+num))->show();
+  //  }
+
+  //<set> version
   void showHit(UInt_t num) {
-    (*(THcShowerHitList::begin()+num))->show();
+    THcShowerHitIt it = THcShowerHitList::begin();
+    for (UInt_t j=0; j<num; j++) it++;
+    (*it)->show();
   }
 
   // X coordinate of center of gravity of cluster,
@@ -313,8 +330,13 @@ class THcShowerClusterList : private THcShClusterList {
 
       THcShowerCluster* cluster = new THcShowerCluster;
 
-      (*cluster).grow(*(HitList.end()-1)); //Move the last hit from the hit list
-      HitList.erase(HitList.end()-1);      //into the 1st cluster
+      //(*cluster).grow(*(HitList.end()-1)); //Move the last hit from the hit list
+      //HitList.erase(HitList.end()-1);      //into the 1st cluster
+      //<set> version
+      THcShowerHitIt it = HitList.end();
+      (*cluster).grow(*(--it)); //Move the last hit from the hit list
+      HitList.erase(it);        //into the 1st cluster
+
       bool clustered = true;
 
       while (clustered) {                   //Proceed while a hit is clustered

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -91,7 +91,9 @@ public:
   bool isNeighbour(THcShowerHit* hit1) {      //Is hit1 neighbouring this hit?
     Int_t dRow = fRow-(*hit1).fRow;
     Int_t dCol = fCol-(*hit1).fCol;
-    return TMath::Abs(dRow)<2 && TMath::Abs(dCol)<2;
+    //    return TMath::Abs(dRow)<2 && TMath::Abs(dCol)<2;
+    return (TMath::Abs(dRow)<2 && TMath::Abs(dCol)<2) ||
+      (dRow==0 && TMath::Abs(dCol)<3);
   }
 
   //Print out hit information


### PR DESCRIPTION
In THcShower.h header file:
- Replace THcShowerHitList vector container by THcShowerHitSet set container. Define < operator for THcShowerHit class in order to have the THcShowerHitSet container filled in a sorted manner. This should allow for expediting the clustering process.
- Rather than inheriting from the STL container classes, define THcShowerCluster and THcShowerClusterList classes as STL set and vector type containers. Add and modify methods in THcShower.cxx accordingly.
