### PR TITLE
Fixed "No Time to dist algorithm available" error in `THcDCHit`.

### DIFF
--- a/src/THcDCHit.h
+++ b/src/THcDCHit.h
@@ -17,12 +17,12 @@ class THcDCHit : public TObject {
 
 public:
   THcDCHit( THcDCWire* wire=NULL, Int_t rawtime=0, Double_t time=0.0,
-	    THcDriftChamberPlane* wp=0) :
+    THcDriftChamberPlane* wp=0) :
     fWire(wire), fRawTime(rawtime), fTime(time), fWirePlane(wp),
     fDist(0.0), ftrDist(kBig) {
-    ConvertTimeToDist();
-    fCorrected = 0;
-  }
+      if (wire) ConvertTimeToDist();
+      fCorrected = 0;
+    }
   virtual ~THcDCHit() {}
 
   virtual Double_t ConvertTimeToDist();
@@ -44,7 +44,7 @@ public:
   THcDriftChamberPlane* GetWirePlane() const { return fWirePlane; }
 
 
-  void     SetWire(THcDCWire * wire) { fWire = wire; }
+  void     SetWire(THcDCWire * wire) { fWire = wire; ConvertTimeToDist(); }
   void     SetRawTime(Int_t time)     { fRawTime = time; }
   void     SetTime(Double_t time)     { fTime = time; }
   void     SetDist(Double_t dist)     { fDist = dist; }


### PR DESCRIPTION
This error is triggered when there is no wire defined for hit, or
when the wire has no `GetTDDConv()` method. The ROOT dictionary
calls default constructor that doesn't set the wire and calls
`ConvertTimeToDist()` regardless.

I changed the default constructor to not call the `ConvertTimeToDist()`
if the wire is not set. I also added the call to this function
in the `SetWire()` method.