### PR TITLE
Added THcRawAdcHit and included it in THcRawShowerHit.

### DIFF
--- a/SConscript.py
+++ b/SConscript.py
@@ -23,6 +23,7 @@ src/THcGlobals.h src/THcDCTrack.h src/THcFormula.h
 src/THcRaster.h src/THcRasteredBeam.h src/THcRasterRawHit.h src/THcScalerEvtHandler.h
 src/THcHodoEff.h
 src/THcTrigApp.h src/THcTrigDet.h src/THcTrigRawHit.h
+src/THcRawAdcHit.h
 src/THcDummySpectrometer.h
 src/HallC_LinkDef.h
 """)

--- a/src/HallC_LinkDef.h
+++ b/src/HallC_LinkDef.h
@@ -60,6 +60,7 @@
 #pragma link C++ class THcTrigApp+;
 #pragma link C++ class THcTrigDet+;
 #pragma link C++ class THcTrigRawHit+;
+#pragma link C++ class THcRawAdcHit+;
 #pragma link C++ class THcDummySpectrometer+;
 
 #endif

--- a/src/SConscript.py
+++ b/src/SConscript.py
@@ -28,6 +28,7 @@ THcFormula.cxx
 THcRaster.cxx THcRasteredBeam.cxx THcRasterRawHit.cxx
 THcScalerEvtHandler.cxx
 THcTrigApp.cxx THcTrigDet.cxx THcTrigRawHit.cxx
+THcRawAdcHit.cxx
 THcDummySpectrometer.cxx
 THcHodoEff.cxx
 """)

--- a/src/THcRawAdcHit.cxx
+++ b/src/THcRawAdcHit.cxx
@@ -1,0 +1,203 @@
+/**
+\class THcTrigRawHit
+\ingroup DetSupport
+
+\brief Class representing a single raw ADC hit.
+
+It supports rich data from flash 250 ADC modules.
+*/
+
+#include "THcRawAdcHit.h"
+
+#include <stdexcept>
+
+#include "TString.h"
+
+
+THcRawAdcHit::THcRawAdcHit() :
+  TObject(),
+  fAdc(), fAdcTime(), fAdcPedestal(), fAdcPeak(), fAdcSample(),
+  fHasMulti(kFALSE), fNPulses(0), fNSamples(0)
+{}
+
+
+THcRawAdcHit& THcRawAdcHit::operator=(const THcRawAdcHit& right) {
+  TObject::operator=(right);
+
+  if (this != &right) {
+    for (UInt_t i=0; i<fMaxNPulses; ++i) {
+      fAdc[i] = right.fAdc[i];
+      fAdcTime[i] = right.fAdcTime[i];
+      fAdcPedestal[i] = right.fAdcPedestal[i];
+      fAdcPeak[i] = right.fAdcPeak[i];
+    }
+    for (UInt_t i=0; i<fMaxNSamples; ++i) {
+      fAdcSample[i] = right.fAdcSample[i];
+    }
+    fHasMulti = right.fHasMulti;
+    fNPulses = right.fNPulses;
+    fNSamples = right.fNSamples;
+  }
+
+  return *this;
+}
+
+
+THcRawAdcHit::~THcRawAdcHit() {}
+
+
+void THcRawAdcHit::Clear(Option_t* opt) {
+  TObject::Clear(opt);
+
+  //for (UInt_t i=0; i<fMaxNPulses; ++i) {
+  //  fAdc[i] = 0;
+  //  fAdcTime[i] = 0;
+  //  fAdcPedestal[i] = 0;
+  //  fAdcPeak[i] = 0;
+  //}
+  //for (UInt_t i=0; i<fMaxNSamples; ++i) {
+  //  fAdcSample[i] = 0 ;
+  //}
+  fHasMulti = kFALSE;
+  fNPulses = 0;
+  fNSamples = 0;
+}
+
+
+void THcRawAdcHit::SetData(Int_t data) {
+  if (fNPulses >= fMaxNPulses) {
+    throw std::out_of_range(
+      "`THcRawAdcHit::SetData`: too many pulses!"
+    );
+  }
+  fAdc[fNPulses] = data;
+  ++fNPulses;
+}
+
+
+void THcRawAdcHit::SetSample(Int_t data) {
+  if (fNSamples >= fMaxNSamples) {
+    throw std::out_of_range(
+      "`THcRawAdcHit::SetSample`: too many samples!"
+    );
+  }
+  fAdcSample[fNSamples] = data;
+  ++fNSamples;
+}
+
+
+void THcRawAdcHit::SetDataTimePedestalPeak(
+  Int_t data, Int_t time, Int_t pedestal, Int_t peak
+) {
+  if (fNPulses >= fMaxNPulses) {
+    throw std::out_of_range(
+      "`THcRawAdcHit::SetData`: too many pulses!"
+    );
+  }
+  fAdc[fNPulses] = data;
+  fAdcTime[fNPulses] = data;
+  fAdcPedestal[fNPulses] = data;
+  fAdcPeak[fNPulses] = data;
+  fHasMulti = kTRUE;
+  ++fNPulses;
+}
+
+
+Int_t THcRawAdcHit::GetRawData(UInt_t iPulse) {
+  if (iPulse >= fNPulses && iPulse != 0) {
+    TString msg = TString::Format(
+      "`THcRawAdcHit::GetRawData`: requested pulse %d where only %d pulses available!",
+      iPulse, fNPulses
+    );
+    throw std::out_of_range(msg.Data());
+  }
+  else if (iPulse >= fNPulses && iPulse == 0) {
+    return 0;
+  }
+  else {
+    return fAdc[iPulse];
+  }
+}
+
+
+Int_t THcRawAdcHit::GetAdcTime(UInt_t iPulse) {
+  if (iPulse >= fNPulses && iPulse != 0) {
+    TString msg = TString::Format(
+      "`THcRawAdcHit::GetAdcTime`: requested pulse %d where only %d pulses available!",
+      iPulse, fNPulses
+    );
+    throw std::out_of_range(msg.Data());
+  }
+  else if (fHasMulti) {
+    return fAdcTime[iPulse];
+  }
+  else {
+    return 0;
+  }
+}
+
+
+Int_t THcRawAdcHit::GetAdcPedestal(UInt_t iPulse) {
+  if (iPulse >= fNPulses && iPulse != 0) {
+    TString msg = TString::Format(
+      "`THcRawAdcHit::GetAdcPedestal`: requested pulse %d where only %d pulses available!",
+      iPulse, fNPulses
+    );
+    throw std::out_of_range(msg.Data());
+  }
+  else if (fHasMulti) {
+    return fAdcPedestal[iPulse];
+  }
+  else {
+    return 0;
+  }
+}
+
+
+Int_t THcRawAdcHit::GetAdcPeak(UInt_t iPulse) {
+  if (iPulse >= fNPulses && iPulse != 0) {
+    TString msg = TString::Format(
+      "`THcRawAdcHit::GetAdcPeak`: requested pulse %d where only %d pulses available!",
+      iPulse, fNPulses
+    );
+    throw std::out_of_range(msg.Data());
+  }
+  else if (fHasMulti) {
+    return fAdcPeak[iPulse];
+  }
+  else {
+    return 0;
+  }
+}
+
+
+Int_t THcRawAdcHit::GetSample(UInt_t iSample) {
+  if (iSample >= fNSamples && iSample != 0) {
+    TString msg = TString::Format(
+      "`THcRawAdcHit::GetSample`: requested sample %d where only %d sample available!",
+      iSample, fNSamples
+    );
+    throw std::out_of_range(msg.Data());
+  }
+  else {
+    return fAdcSample[iSample];
+  }
+}
+
+
+UInt_t THcRawAdcHit::GetNPulses() {
+  return fNPulses;
+}
+
+
+UInt_t THcRawAdcHit::GetNSamples() {
+  return fNSamples;
+}
+
+
+Bool_t THcRawAdcHit::HasMulti() {
+  return fHasMulti;
+}
+
+
+ClassImp(THcRawAdcHit)

--- a/src/THcRawAdcHit.h
+++ b/src/THcRawAdcHit.h
@@ -1,0 +1,52 @@
+#ifndef ROOT_THcRawAdcHit
+#define ROOT_THcRawAdcHit
+
+#include "RtypesCore.h"
+#include "TObject.h"
+
+
+class THcRawAdcHit : public TObject {
+  public:
+    THcRawAdcHit();
+    THcRawAdcHit& operator=(const THcRawAdcHit& right);
+    virtual ~THcRawAdcHit();
+
+    virtual void Clear(Option_t* opt="");
+
+    void SetData(Int_t data);
+    void SetSample(Int_t data);
+    void SetDataTimePedestalPeak(
+      Int_t data, Int_t time, Int_t pedestal, Int_t peak
+    );
+
+    Int_t GetRawData(UInt_t iPulse=0);
+    Int_t GetAdcTime(UInt_t iPulse=0);
+    Int_t GetAdcPedestal(UInt_t iPulse=0);
+    Int_t GetAdcPeak(UInt_t iPulse=0);
+    Int_t GetSample(UInt_t iSample);
+
+    UInt_t GetNPulses();
+    UInt_t GetNSamples();
+
+    Bool_t HasMulti();
+
+  protected:
+    static const UInt_t fMaxNPulses = 4;
+    static const UInt_t fMaxNSamples = 160;
+
+    Int_t fAdc[fMaxNPulses];
+    Int_t fAdcTime[fMaxNPulses];
+    Int_t fAdcPedestal[fMaxNPulses];
+    Int_t fAdcPeak[fMaxNPulses];
+    Int_t fAdcSample[fMaxNSamples];
+
+    Bool_t fHasMulti;
+    UInt_t fNPulses;
+    UInt_t fNSamples;
+
+  private:
+    ClassDef(THcRawAdcHit, 0)
+};
+
+
+#endif  // ROOT_THcRawAdcHit

--- a/src/THcRawShowerHit.cxx
+++ b/src/THcRawShowerHit.cxx
@@ -1,167 +1,152 @@
-/** \class THcRawShowerHit
-    \ingroup DetSupport
+/**
+\class THcRawShowerHit
+\ingroup DetSupport
 
- Class representing a single raw hit for a hodoscope paddle                
+\brief Class representing a single raw hit for a hodoscope paddle.
 
- Contains plane, counter and pos/neg adc and tdc values                    
-                                                                           
- Enhanced to work with FADC250 data samples.  If fNPosSamples/fNNegSamples 
- is greater than 1, assume that the data held in the hit is the sampled    
- waveform.  Signals 0,1 will return the integrated pulse with dynamic      
- pedestal subtraction (first four samples comprise the pedestal).  Signals 
- 2,3 are reserved for time information.  Signals 4,5 are pedestals and     
- 6 and 7 are the straight sum of all the samples.                          
-
+  - `signal 0` is ADC pos
+  - `signal 1` is ADC neg
 */
 
 #include "THcRawShowerHit.h"
+
 #include <iostream>
-#include <cassert>
-
-using namespace std;
+#include <stdexcept>
 
 
-void THcRawShowerHit::SetData(Int_t signal, Int_t data) {
-  if(signal==0) {
-    fADC_pos[fNPosSamples++] = data;
-  } else if (signal==1) {
-    fADC_neg[fNNegSamples++] = data;
-  } 
-}
+THcRawShowerHit::THcRawShowerHit(Int_t plane, Int_t counter) :
+  fAdcPos(), fAdcNeg()
+{}
 
-Int_t THcRawShowerHit::GetData(Int_t signal, Int_t isamplow, Int_t isamphigh,
-	      Int_t iintegrallow, Int_t iintegralhigh) {
-  Int_t adcsum=0;
-  Double_t pedestal=0.0;
 
-  if(signal==0 || signal == 1) {
-    pedestal = GetPedestal(signal, isamplow, isamphigh);
+THcRawShowerHit& THcRawShowerHit::operator=(const THcRawShowerHit& right) {
+  THcRawHit::operator=(right);
 
-#if 0
-    for(Int_t i=0;i<fNPosSamples;i++) {
-      cout << fCounter << " " << i;
-      if(i >= isamplow && i<=isamphigh) {
-	cout << "P ";
-      }	else if (i >= iintegrallow && i<=iintegralhigh) {
-	cout << "D ";
-      } else {
-	cout << "  ";
-      }
-      cout << fADC_pos[i] << " " << fADC_pos[i] - pedestal << endl;
-    }
-#endif
+  if (this != &right) {
+    fAdcPos = right.fAdcPos;
+    fAdcNeg = right.fAdcNeg;
   }
-  if(signal==4 || signal==5) {
-    pedestal = GetPedestal(signal-4, isamplow, isamphigh);
-    return(pedestal);
-  }
-  if(signal==0 || signal==6) {
-    assert(iintegralhigh<(Int_t) fNPosSamples);
-    for(UInt_t isample=iintegrallow;isample<=iintegralhigh;isample++) {
-      adcsum += fADC_pos[isample] - pedestal;
-    }
-    return(adcsum);
-  } else if (signal==1 || signal==7) {
-    assert(iintegralhigh<(Int_t) fNNegSamples);
-    for(UInt_t isample=iintegrallow;isample<=iintegralhigh;isample++) {
-      adcsum += fADC_neg[isample] - pedestal;
-    }
-    return(adcsum);
-  } 
-  return(-1); // Actually should throw exception
-}
-  
-// Return sum of samples
-// For Fastbus ADC, this will simply be the hardware ADC value as there
-// is just one sample.  For Flash ADCs, this should return the
-// integrated ADC value if the FADC provided that, otherwise the sum
-// of all the samples
-Int_t THcRawShowerHit::GetData(Int_t signal) {
-  Int_t adcsum=0;
 
-  if(signal==0) {
-    for(UInt_t isample=0;isample<fNPosSamples;isample++) {
-      adcsum += fADC_pos[isample];
-    }
-    return(adcsum);
-  } else if (signal==1) {
-    for(UInt_t isample=0;isample<fNNegSamples;isample++) {
-      adcsum += fADC_neg[isample];
-    }
-    return(adcsum);
-  } 
-  return(-1); // Actually should throw exception
-}
-
-// Return a requested sample
-Int_t THcRawShowerHit::GetSample(Int_t signal, UInt_t isample) {
-  if(signal==0) {
-    if(isample < fNPosSamples) {
-      return(fADC_pos[isample]);
-    }
-  } else if (signal==1) {
-    if(isample < fNNegSamples) {
-      return(fADC_neg[isample]);
-    }
-  }
-  return(-1);
-}
-
-Double_t THcRawShowerHit::GetPedestal(Int_t signal, Int_t isamplow, Int_t isamphigh) {
-  // No error checking on pedestal range
-  Double_t pedestal=0.0;
-  if(signal==0 && fNPosSamples > 1) {
-    if(fNPosSamples > isamphigh) {
-      for(Int_t i = isamplow;i<=isamphigh;i++) {
-	pedestal += fADC_pos[i];
-      }
-      return(pedestal/(isamphigh-isamplow+1));
-    }
-  } else if (signal==1 && fNNegSamples > 1) {
-    if(fNNegSamples > isamphigh) {
-      for(Int_t i = isamplow;i<=isamphigh;i++) {
-	pedestal += fADC_neg[i];
-      }
-      return(pedestal/(isamphigh-isamplow+1));
-    }
-  }
-  return(pedestal);
-}
-      
-// Return the number of samples
-Int_t THcRawShowerHit::GetNSamples(Int_t signal) {
-  if(signal==0) {
-    return(fNPosSamples);
-  } else if (signal==1) {
-    return(fNNegSamples);
-  }
-  return(-1);
-}
-
-//_____________________________________________________________________________
-THcRawShowerHit& THcRawShowerHit::operator=( const THcRawShowerHit& rhs )
-{
-  // Assignment operator.
-
-  cout << "YES THIS HAPPENS" << endl;
-  THcRawHit::operator=(rhs);
-  if ( this != &rhs ) {
-    fPlane = rhs.fPlane;
-    fCounter = rhs.fCounter;
-    for(UInt_t isample=0;isample<fNPosSamples;isample++) {
-      fADC_pos[isample] = rhs.fADC_pos[isample];
-    }
-    for(UInt_t isample=0;isample<fNNegSamples;isample++) {
-      fADC_pos[isample] = rhs.fADC_pos[isample];
-    }
-    fNPosSamples = rhs.fNPosSamples;
-    fNNegSamples = rhs.fNNegSamples;
-  }
   return *this;
 }
 
 
-//////////////////////////////////////////////////////////////////////////
-ClassImp(THcRawShowerHit)
+THcRawShowerHit::~THcRawShowerHit() {}
 
- 
+
+void THcRawShowerHit::Clear(Option_t* opt) {
+  THcRawHit::Clear(opt);
+
+  fAdcPos.Clear();
+  fAdcNeg.Clear();
+}
+
+
+void THcRawShowerHit::SetData(Int_t signal, Int_t data) {
+  if (signal == 0) {
+    fAdcPos.SetData(data);
+  }
+  else if (signal == 1) {
+    fAdcNeg.SetData(data);
+  }
+  else {
+    throw std::out_of_range(
+      "`THcTrigRawHit::GetData`: only signals `0` and `1` available!"
+    );
+  }
+}
+
+
+void THcRawShowerHit::SetSample(Int_t signal, Int_t data) {
+  if (signal == 0) {
+    fAdcPos.SetSample(data);
+  }
+  else if (signal == 1) {
+    fAdcNeg.SetSample(data);
+  }
+  else {
+    throw std::out_of_range(
+      "`THcTrigRawHit::GetData`: only signals `0` and `1` available!"
+    );
+  }
+}
+
+
+void THcRawShowerHit::SetDataTimePedestalPeak(
+  Int_t signal, Int_t data, Int_t time, Int_t pedestal, Int_t peak
+) {
+  if (signal == 0) {
+    fAdcPos.SetDataTimePedestalPeak(data, time, pedestal, peak);
+  }
+  else if (signal == 1) {
+    fAdcNeg.SetDataTimePedestalPeak(data, time, pedestal, peak);
+  }
+  else {
+    throw std::out_of_range(
+      "`THcTrigRawHit::GetData`: only signals `0` and `1` available!"
+    );
+  }
+}
+
+
+void THcRawShowerHit::SetReference(Int_t signal, Int_t reference) {
+  std::cerr
+    << "Warning:"
+    << " `THcRawShowerHit::SetReference`:"
+    << " ADC signal should not have reference time!"
+    << std::endl;
+}
+
+
+Int_t THcRawShowerHit::GetData(Int_t signal) {
+  if (signal == 0) {
+    return fAdcPos.GetRawData();
+  }
+  else if (signal == 1) {
+    return fAdcNeg.GetRawData();
+  }
+  else {
+    throw std::out_of_range(
+      "`THcTrigRawHit::GetData`: only signals `0` and `1` available!"
+    );
+  }
+}
+
+
+Int_t THcRawShowerHit::GetRawData(Int_t signal) {
+  if (signal == 0) {
+    return fAdcPos.GetRawData();
+  }
+  else if (signal == 1) {
+    return fAdcNeg.GetRawData();
+  }
+  else {
+    throw std::out_of_range(
+      "`THcTrigRawHit::GetData`: only signals `0` and `1` available!"
+    );
+  }
+}
+
+
+THcRawHit::ESignalType THcRawShowerHit::GetSignalType(Int_t signal) {
+  return kADC;
+}
+
+
+Int_t THcRawShowerHit::GetNSignals() {
+  return 2;
+}
+
+
+THcRawAdcHit& THcRawShowerHit::GetRawAdcHitPos() {
+  return fAdcPos;
+}
+
+
+THcRawAdcHit& THcRawShowerHit::GetRawAdcHitNeg() {
+  return fAdcNeg;
+}
+
+
+
+ClassImp(THcRawShowerHit)

--- a/src/THcRawShowerHit.h
+++ b/src/THcRawShowerHit.h
@@ -1,51 +1,44 @@
 #ifndef ROOT_THcRawShowerHit
 #define ROOT_THcRawShowerHit
 
+#include "RtypesCore.h"
+
+#include "THcRawAdcHit.h"
 #include "THcRawHit.h"
 
-#define MAXSAMPLES 126
 
 class THcRawShowerHit : public THcRawHit {
-
- public:
   friend class THcShowerPlane;
   friend class THcShowerArray;
 
-  THcRawShowerHit(Int_t plane=0, Int_t counter=0) : 
-    THcRawHit(plane, counter), fNPosSamples(0), fNNegSamples(0) {
-  }
-  THcRawShowerHit& operator=( const THcRawShowerHit& );
-  virtual ~THcRawShowerHit() {}
+  public:
+    THcRawShowerHit(Int_t plane=0, Int_t counter=0);
+    THcRawShowerHit& operator=(const THcRawShowerHit& right);
+    virtual ~THcRawShowerHit();
 
-  virtual void Clear( Option_t* opt="" )
-  { fNPosSamples=0; fNNegSamples=0;}
+    virtual void Clear(Option_t* opt="");
 
-  void SetData(Int_t signal, Int_t data);
-  Int_t GetData(Int_t signal);
-  Int_t GetData(Int_t signal, Int_t isamplow, Int_t isamphigh,
-		Int_t iintegrallow, Int_t iintegralhigh);
-  Int_t GetSample(Int_t signal, UInt_t isample);
-  Double_t GetPedestal(Int_t signal, Int_t isamplow, Int_t isamphigh);
-  Int_t GetNSamples(Int_t signal);
+    virtual void SetData(Int_t signal, Int_t data);
+    virtual void SetSample(Int_t signal, Int_t data);
+    virtual void SetDataTimePedestalPeak(
+      Int_t signal, Int_t data, Int_t time, Int_t pedestal, Int_t peak
+    );
+    virtual void SetReference(Int_t signal, Int_t reference);
 
-  Int_t GetNSignals() { return 2;}
-  ESignalType GetSignalType(Int_t signal) {
-    return kADC;
-  }
-  //  virtual Bool_t  IsSortable () const {return kTRUE; }
-  //  virtual Int_t   Compare(const TObject* obj) const;
+    virtual Int_t GetData(Int_t signal);
+    virtual Int_t GetRawData(Int_t signal);
+    virtual ESignalType GetSignalType(Int_t signal);
+    virtual Int_t GetNSignals();
 
- protected:
-  UInt_t fNPosSamples;
-  UInt_t fNNegSamples;
-  // Is there a way we could pass sample size from the detector initialization
-  Int_t fADC_pos[MAXSAMPLES];
-  Int_t fADC_neg[MAXSAMPLES];
+    THcRawAdcHit& GetRawAdcHitPos();
+    THcRawAdcHit& GetRawAdcHitNeg();
 
- private:
+  protected:
+    THcRawAdcHit fAdcPos;
+    THcRawAdcHit fAdcNeg;
 
-  ClassDef(THcRawShowerHit, 0);	// Raw Shower counter hit
-};  
+  private:
+    ClassDef(THcRawShowerHit, 0);	// Raw Shower counter hit
+};
 
 #endif
- 

--- a/src/THcShowerArray.cxx
+++ b/src/THcShowerArray.cxx
@@ -30,7 +30,7 @@ using namespace std;
 ClassImp(THcShowerArray)
 
 //______________________________________________________________________________
-THcShowerArray::THcShowerArray( const char* name, 
+THcShowerArray::THcShowerArray( const char* name,
 				const char* description,
 				const Int_t layernum,
 				THaDetectorBase* parent )
@@ -411,7 +411,7 @@ Int_t THcShowerArray::CoarseProcess( TClonesArray& tracks )
 	 ppcl != (*fClusterList).end(); ppcl++) {
 
       cout << "  Cluster #" << i++
-	   <<":  E=" << clE(*ppcl) 
+	   <<":  E=" << clE(*ppcl)
 	   << "  Epr=" << clEpr(*ppcl)
 	   << "  X=" << clX(*ppcl)
 	   << "  Z=" << clZ(*ppcl)
@@ -539,7 +539,7 @@ Int_t THcShowerArray::MatchCluster(THaTrack* Track,
 	 << "  Y = " << YTrFront
 	 << "  Pathl = " << pathl
 	 << endl;
-    if (fParent->fvTest) 
+    if (fParent->fvTest)
       cout << "  Fiducial volume test: inFidVol = " << inFidVol << endl;
 
     cout << "  Matched cluster #" << mclust << ",  Delta = " << Delta << endl;
@@ -640,15 +640,10 @@ Int_t THcShowerArray::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
     if(hit->fPlane != fLayerNum) {
       break;
     }
-    
+
     // Should probably check that counter # is in range
-    if(fUsingFADC) {
-      fA[hit->fCounter-1] = hit->GetData(0,fPedSampLow,fPedSampHigh,
-					 fDataSampLow,fDataSampHigh);
-      fP[hit->fCounter-1] = hit->GetPedestal(0,fPedSampLow,fPedSampHigh);
-    } else {
-          fA[hit->fCounter-1] = hit->GetData(0);
-    }
+		// TODO: Need to include rich FADC data if available.
+    fA[hit->fCounter-1] = hit->GetData(0);
 
     if(fA[hit->fCounter-1] > threshold) {
       ngood++;
@@ -674,7 +669,7 @@ Int_t THcShowerArray::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
 
     ihit++;
   }
-    
+
 #if 0
   if(ngood > 0) {
     cout << "+";
@@ -787,10 +782,8 @@ Int_t THcShowerArray::AccumulatePedestals(TClonesArray* rawhits, Int_t nexthit)
 
     Int_t element = hit->fCounter - 1; // Should check if in range
 
-    Int_t adc = fUsingFADC ?
-      hit->GetData(0,fPedSampLow,fPedSampHigh,fDataSampLow,fDataSampHigh)
-      :
-      hit->GetData(0);
+		// TODO: Need to include rich FADC data if available.
+    Int_t adc = hit->GetData(0);
 
     if(adc <= fPedLimit[element]) {
       fPedSum[element] += adc;
@@ -822,10 +815,7 @@ Int_t THcShowerArray::AccumulatePedestals(TClonesArray* rawhits, Int_t nexthit)
 	break;
       }
 
-      Int_t adc = fUsingFADC ?
-	hit->GetData(0,fPedSampLow,fPedSampHigh,fDataSampLow,fDataSampHigh)
-	:
-	hit->GetData(0);
+      Int_t adc = hit->GetData(0);
 
       cout << "  hit " << ih << ":"
 	   << "  plane =  " << hit->fPlane
@@ -847,7 +837,7 @@ void THcShowerArray::CalculatePedestals( )
   // Use the accumulated pedestal data to calculate pedestals.
 
   for(Int_t i=0; i<fNelem;i++) {
-    
+
     fPed[i] = ((Float_t) fPedSum[i]) / TMath::Max(1, fPedCount[i]);
     fSig[i] = sqrt(((Float_t)fPedSum2[i])/TMath::Max(1, fPedCount[i])
 		   - fPed[i]*fPed[i]);
@@ -874,7 +864,7 @@ void THcShowerArray::CalculatePedestals( )
     cout << "---------------------------------------------------------------\n";
 
   }
-  
+
 }
 //_____________________________________________________________________________
 void THcShowerArray::InitializePedestals( )
@@ -894,7 +884,7 @@ void THcShowerArray::InitializePedestals( )
     fPedSum2[i] = 0;
     fPedCount[i] = 0;
   }
-} 
+}
 
 //------------------------------------------------------------------------------
 

--- a/src/THcShowerPlane.cxx
+++ b/src/THcShowerPlane.cxx
@@ -29,7 +29,7 @@ using namespace std;
 ClassImp(THcShowerPlane)
 
 //______________________________________________________________________________
-THcShowerPlane::THcShowerPlane( const char* name, 
+THcShowerPlane::THcShowerPlane( const char* name,
 					    const char* description,
 					    const Int_t layernum,
 					    THaDetectorBase* parent )
@@ -87,7 +87,7 @@ THaAnalysisObject::EStatus THcShowerPlane::Init( const TDatime& date )
 //_____________________________________________________________________________
 Int_t THcShowerPlane::ReadDatabase( const TDatime& date )
 {
-  
+
   // Retrieve FADC parameters.  In principle may want different dynamic
   // pedestal and integration range for preshower and shower, but for now
   // use same parameters
@@ -97,7 +97,7 @@ Int_t THcShowerPlane::ReadDatabase( const TDatime& date )
   fUsingFADC=0;
   fPedSampLow=0;
   fPedSampHigh=9;
-  fDataSampLow=23; 
+  fDataSampLow=23;
   fDataSampHigh=49;
   DBRequest list[]={
     {"cal_using_fadc", &fUsingFADC, kInt, 0, 1},
@@ -126,7 +126,7 @@ Int_t THcShowerPlane::ReadDatabase( const TDatime& date )
 
   Double_t BlockThick = fParent->GetBlockThick(fLayerNum-1);
 
-  Double_t xOrig = (fParent->GetXPos(fLayerNum-1,0) + 
+  Double_t xOrig = (fParent->GetXPos(fLayerNum-1,0) +
 		    fParent->GetXPos(fLayerNum-1,fNelem-1))/2 +
     BlockThick/2;
 
@@ -263,7 +263,7 @@ Int_t THcShowerPlane::CoarseProcess( TClonesArray& tracks )
 {
 
   // Nothing is done here. See ProcessHits method instead.
-  //  
+  //
 
  return 0;
 }
@@ -320,17 +320,11 @@ Int_t THcShowerPlane::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
     if(hit->fPlane > fLayerNum) {
       break;
     }
-    
+
     // Should probably check that counter # is in range
-    if(fUsingFADC) {
-      fA_Pos[hit->fCounter-1] = hit->GetData(0,fPedSampLow,fPedSampHigh,
-					 fDataSampLow,fDataSampHigh);
-      fA_Neg[hit->fCounter-1] = hit->GetData(1,fPedSampLow,fPedSampHigh,
-					 fDataSampLow,fDataSampHigh);
-    } else {
-      fA_Pos[hit->fCounter-1] = hit->GetData(0);
-      fA_Neg[hit->fCounter-1] = hit->GetData(1);
-    }
+		// TODO: Need to include rich FADC data if available.
+    fA_Pos[hit->fCounter-1] = hit->GetData(0);
+    fA_Neg[hit->fCounter-1] = hit->GetData(1);
 
     // Sparsify positive side hits, fill the hit list, compute the
     // energy depostion from positive side for the counter.
@@ -354,7 +348,7 @@ Int_t THcShowerPlane::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
     Double_t thresh_neg = fNegThresh[hit->fCounter -1];
     if(fA_Neg[hit->fCounter-1] >  thresh_neg) {
 
-      THcSignalHit *sighit = 
+      THcSignalHit *sighit =
 	(THcSignalHit*) fNegADCHits->ConstructedAt(nNegADCHits++);
       sighit->Set(hit->fCounter, fA_Neg[hit->fCounter-1]);
 
@@ -496,7 +490,7 @@ Int_t THcShowerPlane::AccumulatePedestals(TClonesArray* rawhits, Int_t nexthit)
 
   return(ihit);
 }
-    
+
 //_____________________________________________________________________________
 void THcShowerPlane::CalculatePedestals( )
 {
@@ -504,7 +498,7 @@ void THcShowerPlane::CalculatePedestals( )
   // Later add check to see if pedestals have drifted ("Danger Will Robinson!")
 
   for(Int_t i=0; i<fNelem;i++) {
-    
+
     // Positive tubes
     fPosPed[i] = ((Float_t) fPosPedSum[i]) / TMath::Max(1, fPosPedCount[i]);
     fPosSig[i] = sqrt(((Float_t)fPosPedSum2[i])/TMath::Max(1, fPosPedCount[i])
@@ -540,7 +534,7 @@ void THcShowerPlane::CalculatePedestals( )
     cout << "---------------------------------------------------------------\n";
 
   }
-  
+
 }
 
 //_____________________________________________________________________________
@@ -568,4 +562,4 @@ void THcShowerPlane::InitializePedestals( )
     fNegPedSum2[i] = 0;
     fNegPedCount[i] = 0;
   }
-} 
+}

--- a/src/THcTrigRawHit.cxx
+++ b/src/THcTrigRawHit.cxx
@@ -352,7 +352,8 @@ void THcTrigRawHit::SetReference(Int_t signal, Int_t reference) {
       << "Warning:"
       << " `THcTrigRawHit::SetReference`:"
       << " signal 0 (ADC) should not have reference time!"
-      << " Check map file!";
+      << " Check map file!"
+      << std::endl;
   }
   else if (signal == 1) {
     fReferenceTime[signal] = reference;


### PR DESCRIPTION
The new class THcRawAdcHit is meant to represent the raw ADC hits. The logic with dealing with
ADCs has become quite complex now and it would have to be multiplicated across all detectors that
have ADC channels. While this by itself is not such a big problem, fixing possible bugs in
multiple places is.

I also redesigned the THcRawShowerHit class to use the new THcRawAdcHit. The redesign was due
anyway, so I took the opportunity.

I also had to modify THcShowerArray and THcShowerPlane. They still need some work to use the
the new flash 250 data, but changes were necessary anyway.