### PR TITLE
Modifications in the THcShower class.

### DIFF
--- a/examples/PARAM/hcana.param
+++ b/examples/PARAM/hcana.param
@@ -51,11 +51,10 @@ scal_num_layers = 4
 scal_fv_delta = 5.
 
 # Constants for the coordiante correction of the calorimeter energy depositions
-# (saw) Copied from HMS
-scal_a_cor = 200.
-scal_b_cor = 8000.
-scal_c_cor = 64.36
-scal_d_cor = 1.66
+scal_a_cor = 400.
+scal_b_cor = 12000.
+scal_c_cor = -87.1628, -100.	# The positive side constants reproduce
+scal_d_cor =  1.65054,    3.	# correction in Engine to accuracy better 0.005.
 
 scal_layer_names = "1pr 2ta 3ta 4ta"
 

--- a/examples/PARAM/hcana.param
+++ b/examples/PARAM/hcana.param
@@ -16,8 +16,8 @@ hcal_fv_delta = 5.
 # Constants for the coordiante correction of the calorimeter energy depositions
 hcal_a_cor = 200.
 hcal_b_cor = 8000.
-hcal_c_cor = 64.36
-hcal_d_cor = 1.66
+hcal_c_cor = 64.36, 64.36	# for positive and negative sides
+hcal_d_cor =  1.66,  1.66
 
 hcal_layer_names = "1pr 2ta 3ta 4ta"
 

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -214,8 +214,8 @@ Int_t THcShower::ReadDatabase( const TDatime& date )
     DBRequest list[]={
       {"cal_a_cor", &fAcor, kDouble},
       {"cal_b_cor", &fBcor, kDouble},
-      {"cal_c_cor", &fCcor, kDouble},
-      {"cal_d_cor", &fDcor, kDouble},
+      {"cal_c_cor", fCcor, kDouble, 2},
+      {"cal_d_cor", fDcor, kDouble, 2},
       {0}
     };
     gHcParms->LoadParmValues((DBRequest*)&list, prefix);
@@ -226,8 +226,8 @@ Int_t THcShower::ReadDatabase( const TDatime& date )
     cout << "  HMS Calorimeter coordinate correction constants:" << endl;
     cout << "    fAcor = " << fAcor << endl;
     cout << "    fBcor = " << fBcor << endl;
-    cout << "    fCcor = " << fCcor << endl;
-    cout << "    fDcor = " << fDcor << endl;
+    cout << "    fCcor = " << fCcor[0] << ", " << fCcor[1] << endl;
+    cout << "    fDcor = " << fDcor[0] << ", " << fDcor[1] << endl;
   }
 
   BlockThick = new Double_t [fNLayers];
@@ -950,8 +950,8 @@ Float_t THcShower::GetShEnergy(THaTrack* Track) {
     for (UInt_t ip=0; ip<fNLayers; ip++) {
 
       // Coordinate correction factors for positive and negative sides,
-      // different for single PMT counters in the 1-st two layes and for
-      // 2 PMT counters in the rear two layers.
+      // different for double PMT counters in the 1-st two layes and for
+      // single PMT counters in the rear two layers.
       Float_t corpos = 1.;   
       Float_t corneg = 1.;
       if (ip < fNegCols) {

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -96,7 +96,9 @@ void THcShower::Setup(const char* name, const char* description)
   delete [] desc;
 
   cout << "---------------------------------------------------------------\n";
-  cout << "From THcShower::Setup: created Shower planes ";
+  cout << "From THcShower::Setup: created Shower planes for "
+       << GetApparatus()->GetName() << ": ";
+
   for(UInt_t i=0;i < fNLayers;i++) {
     cout << fLayerNames[i];
     i < fNLayers-1 ? cout << ", " : cout << ".\n";
@@ -138,7 +140,8 @@ THaAnalysisObject::EStatus THcShower::Init( const TDatime& date )
 
 
   cout << "---------------------------------------------------------------\n";
-  cout << "From THcShower::Init: initialized " << GetName() << endl;
+  cout << "From THcShower::Init: initialized " << GetApparatus()->GetName()
+       <<  GetName() << endl;
   cout << "---------------------------------------------------------------\n";
 
   return fStatus = kOK;
@@ -196,7 +199,8 @@ Int_t THcShower::ReadDatabase( const TDatime& date )
   // Debug output.
   if (fdbg_init_cal) {
     cout << "---------------------------------------------------------------\n";
-    cout << "Debug output from THcShower::ReadDatabase\n";
+    cout << "Debug output from THcShower::ReadDatabase for "
+	 << GetApparatus()->GetName() << endl;
 
     cout << "  Number of neg. columns      = " << fNegCols << endl;
     cout << "  Slop parameter              = " << fSlop << endl;
@@ -223,7 +227,7 @@ Int_t THcShower::ReadDatabase( const TDatime& date )
 
   // Debug output.
   if (fdbg_init_cal) {
-    cout << "  HMS Calorimeter coordinate correction constants:" << endl;
+    cout << "  Coordinate correction constants:\n";
     cout << "    fAcor = " << fAcor << endl;
     cout << "    fBcor = " << fBcor << endl;
     cout << "    fCcor = " << fCcor[0] << ", " << fCcor[1] << endl;
@@ -625,7 +629,9 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
 
   if (fdbg_clusters_cal) {
     cout << "---------------------------------------------------------------\n";
-    cout << "Debug output from THcShower::CoarseProcess\n";
+    cout << "Debug output from THcShower::CoarseProcess for "
+	 << GetApparatus()->GetName() << endl;
+
     cout << "  List of unclustered hits. Total hits:     " << fNhits << endl;
     THcShowerHitIt it = HitSet.begin();    //<set> version
     for (Int_t i=0; i!=fNhits; i++) {
@@ -897,7 +903,8 @@ Int_t THcShower::MatchCluster(THaTrack* Track,
 
   if (fdbg_tracks_cal) {
     cout << "---------------------------------------------------------------\n";
-    cout << "Debug output from THcShower::MatchCluster\n";
+    cout << "Debug output from THcShower::MatchCluster for "
+	 << GetApparatus()->GetName() << endl;
 
     cout << "  Track at DC:"
 	 << "  X = " << Track->GetX()
@@ -974,7 +981,8 @@ Float_t THcShower::GetShEnergy(THaTrack* Track) {
 
   if (fdbg_tracks_cal) {
     cout << "---------------------------------------------------------------\n";
-    cout << "Debug output from THcShower::GetShEnergy\n";
+    cout << "Debug output from THcShower::GetShEnergy for "
+	 << GetApparatus()->GetName() << endl;
 
     cout << "  Track at the calorimeter: X = " << Xtr << "  Y = " << Ytr;
     if (mclust >= 0)
@@ -1011,7 +1019,8 @@ Int_t THcShower::FineProcess( TClonesArray& tracks )
 
   if (fdbg_tracks_cal) {
     cout << "---------------------------------------------------------------\n";
-    cout << "Debug output from THcShower::FineProcess\n";
+    cout << "Debug output from THcShower::FineProcess for "
+	 << GetApparatus()->GetName() << endl;
 
     cout << "  Number of tracks = " << Ntracks << endl;
 

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -215,7 +215,8 @@ public:
       return 0.;
     }
     Int_t sign = 1 - 2*side;
-    return (fCcor + sign*y)/(fCcor + sign*y/fDcor);
+    //    return (fCcor + sign*y)/(fCcor + sign*y/fDcor);
+    return (fCcor[side] + sign*y)/(fCcor[side] + sign*y/fDcor[side]);
   }
 
   // Get total energy deposited in the cluster matched to the given
@@ -282,8 +283,8 @@ protected:
 
   Double_t fAcor;               // Coordinate correction constants
   Double_t fBcor;
-  Double_t fCcor;
-  Double_t fDcor;
+  Double_t fCcor[2];            // for positive ad negative side PMTs
+  Double_t fDcor[2];
 
   THcShowerPlane** fPlanes;     // [fNLayers] Shower Plane objects
 

--- a/src/THcShowerPlane.cxx
+++ b/src/THcShowerPlane.cxx
@@ -151,7 +151,8 @@ Int_t THcShowerPlane::ReadDatabase( const TDatime& date )
 
   if (fParent->fdbg_init_cal) {
     cout << "---------------------------------------------------------------\n";
-    cout << "Debug output from THcShowerPlane::ReadDatabase\n";
+    cout << "Debug output from THcShowerPlane::ReadDatabase for "
+	 << GetApparatus()->GetName() << ":" << endl;
 
     cout << "  Layer #" << fLayerNum << ", number of elements " << fNelem
 	 << endl;
@@ -211,7 +212,9 @@ void THcShowerPlane::Clear( Option_t* )
   // Debug output.
   if ( ((THcShower*) GetParent())->fdbg_decoded_cal ) {
     cout << "---------------------------------------------------------------\n";
-    cout << "Debug output from THcShowerPlane::Clear\n";
+    cout << "Debug output from THcShowerPlane::Clear for "
+	 << GetApparatus()->GetName() << ":" << endl;
+
     cout << " Cleared ADC hits for plane " << GetName() << endl;
     cout << "---------------------------------------------------------------\n";
   }
@@ -225,7 +228,9 @@ Int_t THcShowerPlane::Decode( const THaEvData& evdata )
   //Debug output.
   if ( ((THcShower*) GetParent())->fdbg_decoded_cal ) {
     cout << "---------------------------------------------------------------\n";
-    cout << "Debug output from THcShowerPlane::Decode\n";
+    cout << "Debug output from THcShowerPlane::Decode for "
+	 << GetApparatus()->GetName() << ":" << endl;
+
     cout << " Called for plane " << GetName() << endl;
     cout << "---------------------------------------------------------------\n";
   }
@@ -350,7 +355,9 @@ Int_t THcShowerPlane::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
   if (fParent->fdbg_decoded_cal) {
 
     cout << "---------------------------------------------------------------\n";
-    cout << "Debug output from THcShowerPlane::ProcessHits\n";
+    cout << "Debug output from THcShowerPlane::ProcessHits for "
+	 << GetApparatus()->GetName() << ":" << endl;
+
     cout << "  nrawhits =  " << nrawhits << "  nexthit =  " << nexthit << endl;
     cout << "  Sparsified hits for HMS calorimeter plane #" << fLayerNum
 	 << ", " << GetName() << ":" << endl;
@@ -434,7 +441,9 @@ Int_t THcShowerPlane::AccumulatePedestals(TClonesArray* rawhits, Int_t nexthit)
   if ( ((THcShower*) GetParent())->fdbg_raw_cal ) {
 
     cout << "---------------------------------------------------------------\n";
-    cout << "Debug output from THcShowerPlane::AcculatePedestals\n";
+    cout << "Debug output from THcShowerPlane::AcculatePedestals for "
+	 << GetApparatus()->GetName() << ":" << endl;
+
     cout << "Processed hit list for plane " << GetName() << ":\n";
 
     for (Int_t ih=nexthit; ih<nrawhits; ih++) {
@@ -488,8 +497,10 @@ void THcShowerPlane::CalculatePedestals( )
   if ( ((THcShower*) GetParent())->fdbg_raw_cal ) {
 
     cout << "---------------------------------------------------------------\n";
-    cout << "Debug output from THcShowerPlane::CalculatePedestals\n";
-    cout << "  ADC pedestals and thresholds for HMS calorimeter plane "
+    cout << "Debug output from THcShowerPlane::CalculatePedestals for"
+	 << GetApparatus()->GetName() << ":" << endl;
+
+    cout << "  ADC pedestals and thresholds for calorimeter plane "
 	 << GetName() << endl;
     for(Int_t i=0; i<fNelem;i++) {
       cout << "  element " << i << ": "

--- a/src/THcShowerPlane.cxx
+++ b/src/THcShowerPlane.cxx
@@ -37,8 +37,8 @@ THcShowerPlane::THcShowerPlane( const char* name,
   : THaSubDetector(name,description,parent)
 {
   // Normal constructor with name and description
-  fPosADCHits = new TClonesArray("THcSignalHit",13);
-  fNegADCHits = new TClonesArray("THcSignalHit",13);
+  fPosADCHits = new TClonesArray("THcSignalHit",fNelem);
+  fNegADCHits = new TClonesArray("THcSignalHit",fNelem);
 
   //#if ROOT_VERSION_CODE < ROOT_VERSION(5,32,0)
   //  fPosADCHitsClass = fPosADCHits->GetClass();


### PR DESCRIPTION
Use separate constants for coordinate correction of the positive and negative side PMT signals from the HMS and SOS calorimeters. Define size of arrays of ADC hits of the Shower planes equal to number of blocks in the plane, rather than constant. Modify debug outputs in the THcShower class to indicate spectrometers.
