### PR TITLE
Replaced `gHcParms->Find()` calls with `gHcParms->LoadParmValues()`.

### DIFF
--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -173,9 +173,11 @@ Int_t THcCherenkov::ReadDatabase( const TDatime& date )
   string prefix = string(GetApparatus()->GetName()).substr(0, 1) + GetName();
   std::transform(prefix.begin(), prefix.end(), prefix.begin(), ::tolower);
 
-  string parname = prefix + "_tot_pmts";
-
-  fNelem = (Int_t)gHcParms->Find(parname.c_str())->GetValue(); // class.
+  DBRequest list_1[] = {
+    {"_tot_pmts", &fNelem, kInt},
+    {0}
+  };
+  gHcParms->LoadParmValues(list_1, prefix.c_str());
 
   //    fNelem = 2;      // Default if not defined
   fCerNRegions = 3;

--- a/src/THcRaster.cxx
+++ b/src/THcRaster.cxx
@@ -283,7 +283,13 @@ Int_t THcRaster::Decode( const THaEvData& evdata )
 //_____________________________________________________________________________
 Int_t THcRaster::Process( ){
 
-  Double_t eBeam = 0.001;
+	Double_t eBeam = 0.001;
+  DBRequest list[] = {
+    {"gpbeam", &eBeam, kDouble, 0, 1},
+    {0}
+  };
+  gHcParms->LoadParmValues(list);
+
   /*
     calculate raster position from ADC value.
     From ENGINE/g_analyze_misc.f -
@@ -304,9 +310,6 @@ Int_t THcRaster::Process( ){
     gfry = (gfry_adc/gfry_adcpercm)*(gfr_cal_mom/ebeam)
   */
 
-  if(gHcParms->Find("gpbeam")){
-    eBeam=*(Double_t *)gHcParms->Find("gpbeam")->GetValuePointer();
-  }
   fXpos = (fXADC/fFrXADCperCM)*(fFrCalMom/eBeam);
   fYpos = (fYADC/fFrYADCperCM)*(fFrCalMom/eBeam);
 

--- a/src/THcScintillatorPlane.cxx
+++ b/src/THcScintillatorPlane.cxx
@@ -175,18 +175,18 @@ Int_t THcScintillatorPlane::ReadDatabase( const TDatime& date )
 
   //  static const char* const here = "ReadDatabase()";
   char prefix[2];
-  char parname[100];
 
   prefix[0]=tolower(GetParent()->GetPrefix()[0]);
   prefix[1]='\0';
 
   // need this further down so read them first! GN
-  strcpy(parname,prefix);
-  strcat(parname,"scin_");
-  strcat(parname,GetName());
-  strcat(parname,"_nr");
-  fNelem = *(Int_t *)gHcParms->Find(parname)->GetValuePointer();
-  //
+  string parname = "scin_" + string(GetName()) + "_nr";
+  DBRequest list_1[] = {
+    {parname.c_str(), &fNelem, kInt},
+    {0}
+  };
+  gHcParms->LoadParmValues(list_1, prefix);
+
   // Based on the signs of these quantities in the .pos file the correspondence
   // should be bot=>left  and top=>right when comparing x and y-type scintillators
   char tmpleft[6], tmpright[6];


### PR DESCRIPTION
The calls to `Find()` need to be wrapped in checks if returned pointer is null.
Otherwise a further call to get value produces SegFault. The `LoadParmValues()`
does not suffer from this, since it throws error if non-optional parameter is
not found. The error message also tells which parameter is missing.

I still left three calls to `Find()` in `THcAnalyzer.cxx`. They are wrapped in
checks and some other things...