### PR TITLE
Fixed a weird bug.

### DIFF
--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -1357,7 +1357,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
     std::vector<Double_t> scin_temp;
     fScinHitPaddle.push_back(scin_temp); // Create array of hits per plane
 
-    for (UInt_t ipaddle = 0; ipaddle < fNPaddle[0]; ipaddle++ ){
+    for (UInt_t ipaddle = 0; ipaddle < fNPaddle[ip]; ipaddle++ ){
 	  fScinHitPaddle[ip].push_back(0.0);
 	  fScinHitPaddle[ip][ipaddle] = 0.0;
     }


### PR DESCRIPTION
There was a weird bug in the code, that only triggered for some runs.
It turns out, in the `THcHodoscope::FineProcess` the hits in each plane
were created only for number of paddles in first plane. SHMS, however,
has 13 paddles in first plane and 14 and 21 paddles in last two planes.

The problem is fixed now, but part of that code should be rewritten for
efficiency.