### PR TITLE
Zafar1

### DIFF
--- a/examples/PARAM/htracking.param
+++ b/examples/PARAM/htracking.param
@@ -96,3 +96,6 @@
 ;  htrack_eff_test_scin_planes is the number of planes nec needed to 
 ;  set sweet spot to true. 4 is extra clean, 3 is good enough for e-'s.
   htrack_eff_test_num_scin_planes = 4
+
+  hcer_npe = 2.0
+  hnormalized_energy_tot = 0.7

--- a/examples/PARAM/stracking.param
+++ b/examples/PARAM/stracking.param
@@ -70,3 +70,6 @@
 ;  strack_eff_test_scin_planes is the number of planes nec needed to 
 ;  set sweet spot to true. 4 is extra clean, 3 is good enough for e-'s.
   strack_eff_test_num_scin_planes = 4
+
+  scer_npe = 2.0
+  snormalized_energy_tot = 0.7

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -460,11 +460,11 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
     {"yloscin",                          &fyLoScin[0],            kInt,     (UInt_t) fNHodoscopes},
     {"yhiscin",                          &fyHiScin[0],            kInt,     (UInt_t) fNHodoscopes},
     {"track_eff_test_num_scin_planes",   &fTrackEffTestNScinPlanes,                 kInt},
-    {"cer_npe",                          &fNCerNPE,                              kDouble},
-    {"normalized_energy_tot",            &fNormETot,                             kDouble},
+    {"cer_npe",                          &fNCerNPE,               kDouble,         0,  1},
+    {"normalized_energy_tot",            &fNormETot,              kDouble,         0,  1},
     {0}
   };
-
+  
   fTofUsingInvAdc = 0;		// Default if not defined
   fTofTolerance = 3.0;		// Default if not defined
   fNCerNPE = 2.0;

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -780,7 +780,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
       std::vector<Double_t> dedx_temp;
       fdEdX.push_back(dedx_temp); // Create array of dedx per hit
       
-      //      Int_t fNfpTime = 0;
+      Int_t fNfpTime = 0;
       Double_t betaChiSq = -3;
       Double_t beta = 0;
       //      fTimeAtFP[itrack] = 0.;

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -555,8 +555,8 @@ Int_t THcHodoscope::DefineVariables( EMode mode )
     {"goodstarttime",  "Hodoscope Good Start Time",                "fGoodStartTime"},
     {"goodscinhit",    "Hit in fid area",                          "fGoodScinHits"},
     {"goodscinhitx",   "Hit in fid x range",                       "fGoodScinHitsX"},
-    {"totscinshould",  "Total scin Hits in fid area",              "fScinShould"},
-    {"totscindid",     "Total scin Hits in fid area with a track", "fScinDid"},
+    {"scinshould",  "Total scin Hits in fid area",                 "fScinShould"},
+    {"scindid",     "Total scin Hits in fid area with a track",    "fScinDid"},
     { 0 }
   };
   return DefineVarsFromList( vars, mode );

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -550,13 +550,13 @@ Int_t THcHodoscope::DefineVariables( EMode mode )
 
   RVarDef vars[] = {
     // Move these into THcHallCSpectrometer using track fTracks
-    {"fpHitsTime",      "Time at focal plane from all hits",       "fFPTime"},
-    {"starttime",       "Hodoscope Start Time",                    "fStartTime"},
-    {"goodstarttime",  "Hodoscope Good Start Time",                "fGoodStartTime"},
-    {"goodscinhit",    "Hit in fid area",                          "fGoodScinHits"},
-    {"goodscinhitx",   "Hit in fid x range",                       "fGoodScinHitsX"},
-    {"scinshould",  "Total scin Hits in fid area",                 "fScinShould"},
-    {"scindid",     "Total scin Hits in fid area with a track",    "fScinDid"},
+    {"fpHitsTime",      "Time at focal plane from all hits",         "fFPTime"},
+    {"starttime",       "Hodoscope Start Time",                      "fStartTime"},
+    {"goodstarttime",   "Hodoscope Good Start Time",                 "fGoodStartTime"},
+    {"goodscinhit",     "Hit in fid area",                           "fGoodScinHits"},
+    {"goodscinhitx",    "Hit in fid x range",                        "fGoodScinHitsX"},
+    {"scinshould",      "Total scin Hits in fid area",               "fScinShould"},
+    {"scindid",         "Total scin Hits in fid area with a track",  "fScinDid"},
     { 0 }
   };
   return DefineVarsFromList( vars, mode );
@@ -757,6 +757,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
 
   Double_t hpartmass=0.00051099; // Fix it
   fGoodScinHits = 0;
+  fScinShould = 0; fScinDid = 0;
 
   if (tracks.GetLast()+1 > 0 ) {
 
@@ -1516,8 +1517,6 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
   }
 
   
-  fScinShould = 0;
-  fScinDid = 0;
   if ( ( fGoodScinHits == 1 ) && ( fShower->GetNormETot() > fNormETot ) &&
        ( fChern->GetCerNPE() > fNCerNPE ) )
     fScinShould = 1;

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -382,9 +382,6 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
   //  Int_t plen=strlen(parname);
   cout << " readdatabse hodo fnplanes = " << fNPlanes << endl;
 
-  fScinShould = 0;
-  fScinDid = 0;
-
   fNPaddle = new UInt_t [fNPlanes];
   fFPTime = new Double_t [fNPlanes];
   fPlaneCenter = new Double_t[fNPlanes];
@@ -470,6 +467,9 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
 
   fTofUsingInvAdc = 0;		// Default if not defined
   fTofTolerance = 3.0;		// Default if not defined
+  fNCerNPE = 2.0;
+  fNormETot = 0.7;
+
   gHcParms->LoadParmValues((DBRequest*)&list,prefix);
 
   cout << " x1 lo = " << fxLoScin[0] 
@@ -612,41 +612,11 @@ void THcHodoscope::DeleteArrays()
   delete [] fHodoPosInvAdcLinear; fHodoPosInvAdcLinear = NULL;
   delete [] fHodoNegInvAdcLinear; fHodoNegInvAdcLinear = NULL;
   delete [] fHodoPosInvAdcAdc;    fHodoPosInvAdcAdc = NULL;
+  delete [] fGoodPlaneTime;       fGoodPlaneTime = NULL;
+  delete [] fNPlaneTime;          fNPlaneTime = NULL;
+  delete [] fSumPlaneTime;        fSumPlaneTime = NULL;
+  delete [] fNScinHits;           fNScinHits = NULL;
 
-  delete [] fGoodPlaneTime;       fGoodPlaneTime = NULL;     // Ahmed
-  delete [] fNPlaneTime;          fNPlaneTime = NULL;        // Ahmed
-  delete [] fSumPlaneTime;        fSumPlaneTime = NULL;      // Ahmed
-
-  delete [] fNScinHits;           fNScinHits = NULL;         // Ahmed
-
-  //  delete [] fSpacing; fSpacing = NULL;
-  //delete [] fCenter;  fCenter = NULL; // This 2D. What is correct way to delete?
-
-  //  delete [] fRA_c;    fRA_c    = NULL;
-  //  delete [] fRA_p;    fRA_p    = NULL;
-  //  delete [] fRA;      fRA      = NULL;
-  //  delete [] fLA_c;    fLA_c    = NULL;
-  //  delete [] fLA_p;    fLA_p    = NULL;
-  //  delete [] fLA;      fLA      = NULL;
-  //  delete [] fRT_c;    fRT_c    = NULL;
-  //  delete [] fRT;      fRT      = NULL;
-  //  delete [] fLT_c;    fLT_c    = NULL;
-  //  delete [] fLT;      fLT      = NULL;
-  
-  //  delete [] fRGain;   fRGain   = NULL;
-  //  delete [] fLGain;   fLGain   = NULL;
-  //  delete [] fRPed;    fRPed    = NULL;
-  //  delete [] fLPed;    fLPed    = NULL;
-  //  delete [] fROff;    fROff    = NULL;
-  //  delete [] fLOff;    fLOff    = NULL;
-  //  delete [] fTWalkPar; fTWalkPar = NULL;
-  //  delete [] fTrigOff; fTrigOff = NULL;
-
-  //  delete [] fHitPad;  fHitPad  = NULL;
-  //  delete [] fTime;    fTime    = NULL;
-  //  delete [] fdTime;   fdTime   = NULL;
-  //  delete [] fYt;      fYt      = NULL;
-  //  delete [] fYa;      fYa      = NULL;
 }
 
 //_____________________________________________________________________________
@@ -1542,17 +1512,19 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
 
 
   if ( !fChern || !fShower ) { 
-    return -1;    
+    return 0;    
   }
 
   
+  fScinShould = 0;
+  fScinDid = 0;
   if ( ( fGoodScinHits == 1 ) && ( fShower->GetNormETot() > fNormETot ) &&
        ( fChern->GetCerNPE() > fNCerNPE ) )
-    fScinShould ++;
+    fScinShould = 1;
   
   if ( ( fGoodScinHits == 1 ) && ( fShower->GetNormETot() > fNormETot ) &&
        ( fChern->GetCerNPE() > fNCerNPE ) && ( tracks.GetLast() + 1 > 0 ) ) {
-      fScinDid ++;
+      fScinDid = 1;
   }
   
   return 0;

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -752,7 +752,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
   Int_t fJMax, fMaxHit;
   Int_t fRawIndex = -1;
   Double_t fScinTrnsCoord, fScinLongCoord, fScinCenter, fSumfpTime, fSlope;
-  Double_t fP, fXcoord, fYcoord, fTMin, fNfpTime, fBestXpScin, fBestYpScin;
+  Double_t fP, fXcoord, fYcoord, fTMin, fBestXpScin, fBestYpScin;
   // -------------------------------------------------
 
   Double_t hpartmass=0.00051099; // Fix it

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -140,27 +140,34 @@ void THcHodoscope::Setup(const char* name, const char* description)
   THcHallCSpectrometer *app = dynamic_cast<THcHallCSpectrometer*>(GetApparatus());
   THaDetector* det = app->GetDetector( shower_detector_name );
 
-  if( !dynamic_cast<THcShower*>(det) ) {
-    Error("THcHodoscope", "Cannot find shower detector %s",
-   	  shower_detector_name );
-    return;
+  if( dynamic_cast<THcShower*>(det) ) {
+    fShower = dynamic_cast<THcShower*>(det);
   }
-
-  fShower = dynamic_cast<THcShower*>(det);
+  else if( !dynamic_cast<THcShower*>(det) ) {
+    cout << "Warining: calorimeter analysis module " 
+	 << shower_detector_name << " not loaded for spectrometer "
+	 << prefix << endl;
+    
+    fShower = NULL;
+  }
+  
   // --------------- To get energy from THcShower ----------------------
 
   // --------------- To get NPEs from THcCherenkov -------------------
   const char* chern_detector_name = "cher";
   THaDetector* detc = app->GetDetector( chern_detector_name );
   
-  if( !dynamic_cast<THcCherenkov*>(detc) ) {
-    Error("THcHodoscope", "Cannot find Cherenkov detector %s",
-	  chern_detector_name );
-    return;
+  if( dynamic_cast<THcCherenkov*>(detc) ) {
+    fChern = dynamic_cast<THcCherenkov*>(detc);  
+  }
+  else if( !dynamic_cast<THcCherenkov*>(detc) ) {
+    cout << "Warining: Cherenkov detector analysis module " 
+	 << chern_detector_name << " not loaded for spectrometer "
+	 << prefix << endl;
+    
+    fChern = NULL;
   }
   
-  //  fChern = static_cast<THcCherenkov*>(detc);
-  fChern = dynamic_cast<THcCherenkov*>(detc);  
   // --------------- To get NPEs from THcCherenkov -------------------
 
   fScinShould = 0;
@@ -432,32 +439,35 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
 
   prefix[1]='\0';
   DBRequest list[]={
-    {"start_time_center",     &fStartTimeCenter,                      kDouble},
-    {"start_time_slop",       &fStartTimeSlop,                        kDouble},
-    {"scin_tdc_to_time",      &fScinTdcToTime,                        kDouble},
-    {"scin_tdc_min",          &fScinTdcMin,                           kDouble},
-    {"scin_tdc_max",          &fScinTdcMax,                           kDouble},
-    {"tof_tolerance",         &fTofTolerance,          kDouble,         0,  1},
-    {"pathlength_central",    &fPathLengthCentral,                    kDouble},
-    {"hodo_vel_light",        &fHodoVelLight[0],       kDouble,  fMaxHodoScin},
-    {"hodo_pos_sigma",        &fHodoPosSigma[0],       kDouble,  fMaxHodoScin},
-    {"hodo_neg_sigma",        &fHodoNegSigma[0],       kDouble,  fMaxHodoScin},
-    {"hodo_pos_minph",        &fHodoPosMinPh[0],       kDouble,  fMaxHodoScin},
-    {"hodo_neg_minph",        &fHodoNegMinPh[0],       kDouble,  fMaxHodoScin},
-    {"hodo_pos_phc_coeff",    &fHodoPosPhcCoeff[0],    kDouble,  fMaxHodoScin},
-    {"hodo_neg_phc_coeff",    &fHodoNegPhcCoeff[0],    kDouble,  fMaxHodoScin},
-    {"hodo_pos_time_offset",  &fHodoPosTimeOffset[0],  kDouble,  fMaxHodoScin},
-    {"hodo_neg_time_offset",  &fHodoNegTimeOffset[0],  kDouble,  fMaxHodoScin},
-    {"hodo_pos_ped_limit",    &fHodoPosPedLimit[0],    kInt,     fMaxHodoScin},
-    {"hodo_neg_ped_limit",    &fHodoNegPedLimit[0],    kInt,     fMaxHodoScin},
-    {"tofusinginvadc",        &fTofUsingInvAdc,        kInt,            0,  1},
-    {"xloscin",               &fxLoScin[0],            kInt,     (UInt_t) fNHodoscopes},
-    {"xhiscin",               &fxHiScin[0],            kInt,     (UInt_t) fNHodoscopes},
-    {"yloscin",               &fyLoScin[0],            kInt,     (UInt_t) fNHodoscopes},
-    {"yhiscin",               &fyHiScin[0],            kInt,     (UInt_t) fNHodoscopes},
-    {"track_eff_test_num_scin_planes",   &fTrackEffTestNScinPlanes,      kInt},
+    {"start_time_center",                &fStartTimeCenter,                      kDouble},
+    {"start_time_slop",                  &fStartTimeSlop,                        kDouble},
+    {"scin_tdc_to_time",                 &fScinTdcToTime,                        kDouble},
+    {"scin_tdc_min",                     &fScinTdcMin,                           kDouble},
+    {"scin_tdc_max",                     &fScinTdcMax,                           kDouble},
+    {"tof_tolerance",                    &fTofTolerance,          kDouble,         0,  1},
+    {"pathlength_central",               &fPathLengthCentral,                    kDouble},
+    {"hodo_vel_light",                   &fHodoVelLight[0],       kDouble,  fMaxHodoScin},
+    {"hodo_pos_sigma",                   &fHodoPosSigma[0],       kDouble,  fMaxHodoScin},
+    {"hodo_neg_sigma",                   &fHodoNegSigma[0],       kDouble,  fMaxHodoScin},
+    {"hodo_pos_minph",                   &fHodoPosMinPh[0],       kDouble,  fMaxHodoScin},
+    {"hodo_neg_minph",                   &fHodoNegMinPh[0],       kDouble,  fMaxHodoScin},
+    {"hodo_pos_phc_coeff",               &fHodoPosPhcCoeff[0],    kDouble,  fMaxHodoScin},
+    {"hodo_neg_phc_coeff",               &fHodoNegPhcCoeff[0],    kDouble,  fMaxHodoScin},
+    {"hodo_pos_time_offset",             &fHodoPosTimeOffset[0],  kDouble,  fMaxHodoScin},
+    {"hodo_neg_time_offset",             &fHodoNegTimeOffset[0],  kDouble,  fMaxHodoScin},
+    {"hodo_pos_ped_limit",               &fHodoPosPedLimit[0],    kInt,     fMaxHodoScin},
+    {"hodo_neg_ped_limit",               &fHodoNegPedLimit[0],    kInt,     fMaxHodoScin},
+    {"tofusinginvadc",                   &fTofUsingInvAdc,        kInt,            0,  1},       
+    {"xloscin",                          &fxLoScin[0],            kInt,     (UInt_t) fNHodoscopes},
+    {"xhiscin",                          &fxHiScin[0],            kInt,     (UInt_t) fNHodoscopes},
+    {"yloscin",                          &fyLoScin[0],            kInt,     (UInt_t) fNHodoscopes},
+    {"yhiscin",                          &fyHiScin[0],            kInt,     (UInt_t) fNHodoscopes},
+    {"track_eff_test_num_scin_planes",   &fTrackEffTestNScinPlanes,                 kInt},
+    {"cer_npe",                          &fNCerNPE,                              kDouble},
+    {"normalized_energy_tot",            &fNormETot,                             kDouble},
     {0}
   };
+
   fTofUsingInvAdc = 0;		// Default if not defined
   fTofTolerance = 3.0;		// Default if not defined
   gHcParms->LoadParmValues((DBRequest*)&list,prefix);
@@ -474,8 +484,10 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
        << " y2 hi = " << fyHiScin[1] 
        << endl;
 
-  cout << "Hdososcope planes hits for trigger = " 
-       << fTrackEffTestNScinPlanes << endl;
+  cout << "Hdososcope planes hits for trigger = " << fTrackEffTestNScinPlanes 
+       << " normalized energy min = " << fNormETot
+       << " number of photo electrons = " << fNCerNPE
+       << endl;
 
   if (fTofUsingInvAdc) {
     DBRequest list2[]={
@@ -1529,15 +1541,19 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
   }
 
 
-  if ( ( fGoodScinHits == 1 ) && ( fShower->GetNormETot() > 0.7 ) &&
-       ( fChern->GetCerNPE() > 2.0 ) )
-    fScinShould ++;
-  
-  if ( ( fGoodScinHits == 1 ) && ( fShower->GetNormETot() > 0.7 ) &&
-       ( fChern->GetCerNPE() > 2.0 ) && ( tracks.GetLast() + 1 > 0 ) ) {
-    fScinDid ++;
+  if ( !fChern || !fShower ) { 
+    return -1;    
   }
 
+  
+  if ( ( fGoodScinHits == 1 ) && ( fShower->GetNormETot() > fNormETot ) &&
+       ( fChern->GetCerNPE() > fNCerNPE ) )
+    fScinShould ++;
+  
+  if ( ( fGoodScinHits == 1 ) && ( fShower->GetNormETot() > fNormETot ) &&
+       ( fChern->GetCerNPE() > fNCerNPE ) && ( tracks.GetLast() + 1 > 0 ) ) {
+      fScinDid ++;
+  }
   
   return 0;
   

--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -145,7 +145,6 @@ protected:
   THcShower* fShower;
   THcCherenkov* fChern;
 
-  Int_t        fGood_hits;
 
   Int_t        fCheckEvent;
   Int_t        fEventType;
@@ -167,6 +166,8 @@ protected:
   Double_t*    fPlaneCenter;
   Double_t*    fPlaneSpacing;
 
+  Double_t     fNormETot;
+  Double_t     fNCerNPE;
   Int_t        fTestSum;
   Int_t        fTrackEffTestNScinPlanes;
   Int_t        fGoodScinHits;


### PR DESCRIPTION
Loop up of Shower and Cherenkov in THcHodoscope::Setup
If calorimeter and cherenkov is not added to SOS or HMS then it prints a warning message and does not calcualte the efficiency for that spectrometer.

Minimm value of normalized energy and minum value of number of cherenkov photo electrons is added to parameter files for the calculation of tracking efficiency.

NCerNPE and fNormETot be optional parameters When there is not the  !fChern || !fShower and instead just
not increment the counter. cer_npe and normalized_energy_tot are optional 

Changed the name of two global varialble of hodoscope