### PR TITLE
Fix problem in THcScintillatorPlane.cxx and add debug statement used in THcHodoscope.cxx

### DIFF
--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -459,9 +459,10 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
     {"cer_npe",                          &fNCerNPE,               kDouble,         0,  1},
     {"normalized_energy_tot",            &fNormETot,              kDouble,         0,  1},
     {"hodo_slop",                        fHodoSlop,               kDouble,  fNPlanes},
+    {"debugprintscinraw",                &fdebugprintscinraw,               kInt,  0,1},
     {0}
   };
-  
+  fdebugprintscinraw=0;
   fTofUsingInvAdc = 0;		// Default if not defined
   fTofTolerance = 3.0;		// Default if not defined
   fNCerNPE = 2.0;
@@ -687,14 +688,12 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
     // GN: select only events that have reasonable TDC values to start with
     // as per the Engine h_strip_scin.f
     nexthit = fPlanes[ip]->ProcessHits(fRawHitList,nexthit);
-    if (fPlanes[ip]->GetNScinHits()>0) {
+     if (fPlanes[ip]->GetNScinHits()>0) {
       fPlanes[ip]->PulseHeightCorrection();
       // GN: allow for more than one fptime per plane!!
       for (Int_t i=0;i<fPlanes[ip]->GetNScinGoodHits();i++) {
 	if (TMath::Abs(fPlanes[ip]->GetFpTime(i)-fStartTimeCenter)<=fStartTimeSlop) {
 	  fStartTime=fStartTime+fPlanes[ip]->GetFpTime(i);
-	  // GN write stuff out so I can compare with engine
-	  ///	  cout<<"hcana event= "<<evdata.GetEvNum()<<" fNfptimes= "<<fNfptimes<<" fptime= "<<fPlanes[ip]->GetFpTime(i)<<endl;
 	  fNfptimes++;
 	}
       }
@@ -707,15 +706,15 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
     fGoodStartTime=kFALSE;
     fStartTime=fStartTimeCenter;
   }
-#if 0
-  for(Int_t ihit = 0; ihit < fNRawHits ; ihit++) {
+  if (fdebugprintscinraw == 1) {
+  for(UInt_t ihit = 0; ihit < fNRawHits ; ihit++) {
     THcRawHodoHit* hit = (THcRawHodoHit *) fRawHitList->At(ihit);
     cout << ihit << " : " << hit->fPlane << ":" << hit->fCounter << " : "
 	 << hit->fADC_pos << " " << hit->fADC_neg << " "  <<  hit->fTDC_pos
 	 << " " <<  hit->fTDC_neg << endl;
   }
   cout << endl;
-#endif
+  }
   ///  fStartTime = 500;		// Drift Chamber will need this
 
   return nhits;
@@ -921,7 +920,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
 	  }
 	}
 	
-	if ( jmax > 0 ){ // Line 248. Here I followed the code of THcSCintilaltorPlane::PulseHeightCorrection
+
 	  Double_t tmin = 0.5 * jmax;
 	  for(Int_t iphit = 0; iphit < fNScinHits[ip]; iphit++) { // Loop over sinc. hits. in plane
 	    if ( ( fTOFPInfo[iphit].time_pos > tmin ) && ( fTOFPInfo[iphit].time_pos < ( tmin + fTofTolerance ) ) ) {
@@ -931,7 +930,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
 	      fTOFPInfo[iphit].keep_neg=kTRUE;
 	    }	
 	  }
-	} // jmax > 0 condition
+
 	
 	//---------------------------------------------------------------------------------------------	
 	// ---------------------- Scond loop over scint. hits in a plane ------------------------------

--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -169,6 +169,7 @@ protected:
   Double_t     fNormETot;
   Double_t     fNCerNPE;
   Double_t*    fHodoSlop;
+  Int_t        fdebugprintscinraw;
   Int_t        fTestSum;
   Int_t        fTrackEffTestNScinPlanes;
   Int_t        fGoodScinHits;

--- a/src/THcRawHodoHit.h
+++ b/src/THcRawHodoHit.h
@@ -7,6 +7,7 @@ class THcRawHodoHit : public THcRawHit {
 
  public:
   friend class THcScintillatorPlane;
+  friend class THcHodoscope;
 
   THcRawHodoHit(Int_t plane=0, Int_t counter=0) : THcRawHit(plane, counter), 
     fADC_pos(-1), fADC_neg(-1),

--- a/src/THcScintillatorPlane.cxx
+++ b/src/THcScintillatorPlane.cxx
@@ -246,6 +246,8 @@ Int_t THcScintillatorPlane::FineProcess( TClonesArray& tracks )
 {
   return 0;
 }
+
+
 //_____________________________________________________________________________
 Int_t THcScintillatorPlane::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
 {
@@ -397,15 +399,6 @@ Int_t THcScintillatorPlane::PulseHeightCorrection()
 	    TMath::Sqrt(TMath::Max(0.,(neg_ph[i]/((THcHodoscope *)GetParent())->GetHodoNegMinPh(index)-1)));
 	  negtime[i]=negtime[i]-((THcHodoscope *)GetParent())->GetHodoNegTimeOffset(index);
 
-	  // ***************
-	  ///	  cout <<"hcana i = "<<i<<endl;
-	  ///  cout <<"hcana tdc_pos = "<<((THcSignalHit*) fPosTDCHits->At(i))->GetData()<<endl;
-	  ///cout <<"hcana pos_ph = "<<pos_ph[i]<<endl;
-	  //	  cout <<"hcana pos_phc_coeff = "<<((THcHodoscope *)GetParent())->GetHodoPosPhcCoeff(index)<<endl;
-	  //	  cout <<"hcana postime = "<<postime[i]<<endl;
-	  //cout <<"hcana negtime = "<<negtime[i]<<endl;
-	  //*************
-
 	  // Find hit position.  If postime larger, then hit was nearer negative side.
 	  dist_from_center=0.5*(negtime[i]-postime[i])*((THcHodoscope *)GetParent())->GetHodoVelLight(index);
 	  scint_center=0.5*(fPosLeft+fPosRight);
@@ -435,10 +428,12 @@ Int_t THcScintillatorPlane::PulseHeightCorrection()
   maxhit=0;
   for (i=0;i<200;i++) {
     if (timehist[i]>maxhit) {
-      jmax=i;
+       jmax=i;
       maxhit=timehist[i];
+      //     cout << " i = " << i << " " << jmax << " " << timehist[i] << endl; 
     }
   }
+  // cout << " jmax = " << jmax << " " << maxhit << endl;
   // Resume regular tof code, now using time filer(?) from above
   // Check for TWO good TDC hits
   for (i=0;i<fNScinHits;i++) {
@@ -446,12 +441,10 @@ Int_t THcScintillatorPlane::PulseHeightCorrection()
 	(((THcSignalHit*) fPosTDCHits->At(i))->GetData()<=maxtdc) &&
 	(((THcSignalHit*) fNegTDCHits->At(i))->GetData()>=mintdc) &&
 	(((THcSignalHit*) fNegTDCHits->At(i))->GetData()<=maxtdc)) {
-      if(jmax>0) {
 	Double_t tmin = 0.5*jmax;
 	if ((time_pos[i]>tmin) && (time_pos[i]<tmin+toftolerance) &&
 	    (time_neg[i]>tmin) && (time_neg[i]<tmin+toftolerance))
 	  two_good_times[i]=kTRUE;
-      }
     }
   } // end of loop that finds tube setting time
   for (i=0;i<fNScinHits;i++) {


### PR DESCRIPTION
In THcScintillatorPlane.cxx in the ProcessHits method 
eliminate IF statement on jmax>0 when determining two_good_times
When totolerance is large then jmax can legitimately equal zero
since in effect there is one bin in the histogram.
No reason for the if statement
In THcHodoScope FineProcess did the same fix for jmax
Also in THcHodoScope add fdebugprintscinraw variable for hdebugprintscinraw to debug
raw hodoscope info.
