### PR TITLE
Modified THcHodoscope::FineProcess for dumping data for hodo calibrations

### DIFF
--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -873,6 +873,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
   Int_t timehist[200];
   // -------------------------------------------------
 
+  //  fDumpOut << " ntrack =  " << ntracks  << endl;
 
   if (tracks.GetLast()+1 > 0 ) {
 
@@ -983,7 +984,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
 
 	  // Index to access the 2d arrays of paddle/scintillator properties
 	  Int_t fPIndex = GetScinIndex(ip,paddle);
-
+          
 	  if ( TMath::Abs( scinCenter - scinTrnsCoord ) <
 	       ( fPlanes[ip]->GetSize() * 0.5 + fPlanes[ip]->GetHodoSlop() ) ){ // Line 293
 
@@ -1090,7 +1091,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
 	THcHodoHit *hit = fTOFPInfo[ih].hit;
 	Int_t iphit = fTOFPInfo[ih].hitNumInPlane;
 	Int_t ip = fTOFPInfo[ih].planeIndex;
-
+	//         fDumpOut << " looping over hits = " << ih << " plane = " << ip+1 << endl;
 	GoodFlags flags;
 	// Flags are used by THcHodoEff
 	fGoodFlags[itrack][ip].push_back(flags);
@@ -1346,6 +1347,10 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
     } // Main loop over tracks ends here.
 
   } // If condition for at least one track
+
+   if(fDumpTOF && ntracks==1 ) {
+	      fDumpOut << "0 "  << endl;
+	    }
 
   //-----------------------------------------------------------------------
   //
@@ -1605,9 +1610,6 @@ Int_t THcHodoscope::FineProcess( TClonesArray& tracks )
        ( fChern->GetCerNPE() > fNCerNPE ) && ( tracks.GetLast() + 1 > 0 ) ) {
       fScinDid = 1;
   }
-	    if(fDumpTOF && ntracks==1) {
-	      fDumpOut << "0 "  << endl;
-	    }
 
   return 0;
 


### PR DESCRIPTION
Moved the writing out of the "0" to  fDumpOut file for hodo calibrations
to immediatiately after the TOF with track info calculations.
Before it had been after the lines

  if ( !fChern || !fShower ) {
    return 0;
  }

so if Cerenkov and shower were not used in replay the code would not get
to write out the "0" which is used to denote each end of an event data for
the calibration script.