### PR TITLE
Unified filling of the gHcDetectorMap for all detector classes.

### DIFF
--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -150,13 +150,12 @@ THaAnalysisObject::EStatus THcAerogel::Init( const TDatime& date )
   if( (status = THaNonTrackingDetector::Init( date )) )
     return fStatus=status;
 
-  // Will need to determine which apparatus it belongs to and use the
-  // appropriate detector ID in the FillMap call
-  if( gHcDetectorMap->FillMap(fDetMap, "HAERO") < 0 ) {
+  char EngineDID[] = "xAERO";
+  EngineDID[0] = toupper(GetApparatus()->GetName()[0]);
+  if( gHcDetectorMap->FillMap(fDetMap, EngineDID) < 0 ) {
     static const char* const here = "Init()";
-    Error( Here(here), "Error filling detectormap for %s.", 
-	     "HAERO");
-      return kInitError;
+    Error( Here(here), "Error filling detectormap for %s.", EngineDID );
+    return kInitError;
   }
 
   return fStatus = kOK;

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -123,12 +123,12 @@ THaAnalysisObject::EStatus THcCherenkov::Init( const TDatime& date )
   if( (status = THaNonTrackingDetector::Init( date )) )
     return fStatus=status;
 
-  // Will need to determine which apparatus it belongs to and use the
-  // appropriate detector ID in the FillMap call
-  if( gHcDetectorMap->FillMap(fDetMap, "HCER") < 0 ) {
-    Error( Here(here), "Error filling detectormap for %s.", 
-	     "HCER");
-      return kInitError;
+  char EngineDID[] = "xCER";
+  EngineDID[0] = toupper(GetApparatus()->GetName()[0]);
+  if( gHcDetectorMap->FillMap(fDetMap, EngineDID) < 0 ) {
+    static const char* const here = "Init()";
+    Error( Here(here), "Error filling detectormap for %s.", EngineDID );
+    return kInitError;
   }
 
   return fStatus = kOK;

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -217,20 +217,12 @@ THaAnalysisObject::EStatus THcDC::Init( const TDatime& date )
   //  };
   //  memcpy( fDataDest, tmp, NDEST*sizeof(DataDest) );
 
-  // Will need to determine which apparatus it belongs to and use the
-  // appropriate detector ID in the FillMap call
-  char EngineDID[4];
-
+  char EngineDID[] = "xDC";
   EngineDID[0] = toupper(GetApparatus()->GetName()[0]);
-  EngineDID[1] = 'D';
-  EngineDID[2] = 'C';
-  EngineDID[3] = '\0';
-  
   if( gHcDetectorMap->FillMap(fDetMap, EngineDID) < 0 ) {
     static const char* const here = "Init()";
-    Error( Here(here), "Error filling detectormap for %s.", 
-	     EngineDID);
-      return kInitError;
+    Error( Here(here), "Error filling detectormap for %s.", EngineDID );
+    return kInitError;
   }
 
   return fStatus = kOK;

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -199,13 +199,12 @@ THaAnalysisObject::EStatus THcHodoscope::Init( const TDatime& date )
   //  };
   //  memcpy( fDataDest, tmp, NDEST*sizeof(DataDest) );
 
-  char EngineDID[]="xSCIN";
+  char EngineDID[] = "xSCIN";
   EngineDID[0] = toupper(GetApparatus()->GetName()[0]);
   if( gHcDetectorMap->FillMap(fDetMap, EngineDID) < 0 ) {
     static const char* const here = "Init()";
-    Error( Here(here), "Error filling detectormap for %s.", 
-	     EngineDID);
-      return kInitError;
+    Error( Here(here), "Error filling detectormap for %s.", EngineDID );
+    return kInitError;
   }
 
   fNScinHits     = new Int_t [fNPlanes];

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -150,14 +150,12 @@ THaAnalysisObject::EStatus THcShower::Init( const TDatime& date )
     }
   }
 
-  char EngineDID[] = " CAL";
+  char EngineDID[] = "xCAL";
   EngineDID[0] = toupper(GetApparatus()->GetName()[0]);
-
   if( gHcDetectorMap->FillMap(fDetMap, EngineDID) < 0 ) {
     static const char* const here = "Init()";
-    Error( Here(here), "Error filling detectormap for %s.", 
-	     EngineDID);
-      return kInitError;
+    Error( Here(here), "Error filling detectormap for %s.", EngineDID );
+    return kInitError;
   }
 
   if(fHasArray) {


### PR DESCRIPTION
Some detector classes lacked the ability to get the appropriate Apparatus character and were only working for HMS. This is with respect to the detector IDs in the map files.