### PR TITLE
Flash ADCs in hitlists

### DIFF
--- a/src/THcHitList.cxx
+++ b/src/THcHitList.cxx
@@ -22,6 +22,7 @@ THcHitList::THcHitList()
 
 THcHitList::~THcHitList() {
   // Destructor
+  delete fSignalTypes;
 }
 
 void THcHitList::InitHitList(THaDetMap* detmap,
@@ -35,6 +36,13 @@ void THcHitList::InitHitList(THaDetMap* detmap,
   fNRawHits = 0;
   for(Int_t i=0;i<maxhits;i++) {
     fRawHitList->ConstructedAt(i);
+  }
+  // Query a raw hit object to see what kind of data to deliver
+  THcRawHit* rawhit = (THcRawHit*) (*fRawHitList)[0];
+  fNSignals = rawhit->GetNSignals();
+  fSignalTypes = new THcRawHit::ESignalType[fNSignals];
+  for(UInt_t isig=0;isig<fNSignals;isig++) {
+    fSignalTypes[isig] = rawhit->GetSignalType(isig);
   }
 
   fdMap = detmap;
@@ -75,6 +83,7 @@ void THcHitList::InitHitList(THaDetMap* detmap,
     }
   }
   // Loop to check that requested refindex's are defined
+  // and that signal #'s are in range
   for (Int_t i=0; i < fdMap->GetSize(); i++) {
     THaDetMap::Module* d = fdMap->GetModule(i);
     Int_t refindex = d->refindex;
@@ -84,6 +93,11 @@ void THcHitList::InitHitList(THaDetMap* detmap,
 	  " (" << d->crate << ", " << d->slot <<
 	  ", " << d->lo << ")" << endl;
       }
+    }
+    if(d->signal >= fNSignals) {
+      cout << "Invalid signal " << d->signal << " for " <<
+	    " (" << d->crate << ", " << d->slot <<
+	    ", " << d->lo << ")" << endl;
     }
   }
 
@@ -126,6 +140,11 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata ) {
     Int_t plane = d->plane;
     if (plane >= 1000) continue; // Skip reference times
     Int_t signal = d->signal;
+    UInt_t signaltype = fSignalTypes[signal];
+    Bool_t multifunction = evdata.IsMultifunction(d->crate, d->slot);
+    // Should probably get the Decoder::Module object and use it's
+    // methods.  Saving a THaEvData::GetModule call every time
+
     for ( Int_t j=0; j < evdata.GetNumChan( d->crate, d->slot); j++) {
       THcRawHit* rawhit=0;
 
@@ -159,33 +178,55 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata ) {
 
       // Get the data from this channel
       // Allow for multiple hits
-      Int_t nMHits = evdata.GetNumHits(d->crate, d->slot, chan);
-      for (Int_t mhit = 0; mhit < nMHits; mhit++) {
-	Int_t data = evdata.GetData( d->crate, d->slot, chan, mhit);
-	// cout << "Signal " << signal << "=" << data << endl;
-	rawhit->SetData(signal,data);
-      }
-      // Get the reference time.  Only take the first hit
-      // If a reference channel
-      // was specified, it takes precidence of reference index
-      if(d->refchan >= 0) {
-	if( evdata.GetNumHits(d->crate,d->slot,d->refchan) > 0) {
-	  Int_t reftime = evdata.GetData(d->crate, d->slot, d->refchan, 0);
-	  rawhit->SetReference(signal, reftime);
-	} else {
-	  cout << "HitList: refchan " << d->refindex <<
-	      " missing for (" << d->crate << ", " << d->slot <<
-	      ", " << chan << ")" << endl;
+      if(signaltype == THcRawHit::kTDC || !multifunction) {
+	Int_t nMHits = evdata.GetNumHits(d->crate, d->slot, chan);
+	for (Int_t mhit = 0; mhit < nMHits; mhit++) {
+	  Int_t data = evdata.GetData( d->crate, d->slot, chan, mhit);
+	  // cout << "Signal " << signal << "=" << data << endl;
+	  rawhit->SetData(signal,data);
 	}
-      } else {
-	if(d->refindex >=0 && d->refindex < fNRefIndex) {
-	  if(fRefIndexMaps[d->refindex].hashit) {
-	    rawhit->SetReference(signal, fRefIndexMaps[d->refindex].reftime);
+	// Get the reference time.  Only take the first hit
+	// If a reference channel
+	// was specified, it takes precidence of reference index
+	if(d->refchan >= 0) {
+	  if( evdata.GetNumHits(d->crate,d->slot,d->refchan) > 0) {
+	    Int_t reftime = evdata.GetData(d->crate, d->slot, d->refchan, 0);
+	    rawhit->SetReference(signal, reftime);
 	  } else {
-	    cout << "HitList: refindex " << d->refindex <<
+	    cout << "HitList: refchan " << d->refindex <<
 	      " missing for (" << d->crate << ", " << d->slot <<
 	      ", " << chan << ")" << endl;
 	  }
+	} else {
+	  if(d->refindex >=0 && d->refindex < fNRefIndex) {
+	    if(fRefIndexMaps[d->refindex].hashit) {
+	      rawhit->SetReference(signal, fRefIndexMaps[d->refindex].reftime);
+	    } else {
+	      cout << "HitList: refindex " << d->refindex <<
+		" missing for (" << d->crate << ", " << d->slot <<
+		", " << chan << ")" << endl;
+	    }
+	  }
+	}
+      } else {			// This is a Flash ADC
+	// Copy the samples
+	Int_t nsamples=evdata.GetNumEvents(Decoder::kSampleADC, d->crate, d->slot, chan);
+
+	// If nsamples comes back zero, may want to suppress further attempts to
+	// get sample data for this or all modules
+	for (Int_t isamp=0;isamp<nsamples;isamp++) {
+	  rawhit->SetSample(signal,evdata.GetData(Decoder::kSampleADC, d->crate, d->slot, chan, isamp));
+	}
+	// Now get the pulse mode data
+	// Pulse area will go into regular SetData, others will use special hit methods
+	Int_t npulses=evdata.GetNumEvents(Decoder::kPulseIntegral, d->crate, d->slot, chan);
+	// Assume that the # of pulses for kPulseTime, kPulsePeak and kPulsePedestal are same;
+	for (Int_t ipulse=0;ipulse<npulses;ipulse++) {
+	  rawhit->SetDataTimePedestalPeak(signal,
+					  evdata.GetData(Decoder::kPulseIntegral, d->crate, d->slot, chan, ipulse),
+					  evdata.GetData(Decoder::kPulseTime, d->crate, d->slot, chan, ipulse),
+					  evdata.GetData(Decoder::kPulsePedestal, d->crate, d->slot, chan, ipulse),
+					  evdata.GetData(Decoder::kPulsePeak, d->crate, d->slot, chan, ipulse));
 	}
       }
     }

--- a/src/THcHitList.h
+++ b/src/THcHitList.h
@@ -6,6 +6,7 @@
 #include "THaEvData.h"
 #include "TClonesArray.h"
 #include "TObject.h"
+#include "Decoder.h"
 
 
 using namespace std;
@@ -54,6 +55,8 @@ protected:
   // picks ridiculously large refindexes?
 
   Int_t fNRefIndex;
+  UInt_t fNSignals;
+  THcRawHit::ESignalType *fSignalTypes;
 
   ClassDef(THcHitList,0);  // List of raw hits sorted by plane, counter
 };

--- a/src/THcRawDCHit.h
+++ b/src/THcRawDCHit.h
@@ -26,6 +26,11 @@ public:
   Int_t GetReference(Int_t signal);
   Bool_t HasReference(Int_t signal) {return fHasRef;}
 
+  Int_t GetNSignals() { return 1;}
+  ESignalType GetSignalType(Int_t signal) {
+    return(kTDC);
+  }
+
   virtual Bool_t  IsSortable () const {return kTRUE; }
   virtual Int_t   Compare(const TObject* obj) const;
 

--- a/src/THcRawHit.h
+++ b/src/THcRawHit.h
@@ -20,6 +20,8 @@ public:
       return *this; };
 
   virtual ~THcRawHit() {}
+ 
+  enum ESignalType { kUndefined, kTDC, kADC};
 
   // This line causes problem
   //  virtual void Clear( Option_t* opt="" )=0;
@@ -28,8 +30,14 @@ public:
   //  virtual Bool_t  operator!=( const THcRawHit& ) = 0;
 
   virtual void SetData(Int_t signal, Int_t data) {};
+  virtual void SetSample(Int_t signal, Int_t data) {};
+  virtual void SetDataTimePedestalPeak(Int_t signal, Int_t data,
+				       Int_t time, Int_t pedestal, Int_t peak) {};
   virtual Int_t GetData(Int_t signal) {return 0;}; /* Ref time subtracted */
   virtual Int_t GetRawData(Int_t signal) {return 0;} /* Ref time not subtracted */
+  virtual ESignalType GetSignalType(Int_t signal) {return kUndefined;}
+  virtual Int_t GetNSignals() { return 1;}
+
   virtual void SetReference(Int_t signal, Int_t reference) {};
   virtual Bool_t HasReference(Int_t signal) {return kFALSE;};
   virtual Int_t GetReference(Int_t signal) {return 0;};
@@ -42,7 +50,7 @@ public:
 
   Int_t fPlane;
   Int_t fCounter;
-
+ 
  private:
 
   ClassDef(THcRawHit,0)      // Raw Hit Base Class

--- a/src/THcRawHodoHit.cxx
+++ b/src/THcRawHodoHit.cxx
@@ -23,17 +23,82 @@ using namespace std;
 
 void THcRawHodoHit::SetData(Int_t signal, Int_t data) {
   if(signal==0) {
-    if (fNRawHits[0] >= fMaxNSamplesADC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` ADC+!");}
+    if (fNRawHits[0] >= fMaxNPulsesADC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` ADC+!");}
     fADC_pos[fNRawHits[0]++] = data;
   } else if (signal==1) {
-    if (fNRawHits[1] >= fMaxNSamplesADC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` ADC-!");}
+    if (fNRawHits[1] >= fMaxNPulsesADC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` ADC-!");}
     fADC_neg[fNRawHits[1]++] = data;
   } else if(signal==2) {
-    if (fNRawHits[2] >= fMaxNSamplesTDC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` TDC+!");}
+    if (fNRawHits[2] >= fMaxNHitsTDC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` TDC+!");}
     fTDC_pos[fNRawHits[2]++] = data;
   } else if (signal==3) {
-    if (fNRawHits[3] >= fMaxNSamplesTDC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` TDC-!");}
+    if (fNRawHits[3] >= fMaxNHitsTDC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` TDC-!");}
     fTDC_neg[fNRawHits[3]++] = data;
+  }
+}
+
+void THcRawHodoHit::SetDataTimePedestalPeak(Int_t signal, Int_t data, Int_t time,
+					    Int_t pedestal, Int_t peak) {
+  if(signal==0) {
+    if (fNRawHits[0] >= fMaxNPulsesADC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` ADC+!");}
+    fADC_pos[fNRawHits[0]] = data;
+    fADC_Time_pos[fNRawHits[0]] = time;
+    fADC_Pedestal_pos[fNRawHits[0]] = pedestal;
+    fADC_Peak_pos[fNRawHits[0]++] = peak;
+    fHasMulti[signal]=kTRUE;
+    //    cout << fPlane << "/" << fCounter << "+ " << fNRawHits[0] <<  " " <<
+    //      data << "/" << time << "/" << pedestal << "/" << peak << endl;
+  } else if (signal==1) {
+    if (fNRawHits[1] >= fMaxNPulsesADC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` ADC-!");}
+    fADC_neg[fNRawHits[1]] = data;
+    fADC_Time_neg[fNRawHits[1]] = time;
+    fADC_Pedestal_neg[fNRawHits[1]] = pedestal;
+    fADC_Peak_neg[fNRawHits[1]++] = peak;
+    fHasMulti[signal]=kTRUE;
+    //    cout << fPlane << "/" << fCounter << "- " << fNRawHits[0] <<  " " <<
+    //      data << "/" << time << "/" << pedestal << "/" << peak << endl;
+  }
+}
+
+void THcRawHodoHit::SetSample(Int_t signal, Int_t data) {
+  if(signal==0) {
+    if (fNRawSamplesPos >= fMaxNSamplesADC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` ADC+!");}
+    fADC_Samples_pos[fNRawSamplesPos++] = data;
+  } else if (signal==1) {
+    if (fNRawSamplesNeg >= fMaxNSamplesADC) {throw std::runtime_error("Too many samples for `THcRawHodoHit` ADC-!");}
+    fADC_Samples_neg[fNRawSamplesNeg++] = data;
+  }
+}
+
+Int_t THcRawHodoHit::GetIntegralPos() {
+  Int_t sum=0;
+  for(UInt_t i=0;i<fNRawSamplesPos;i++) {
+    sum += fADC_Samples_pos[i];
+  }
+  return(sum);
+}
+
+Int_t THcRawHodoHit::GetIntegralNeg() {
+  Int_t sum=0;
+  for(UInt_t i=0;i<fNRawSamplesNeg;i++) {
+    sum += fADC_Samples_neg[i];
+  }
+  return(sum);
+}
+
+Int_t THcRawHodoHit::GetPedestalPos() {
+  if(fHasMulti[0] && fNRawHits[0]>0) {
+    return(fADC_Pedestal_pos[0]);
+  } else {
+    return(0);
+  }
+}
+
+Int_t THcRawHodoHit::GetPedestalNeg() {
+  if(fHasMulti[1] && fNRawHits[1]>0) {
+    return(fADC_Pedestal_neg[0]);
+  } else {
+    return(0);
   }
 }
 
@@ -42,7 +107,12 @@ Int_t THcRawHodoHit::GetData(Int_t signal) {
 }
 Int_t THcRawHodoHit::GetData(Int_t signal, UInt_t ihit) {
   Int_t value;
-  if(ihit > 0 && ihit>= fNRawHits[signal]) {
+  if(ihit>= fNRawHits[signal]) {
+    if(ihit==0) {
+      // We were not doing this, before, so we could have been sending
+      // stale data for missing tdc or adc hits
+      return(0);
+    }
     cout << "THcRawHodoHit::GetData(): requested hit #" << ihit << " out of range: "
 	 << fNRawHits[signal] << endl;
     return(-1);
@@ -109,6 +179,9 @@ Int_t THcRawHodoHit::GetReference(Int_t signal) {
 Bool_t THcRawHodoHit::HasReference(Int_t signal) {
   return(fHasRef[signal]);
 }
+Bool_t THcRawHodoHit::HasMulti(Int_t signal) {
+  return(fHasMulti[signal]);
+}
 
   // Do we use this?
 //_____________________________________________________________________________
@@ -116,18 +189,26 @@ THcRawHodoHit& THcRawHodoHit::operator=( const THcRawHodoHit& rhs )
 {
   // Assignment operator.
 
+  cout << "operator=" << endl;
   THcRawHit::operator=(rhs);
   if ( this != &rhs ) {
     for(Int_t is=0;is<4;is++) {
       fReferenceTime[is] = rhs.fReferenceTime[is];
       fNRawHits[is] = rhs.fNRawHits[is];
       fHasRef[is] = rhs.fHasRef[is];
+      fHasMulti[is] = rhs.fHasMulti[is];
     }
     for(UInt_t ih=0;ih<fNRawHits[0];ih++) {
       fADC_pos[ih] = rhs.fADC_pos[ih];
+      fADC_Time_pos[ih] = rhs.fADC_Time_pos[ih];
+      fADC_Pedestal_pos[ih] = rhs.fADC_Pedestal_pos[ih];
+      fADC_Peak_pos[ih] = rhs.fADC_Peak_pos[ih];
     }
     for(UInt_t ih=0;ih<fNRawHits[1];ih++) {
       fADC_neg[ih] = rhs.fADC_neg[ih];
+      fADC_Time_neg[ih] = rhs.fADC_Time_neg[ih];
+      fADC_Pedestal_neg[ih] = rhs.fADC_Pedestal_neg[ih];
+      fADC_Peak_neg[ih] = rhs.fADC_Peak_neg[ih];
     }
     for(UInt_t ih=0;ih<fNRawHits[2];ih++) {
       fTDC_pos[ih] = rhs.fTDC_pos[ih];
@@ -135,6 +216,16 @@ THcRawHodoHit& THcRawHodoHit::operator=( const THcRawHodoHit& rhs )
     for(UInt_t ih=0;ih<fNRawHits[3];ih++) {
       fTDC_neg[ih] = rhs.fTDC_neg[ih];
     }
+    fNRawSamplesPos = rhs.fNRawSamplesPos;
+    fNRawSamplesNeg = rhs.fNRawSamplesNeg;
+    for(UInt_t is=0;is<fNRawSamplesPos;is++) {
+      fADC_Samples_pos[is] = rhs.fADC_Samples_pos[is];
+    }
+    for(UInt_t is=0;is<fNRawSamplesNeg;is++) {
+      fADC_Samples_neg[is] = rhs.fADC_Samples_neg[is];
+    }
+    
+    
   }
   return *this;
 }

--- a/src/THcRawHodoHit.h
+++ b/src/THcRawHodoHit.h
@@ -13,8 +13,11 @@ class THcRawHodoHit : public THcRawHit {
   THcRawHodoHit(Int_t plane=0, Int_t counter=0) : THcRawHit(plane, counter) {
     for(Int_t i=0;i<4;i++) {
       fHasRef[i] = kFALSE;
+      fHasMulti[i] = kFALSE;
       fNRawHits[i] = 0;
     }
+    fNRawSamplesPos = 0;
+    fNRawSamplesNeg = 0;
   }
   THcRawHodoHit& operator=( const THcRawHodoHit& );
   virtual ~THcRawHodoHit() {}
@@ -22,10 +25,16 @@ class THcRawHodoHit : public THcRawHit {
   virtual void Clear( Option_t* opt="" ) {
     for(Int_t i=0;i<4;i++) {
       fHasRef[i] = kFALSE;
+      fHasMulti[i] = kFALSE;
       fNRawHits[i] = 0;
     }
+    fNRawSamplesPos = 0;
+    fNRawSamplesNeg = 0;
   }
   void SetData(Int_t signal, Int_t data);
+  void SetDataTimePedestalPeak(Int_t signal, Int_t data, Int_t time,
+			       Int_t pedestal, Int_t peak);
+  void SetSample(Int_t signal, Int_t data);
   void SetReference(Int_t signal, Int_t reference);
   Int_t GetData(Int_t signal);
   Int_t GetData(Int_t signal, UInt_t ihit);
@@ -33,6 +42,7 @@ class THcRawHodoHit : public THcRawHit {
   Int_t GetRawData(Int_t signal, UInt_t ihit);
   Int_t GetReference(Int_t signal);
   Bool_t HasReference(Int_t signal);
+  Bool_t HasMulti(Int_t signal);
 
   //  virtual Bool_t  IsSortable () const {return kTRUE; }
   //  virtual Int_t   Compare(const TObject* obj) const;
@@ -42,20 +52,43 @@ class THcRawHodoHit : public THcRawHit {
   Int_t GetTDCPos() {return GetData(2, 0);}
   Int_t GetTDCNeg() {return GetData(3, 0);}
 
-  UInt_t GetMaxNSamplesTDC() {return fMaxNSamplesTDC;}
+  UInt_t GetMaxNSamplesTDC() {return fMaxNHitsTDC;}
   Int_t GetTDCPos(UInt_t ihit) {return GetData(2, ihit);}
   Int_t GetTDCNeg(UInt_t ihit) {return GetData(3, ihit);}
 
+  Int_t GetIntegralPos();
+  Int_t GetIntegralNeg();
+  Int_t GetPedestalPos();
+  Int_t GetPedestalNeg();
+
+  Int_t GetNSignals() { return 4;}
+  ESignalType GetSignalType(Int_t signal) {
+    if(signal==0||signal==1) {return kADC;}
+    else {return kTDC;}
+  }
+
  protected:
   static const UInt_t fMaxNSamplesADC = 160;
-  static const UInt_t fMaxNSamplesTDC = 16;
-  Int_t fADC_pos[fMaxNSamplesADC];
-  Int_t fADC_neg[fMaxNSamplesADC];
-  Int_t fTDC_pos[fMaxNSamplesTDC];
-  Int_t fTDC_neg[fMaxNSamplesTDC];
+  static const UInt_t fMaxNPulsesADC = 4;
+  static const UInt_t fMaxNHitsTDC = 16;
+  Int_t fADC_pos[fMaxNPulsesADC];
+  Int_t fADC_neg[fMaxNPulsesADC];
+  Int_t fTDC_pos[fMaxNHitsTDC];
+  Int_t fTDC_neg[fMaxNHitsTDC];
+  Int_t fADC_Time_pos[fMaxNPulsesADC];
+  Int_t fADC_Time_neg[fMaxNPulsesADC];
+  Int_t fADC_Pedestal_pos[fMaxNPulsesADC];
+  Int_t fADC_Pedestal_neg[fMaxNPulsesADC];
+  Int_t fADC_Peak_pos[fMaxNPulsesADC];
+  Int_t fADC_Peak_neg[fMaxNPulsesADC];
+  Int_t fADC_Samples_pos[fMaxNSamplesADC];
+  Int_t fADC_Samples_neg[fMaxNSamplesADC];
   Int_t fReferenceTime[4];
   Bool_t fHasRef[4];
+  Bool_t fHasMulti[4];
   UInt_t fNRawHits[4];
+  UInt_t fNRawSamplesPos;
+  UInt_t fNRawSamplesNeg;
 
  private:
 

--- a/src/THcRawShowerHit.h
+++ b/src/THcRawShowerHit.h
@@ -28,6 +28,10 @@ class THcRawShowerHit : public THcRawHit {
   Double_t GetPedestal(Int_t signal, Int_t isamplow, Int_t isamphigh);
   Int_t GetNSamples(Int_t signal);
 
+  Int_t GetNSignals() { return 2;}
+  ESignalType GetSignalType(Int_t signal) {
+    return kADC;
+  }
   //  virtual Bool_t  IsSortable () const {return kTRUE; }
   //  virtual Int_t   Compare(const TObject* obj) const;
 

--- a/src/THcScintillatorPlane.h
+++ b/src/THcScintillatorPlane.h
@@ -66,6 +66,10 @@ class THcScintillatorPlane : public THaSubDetector {
   TClonesArray* frNegTDCHits;
   TClonesArray* frPosADCHits;
   TClonesArray* frNegADCHits;
+  TClonesArray* frPosADCSums;
+  TClonesArray* frNegADCSums;
+  TClonesArray* frPosADCPeds;
+  TClonesArray* frNegADCPeds;
   TClonesArray* fHodoHits;
 
   Int_t fPlaneNum;		/* Which plane am I 1-4 */
@@ -76,6 +80,14 @@ class THcScintillatorPlane : public THaSubDetector {
   Int_t fNGoodHits;                 /* number of hits in plane (used in determining focal plane time) */
 
   // Constants
+  Int_t fADCMode;		// 0: standard, 1: use FADC ped, 2: integrate sample
+                                // 3: integrate sample, subract dynamic pedestal
+  static const Int_t kADCStandard=0;
+  static const Int_t kADCDynamicPedestal=1;
+  static const Int_t kADCSampleIntegral=2;
+  static const Int_t kADCSampIntDynPed=3;
+  Double_t fADCPedScaleFactor;	// Multiply dynamic pedestal by this before subtracting
+  Int_t fADCDiagCut;		// Cut for ADC in hit maps.  Defaults to 50
   Int_t fTdcOffset;		/* Overall offset to raw tdc */
   Int_t fMaxHits;               /* maximum number of hits to be considered - useful for dimensioning arrays */
   Double_t fSpacing;            /* paddle spacing */


### PR DESCRIPTION
This pull request adds the ability to get flash ADC information and put it into the detector raw hits in the hitlists.  Changes are made to THcScintillator (Part of hodoscope class) to show how this information can be used in the detector classes.  The other detector classes will need to be similarly updated.