### PR TITLE
Fixed initializer list warnings in older compilers.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -40,10 +40,10 @@ EnsureSConsVersion(2,1,0)
 #
 baseenv.Append(MAIN_DIR= Dir('.').abspath)
 baseenv.Append(HC_DIR= baseenv.subst('$MAIN_DIR'))
-baseenv.Append(HC_SRC= baseenv.subst('$HC_DIR')+'/src ') 
+baseenv.Append(HC_SRC= baseenv.subst('$HC_DIR')+'/src ')
 baseenv.Append(HA_DIR= baseenv.subst('$HC_DIR')+'/podd ')
-baseenv.Append(HA_SRC= baseenv.subst('$HA_DIR')+'/src ') 
-baseenv.Append(HA_DC= baseenv.subst('$HA_DIR')+'/hana_decode ') 
+baseenv.Append(HA_SRC= baseenv.subst('$HA_DIR')+'/src ')
+baseenv.Append(HA_DC= baseenv.subst('$HA_DIR')+'/hana_decode ')
 baseenv.Append(MAJORVERSION = '1')
 baseenv.Append(MINORVERSION = '6')
 baseenv.Append(PATCH = '0')
@@ -58,7 +58,7 @@ print "Software Version = %s" % baseenv.subst('$VERSION')
 ivercode = 65536*int(float(baseenv.subst('$SOVERSION')))+ 256*int(10*(float(baseenv.subst('$SOVERSION'))-int(float(baseenv.subst('$SOVERSION')))))+ int(float(baseenv.subst('$PATCH')))
 baseenv.Append(VERCODE = ivercode)
 #
-# evio environment 
+# evio environment
 #
 evio_libdir = os.getenv('EVIO_LIBDIR')
 evio_incdir = os.getenv('EVIO_INCDIR')
@@ -73,8 +73,8 @@ if evio_libdir is None or evio_incdir is None:
 	platform = uname[0];
 	machine = uname[4];
 	evio_name = platform + '-' + machine
-	print "evio_name = %s" % evio_name	
-	evio_local_lib = "%s/evio-%s/%s/lib" % (evio_local,evio_version,evio_name) 
+	print "evio_name = %s" % evio_name
+	evio_local_lib = "%s/evio-%s/%s/lib" % (evio_local,evio_version,evio_name)
 	evio_local_inc = "%s/evio-%s/%s/include" % (evio_local,evio_version,evio_name)
 	evio_tarfile = "%s/evio-%s.tgz" % (evio_local,evio_version)
 
@@ -177,7 +177,7 @@ def which(program):
 	import os
 	def is_exe(fpath):
 		return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-	
+
 	fpath, fname = os.path.split(program)
 	if fpath:
 		if is_exe(program):
@@ -219,6 +219,18 @@ pbaseenv=baseenv.Clone()
 pbaseenv.Prepend(LIBS=[hallclib,hallalib,dclib,eviolib])
 baseenv.Prepend(LIBS=[hallalib,dclib,eviolib])
 Export('pbaseenv')
+
+if pbaseenv['CXX'] == 'g++':
+	gxxVersion = [int(i) for i in pbaseenv['CXXVERSION'].split('.')]
+	if (gxxVersion[0] < 4) or (gxxVersion[0] == 4 and gxxVersion[1] < 4):
+		print('Error: g++ version too old! Need at least g++ 4.4!')
+		Exit(1)
+	elif gxxVersion[0] == 4 and 4 <= gxxVersion[1] < 7:
+		if '-std=c++0x' not in pbaseenv['CXXFLAGS']:
+			pbaseenv.Append(CXXFLAGS='-std=c++0x')
+	else:
+		if '-std=c++11' not in pbaseenv['CXXFLAGS']:
+			pbaseenv.Append(CXXFLAGS='-std=c++11')
 
 SConscript(dirs = directorylist,name='SConscript.py',exports='baseenv')
 

--- a/src/THcDummySpectrometer.cxx
+++ b/src/THcDummySpectrometer.cxx
@@ -94,7 +94,8 @@ Int_t THcDummySpectrometer::DefineVariables(THaAnalysisObject::EMode mode) {
   fIsSetup = (mode == kDefine);
 
   std::vector<RVarDef> vars;
-  vars.push_back({0});
+  RVarDef end {0};
+  vars.push_back(end);
 
   return DefineVarsFromList(vars.data(), mode);
 }

--- a/src/THcTrigApp.cxx
+++ b/src/THcTrigApp.cxx
@@ -95,7 +95,8 @@ Int_t THcTrigApp::DefineVariables(THaAnalysisObject::EMode mode) {
   fIsSetup = (mode == kDefine);
 
   std::vector<RVarDef> vars;
-  vars.push_back({0});
+  RVarDef end {0};
+  vars.push_back(end);
 
   return DefineVarsFromList(vars.data(), mode);
 }

--- a/src/THcTrigDet.cxx
+++ b/src/THcTrigDet.cxx
@@ -238,27 +238,30 @@ Int_t THcTrigDet::DefineVariables(THaAnalysisObject::EMode mode) {
   for (int i=0; i<fNumAdc; ++i) {
     adcValTitle.at(i) = fAdcNames.at(i) + "_adc";
     adcValVar.at(i) = TString::Format("fAdcVal[%d]", i);
-    vars.push_back({
+    RVarDef entry1 {
       adcValTitle.at(i).Data(),
       adcValTitle.at(i).Data(),
       adcValVar.at(i).Data()
-    });
+    };
+    vars.push_back(entry1);
 
     adcPedestalTitle.at(i) = fAdcNames.at(i) + "_adcPed";
     adcPedestalVar.at(i) = TString::Format("fAdcPedestal[%d]", i);
-    vars.push_back({
+    RVarDef entry2 {
       adcPedestalTitle.at(i).Data(),
       adcPedestalTitle.at(i).Data(),
       adcPedestalVar.at(i).Data()
-    });
+    };
+    vars.push_back(entry2);
 
     adcMultiplicityTitle.at(i) = fAdcNames.at(i) + "_adcMult";
     adcMultiplicityVar.at(i) = TString::Format("fAdcMultiplicity[%d]", i);
-    vars.push_back({
+    RVarDef entry3 {
       adcMultiplicityTitle.at(i).Data(),
       adcMultiplicityTitle.at(i).Data(),
       adcMultiplicityVar.at(i).Data()
-    });
+    };
+    vars.push_back(entry3);
   }
 
   // Push the variable names for TDC channels.
@@ -267,22 +270,25 @@ Int_t THcTrigDet::DefineVariables(THaAnalysisObject::EMode mode) {
   for (int i=0; i<fNumTdc; ++i) {
     tdcValTitle.at(i) = fTdcNames.at(i) + "_tdc";
     tdcValVar.at(i) = TString::Format("fTdcVal[%d]", i);
-    vars.push_back({
+    RVarDef entry1 {
       tdcValTitle.at(i).Data(),
       tdcValTitle.at(i).Data(),
       tdcValVar.at(i).Data()
-    });
+    };
+    vars.push_back(entry1);
 
     tdcMultiplicityTitle.at(i) = fTdcNames.at(i) + "_tdcMult";
     tdcMultiplicityVar.at(i) = TString::Format("fTdcMultiplicity[%d]", i);
-    vars.push_back({
+    RVarDef entry2 {
       tdcMultiplicityTitle.at(i).Data(),
       tdcMultiplicityTitle.at(i).Data(),
       tdcMultiplicityVar.at(i).Data()
-    });
+    };
+    vars.push_back(entry2);
   }
 
-  vars.push_back({0});
+  RVarDef end {0};
+  vars.push_back(end);
 
   return DefineVarsFromList(vars.data(), mode);
 }


### PR DESCRIPTION
As it turns out, this was not so easy fix. I had to do:
- add at least c++0x support to scons (works for g++ 4.4.7!)
- change how my DefineVariables works

The c++0x support is bonus, since now we can use some additional features, like auto keyword (see https://gcc.gnu.org/gcc-4.4/cxx0x_status.html).