### PR TITLE
Correct filling of HitSet in THcShowerArray::CoarseProcess.

### DIFF
--- a/src/THcShowerArray.cxx
+++ b/src/THcShowerArray.cxx
@@ -399,8 +399,8 @@ Int_t THcShowerArray::CoarseProcess( TClonesArray& tracks )
   THcShowerHitSet HitSet;         //set of hits
 
   UInt_t k=0;
-  for (UInt_t i=0; i<fNRows; i++) {
-    for(UInt_t j=0; j < fNColumns; j++) {
+  for(UInt_t j=0; j < fNColumns; j++) {
+    for (UInt_t i=0; i<fNRows; i++) {
 
       if (fA_p[k] > 0) {    //hit
 


### PR DESCRIPTION
Correct filling of HitSet in THcShowerArray::CoarseProcess.

	Cycle over array of pedestal subtracted fADC signals fA_p in
	the same order as it was filled.