### PR TITLE
Added capability to set F250 parameters from PSE125.

### DIFF
--- a/src/THcHitList.cxx
+++ b/src/THcHitList.cxx
@@ -10,6 +10,10 @@
 #include "TError.h"
 #include "TClass.h"
 
+#include "THcConfigEvtHandler.h"
+#include "THaGlobals.h"
+#include "TList.h"
+
 using namespace std;
 
 THcHitList::THcHitList()
@@ -17,6 +21,7 @@ THcHitList::THcHitList()
   // Normal constructor.
 
   fRawHitList = NULL;
+  fPSE125 = NULL;
 
 }
 
@@ -101,6 +106,10 @@ void THcHitList::InitHitList(THaDetMap* detmap,
     }
   }
 
+  fPSE125 = static_cast<THcConfigEvtHandler*>(gHaEvtHandlers->FindObject("HC"));
+  if (!fPSE125) {
+    cout << "THcHitList::InitHitList : Prestart event 125 not found." << endl;
+  }
 }
 
 Int_t THcHitList::DecodeToHitList( const THaEvData& evdata ) {
@@ -111,6 +120,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata ) {
   // multiple signal types (e.g. ADC+, ADC-, TDC+, TDC-), or multiple
   // hits for multihit tdcs.
   // The hit list is sorted (by plane, counter) after filling.
+
 
   // cout << " Clearing TClonesArray " << endl;
   fRawHitList->Clear( );
@@ -212,6 +222,15 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata ) {
 	  }
 	}
       } else {			// This is a Flash ADC
+
+        if (fPSE125) {  // Set F250 parameters.
+          rawhit->SetF250Params(
+            fPSE125->GetNSA(d->crate),
+            fPSE125->GetNSB(d->crate),
+            fPSE125->GetNPED(d->crate)
+          );
+        }
+
 	// Copy the samples
 	Int_t nsamples=evdata.GetNumEvents(Decoder::kSampleADC, d->crate, d->slot, chan);
 

--- a/src/THcHitList.h
+++ b/src/THcHitList.h
@@ -18,6 +18,7 @@ using namespace std;
 //////////////////////////////////////////////////////////////////////////
 
 //class THaDetMap;
+class THcConfigEvtHandler;
 
 class THcHitList {
 
@@ -57,6 +58,8 @@ protected:
   Int_t fNRefIndex;
   UInt_t fNSignals;
   THcRawHit::ESignalType *fSignalTypes;
+
+  THcConfigEvtHandler* fPSE125;
 
   ClassDef(THcHitList,0);  // List of raw hits sorted by plane, counter
 };

--- a/src/THcRawAdcHit.cxx
+++ b/src/THcRawAdcHit.cxx
@@ -167,6 +167,14 @@ Returns 0 if no signal pedestal is set.
 \brief Gets pedestal subtracted integral of samples. In channels.
 */
 
+/**
+\fn void THcRawAdcHit::SetF250Params(Int_t NSA, Int_t NSB, Int_t NPED)
+\brief Sets F250 parameters used for pedestal subtraction.
+\param [in] NSA NSA parameter of F250 modules.
+\param [in] NSB NSB parameter of F250 modules.
+\param [in] NPED NPED parameter of F250 modules.
+*/
+
 // TODO: Disallow using both SetData and SetDataTimePedestalPeak.
 
 
@@ -447,6 +455,13 @@ Int_t THcRawAdcHit::GetSampleIntRaw() const {
 
 Double_t THcRawAdcHit::GetSampleInt() const {
   return static_cast<Double_t>(GetSampleIntRaw()) - GetPed()*static_cast<Double_t>(fNSamples);
+}
+
+
+void THcRawAdcHit::SetF250Params(Int_t NSA, Int_t NSB, Int_t NPED) {
+  fNPedestalSamples = NPED;
+  fNPeakSamples = NSA + NSB;
+  fPeakPedestalRatio = 1.0*fNPeakSamples/fNPedestalSamples;
 }
 
 

--- a/src/THcRawAdcHit.h
+++ b/src/THcRawAdcHit.h
@@ -46,6 +46,8 @@ class THcRawAdcHit : public TObject {
     Int_t GetSampleIntRaw() const;
     Double_t GetSampleInt() const;
 
+    void SetF250Params(Int_t NSA, Int_t NSB, Int_t NPED);
+
   protected:
     static const UInt_t fMaxNPulses = 4;
     static const UInt_t fMaxNSamples = 511;

--- a/src/THcRawHit.h
+++ b/src/THcRawHit.h
@@ -42,6 +42,8 @@ public:
   virtual Bool_t HasReference(Int_t signal) {return kFALSE;};
   virtual Int_t GetReference(Int_t signal) {return 0;};
 
+  virtual void SetF250Params(Int_t NSA, Int_t NSB, Int_t NPED) {};
+
   // Derived objects must be sortable and supply Compare method
   //  virtual Bool_t  IsSortable () const {return kFALSE; }
   //  virtual Int_t   Compare(const TObject* obj) const {return 0;}

--- a/src/THcRawHodoHit.cxx
+++ b/src/THcRawHodoHit.cxx
@@ -198,4 +198,11 @@ THcRawTdcHit& THcRawHodoHit::GetRawTdcHitNeg() {
 }
 
 
+void THcRawHodoHit::SetF250Params(Int_t NSA, Int_t NSB, Int_t NPED) {
+  for (Int_t iAdcSig=0; iAdcSig<fNAdcSignals; ++iAdcSig) {
+    fAdcHits[iAdcSig].SetF250Params(NSA, NSB, NPED);
+  }
+}
+
+
 ClassImp(THcRawHodoHit)

--- a/src/THcRawHodoHit.h
+++ b/src/THcRawHodoHit.h
@@ -39,6 +39,8 @@ class THcRawHodoHit : public THcRawHit {
     THcRawTdcHit& GetRawTdcHitPos();
     THcRawTdcHit& GetRawTdcHitNeg();
 
+    void SetF250Params(Int_t NSA, Int_t NSB, Int_t NPED);
+
   protected:
     static const Int_t fNAdcSignals = 2;
     static const Int_t fNTdcSignals = 2;

--- a/src/THcRawShowerHit.cxx
+++ b/src/THcRawShowerHit.cxx
@@ -142,4 +142,11 @@ THcRawAdcHit& THcRawShowerHit::GetRawAdcHitNeg() {
 }
 
 
+void THcRawShowerHit::SetF250Params(Int_t NSA, Int_t NSB, Int_t NPED) {
+  for (Int_t iAdcSig=0; iAdcSig<fNAdcSignals; ++iAdcSig) {
+    fAdcHits[iAdcSig].SetF250Params(NSA, NSB, NPED);
+  }
+}
+
+
 ClassImp(THcRawShowerHit)

--- a/src/THcRawShowerHit.h
+++ b/src/THcRawShowerHit.h
@@ -31,6 +31,8 @@ class THcRawShowerHit : public THcRawHit {
     THcRawAdcHit& GetRawAdcHitPos();
     THcRawAdcHit& GetRawAdcHitNeg();
 
+    void SetF250Params(Int_t NSA, Int_t NSB, Int_t NPED);
+
   protected:
     static const Int_t fNAdcSignals = 2;
 

--- a/src/THcTrigRawHit.cxx
+++ b/src/THcTrigRawHit.cxx
@@ -121,6 +121,11 @@ It supports rich data from flash 250 ADC modules.
 \brief Gets reference to THcRawTdcHit.
 */
 
+/**
+\fn void THcTrigRawHit::SetF250Params(Int_t NSA, Int_t NSB, Int_t NPED)
+\brief See THcRawAdcHit::SetF250Params.
+*/
+
 // TODO: Check if signal matches plane.
 
 #include "THcTrigRawHit.h"
@@ -304,6 +309,13 @@ THcRawAdcHit& THcTrigRawHit::GetRawAdcHit() {
 
 THcRawTdcHit& THcTrigRawHit::GetRawTdcHit() {
   return fTdcHits[0];
+}
+
+
+void THcTrigRawHit::SetF250Params(Int_t NSA, Int_t NSB, Int_t NPED) {
+  for (Int_t iAdcSig=0; iAdcSig<fNAdcSignals; ++iAdcSig) {
+    fAdcHits[iAdcSig].SetF250Params(NSA, NSB, NPED);
+  }
 }
 
 

--- a/src/THcTrigRawHit.h
+++ b/src/THcTrigRawHit.h
@@ -33,6 +33,8 @@ class THcTrigRawHit : public THcRawHit {
     THcRawAdcHit& GetRawAdcHit();
     THcRawTdcHit& GetRawTdcHit();
 
+    void SetF250Params(Int_t NSA, Int_t NSB, Int_t NPED);
+
   protected:
     static const Int_t fNAdcSignals = 1;
     static const Int_t fNTdcSignals = 1;


### PR DESCRIPTION
PSE125 holds information about setting of F250 modules. Now this
information is used to set `fNPedestalSamples` and `fNPeakSamples`
parameters of `THcRawAdcHit`.

This is done through `THcHitList`, since it has information about
which crate and module each channel is in. Currently, the information
is set for each event, because of the hitlist and analyzer design.

I added the neccessary support for these changes to all raw hit
classes.