### PR TITLE
Changed fMaxNSamplesADC to 511.

### DIFF
--- a/src/THcRawAdcHit.h
+++ b/src/THcRawAdcHit.h
@@ -37,7 +37,7 @@ class THcRawAdcHit : public TObject {
 
   protected:
     static const UInt_t fMaxNPulses = 4;
-    static const UInt_t fMaxNSamples = 160;
+    static const UInt_t fMaxNSamples = 511;
 
     Int_t fAdc[fMaxNPulses];
     Int_t fAdcTime[fMaxNPulses];

--- a/src/THcRawHodoHit.h
+++ b/src/THcRawHodoHit.h
@@ -68,7 +68,7 @@ class THcRawHodoHit : public THcRawHit {
   }
 
  protected:
-  static const UInt_t fMaxNSamplesADC = 160;
+  static const UInt_t fMaxNSamplesADC = 511;
   static const UInt_t fMaxNPulsesADC = 4;
   static const UInt_t fMaxNHitsTDC = 16;
   Int_t fADC_pos[fMaxNPulsesADC];

--- a/src/THcTrigRawHit.h
+++ b/src/THcTrigRawHit.h
@@ -38,7 +38,7 @@ class THcTrigRawHit : public THcRawHit {
 
   protected:
     static const UInt_t fMaxNPulsesAdc = 4;
-    static const UInt_t fMaxNSamplesAdc = 160;
+    static const UInt_t fMaxNSamplesAdc = 511;
     static const UInt_t fMaxNHitsTdc = 16;
     static const UInt_t fNPlanes = 2;
 


### PR DESCRIPTION
The f250 modules can produce at most 511 samples (9 bit) so it seemed reasonable to increase
the maximum number of samples in the raw hits to this value. The previous value of 160 was pulled out of thin air.