### PR TITLE
Raw hit lists limits

### DIFF
--- a/src/THcRawDCHit.cxx
+++ b/src/THcRawDCHit.cxx
@@ -1,17 +1,19 @@
 /** \class  THcRawDCHit
     \ingroup DetSupport
 
- Class representing for drift chamber wire (or other device with      
-   a single multihit TDC channel per detector element                 
+ Class representing for drift chamber wire (or other device with
+   a single multihit TDC channel per detector element
 
 */
 
 #include "THcRawDCHit.h"
+#include <stdexcept>
 
 using namespace std;
 
 
 void THcRawDCHit::SetData(Int_t signal, Int_t data) {
+  if (fNHits >= fMaxNSamplesTDC) {throw std::runtime_error("Too many samples for `THcRawDCHit` TDC!");}
   fTDC[fNHits++] = data;
 }
 
@@ -114,4 +116,3 @@ THcRawDCHit& THcRawDCHit::operator=( const THcRawDCHit& rhs )
 
 //////////////////////////////////////////////////////////////////////////
 ClassImp(THcRawDCHit)
-

--- a/src/THcRawDCHit.h
+++ b/src/THcRawDCHit.h
@@ -3,15 +3,13 @@
 
 #include "THcRawHit.h"
 
-#define MAXHITS 16
-
 class THcRawDCHit : public THcRawHit {
 
 public:
   friend class THcDriftChamberPlane;
   friend class THcDC;
 
-  THcRawDCHit(Int_t plane=0, Int_t counter=0) : THcRawHit(plane, counter), 
+  THcRawDCHit(Int_t plane=0, Int_t counter=0) : THcRawHit(plane, counter),
     fNHits(0), fHasRef{kFALSE} {
   }
   THcRawDCHit& operator=( const THcRawDCHit& );
@@ -31,16 +29,18 @@ public:
   virtual Bool_t  IsSortable () const {return kTRUE; }
   virtual Int_t   Compare(const TObject* obj) const;
 
+  UInt_t GetMaxNSamplesTDC() {return fMaxNSamplesTDC;}
 
 protected:
+  static const UInt_t fMaxNSamplesTDC = 16;
   UInt_t fNHits;
-  Int_t fTDC[MAXHITS];
+  Int_t fTDC[fMaxNSamplesTDC];
   Int_t fReferenceTime;
   Int_t fHasRef;
 
 private:
 
   ClassDef(THcRawDCHit, 0);	// Raw Drift Chamber hit
-};  
+};
 
 #endif

--- a/src/THcRawHodoHit.cxx
+++ b/src/THcRawHodoHit.cxx
@@ -3,10 +3,10 @@
 
 Raw Hodoscope Hit Info
 
-Class representing a single raw hit for a hodoscope paddle  
-                                                            
- Contains plane, counter and pos/neg adc and tdc values   
-                                                          
+Class representing a single raw hit for a hodoscope paddle
+
+ Contains plane, counter and pos/neg adc and tdc values
+
 
 */
 
@@ -15,6 +15,7 @@ Class representing a single raw hit for a hodoscope paddle
 #include <cstdlib>
 #include <iostream>
 #include <cassert>
+#include <stdexcept>
 
 #include "THcRawHodoHit.h"
 
@@ -22,12 +23,16 @@ using namespace std;
 
 void THcRawHodoHit::SetData(Int_t signal, Int_t data) {
   if(signal==0) {
+    if (fNRawHits[0] >= fMaxNSamplesADC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` ADC+!");}
     fADC_pos[fNRawHits[0]++] = data;
   } else if (signal==1) {
+    if (fNRawHits[1] >= fMaxNSamplesADC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` ADC-!");}
     fADC_neg[fNRawHits[1]++] = data;
   } else if(signal==2) {
+    if (fNRawHits[2] >= fMaxNSamplesTDC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` TDC+!");}
     fTDC_pos[fNRawHits[2]++] = data;
   } else if (signal==3) {
+    if (fNRawHits[3] >= fMaxNSamplesTDC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` TDC-!");}
     fTDC_neg[fNRawHits[3]++] = data;
   }
 }
@@ -56,7 +61,7 @@ Int_t THcRawHodoHit::GetData(Int_t signal, UInt_t ihit) {
     return(-1);			// Actually should throw an exception
   }
   // We are return -1 as a error, but reference subtracted
-  // time can be negative.  
+  // time can be negative.
   if(fHasRef[signal]) {
     value -= fReferenceTime[signal];
   }
@@ -137,4 +142,3 @@ THcRawHodoHit& THcRawHodoHit::operator=( const THcRawHodoHit& rhs )
 
 //////////////////////////////////////////////////////////////////////////
 ClassImp(THcRawHodoHit)
-

--- a/src/THcRawHodoHit.h
+++ b/src/THcRawHodoHit.h
@@ -3,8 +3,6 @@
 
 #include "THcRawHit.h"
 
-#define MAXHITS 16
-
 class THcRawHodoHit : public THcRawHit {
 
  public:
@@ -35,22 +33,26 @@ class THcRawHodoHit : public THcRawHit {
   Int_t GetRawData(Int_t signal, UInt_t ihit);
   Int_t GetReference(Int_t signal);
   Bool_t HasReference(Int_t signal);
-  
+
   //  virtual Bool_t  IsSortable () const {return kTRUE; }
   //  virtual Int_t   Compare(const TObject* obj) const;
+  UInt_t GetMaxNSamplesADC() {return fMaxNSamplesADC;}
   Int_t GetADCPos() {return GetData(0, 0);}
   Int_t GetADCNeg() {return GetData(1, 0);}
   Int_t GetTDCPos() {return GetData(2, 0);}
   Int_t GetTDCNeg() {return GetData(3, 0);}
 
+  UInt_t GetMaxNSamplesTDC() {return fMaxNSamplesTDC;}
   Int_t GetTDCPos(UInt_t ihit) {return GetData(2, ihit);}
   Int_t GetTDCNeg(UInt_t ihit) {return GetData(3, ihit);}
 
  protected:
-  Int_t fADC_pos[MAXHITS];
-  Int_t fADC_neg[MAXHITS];
-  Int_t fTDC_pos[MAXHITS];
-  Int_t fTDC_neg[MAXHITS];
+  static const UInt_t fMaxNSamplesADC = 160;
+  static const UInt_t fMaxNSamplesTDC = 16;
+  Int_t fADC_pos[fMaxNSamplesADC];
+  Int_t fADC_neg[fMaxNSamplesADC];
+  Int_t fTDC_pos[fMaxNSamplesTDC];
+  Int_t fTDC_neg[fMaxNSamplesTDC];
   Int_t fReferenceTime[4];
   Bool_t fHasRef[4];
   UInt_t fNRawHits[4];
@@ -58,6 +60,6 @@ class THcRawHodoHit : public THcRawHit {
  private:
 
   ClassDef(THcRawHodoHit, 0);	// Raw Hodoscope hit
-};  
+};
 
 #endif


### PR DESCRIPTION
- Moved defined hit number limits to member variables.
- Added range checks when adding data to hits. Now an error is thrown instead of potentially getting core dump.