### PR TITLE
Add fCosmicFlag to Hodoscope class

### DIFF
--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -142,6 +142,7 @@ protected:
   UInt_t fMaxScinPerPlane,fMaxHodoScin; // max number of scin/plane; product of the first two
   Double_t fStartTimeCenter, fStartTimeSlop, fScinTdcToTime;
   Double_t fTofTolerance;
+  Int_t fCosmicFlag; //
   Double_t fPathLengthCentral;
   Double_t fScinTdcMin, fScinTdcMax; // min and max TDC values
   char** fPlaneNames;


### PR DESCRIPTION
The fCosmicFlag is used in EstimateFocalPlaneTime
The start time for the drift chamber is determined as an average
of the focal plane times for each hodo plane. Need to account for
the TOF from the hodoscope to the focal plane (z=0). For cosmic
data need to add this TOF to the corrected scintillator time, while
usually one needs to subtract this TOF. Add a flag as parameter to
switch between these modes.