### PR TITLE
Modified hodoscope and scintillatorplane code for hodo calibration

### DIFF
--- a/hc_hodo_calib/tofcal.f
+++ b/hc_hodo_calib/tofcal.f
@@ -50,7 +50,7 @@
       open(unit=9,file=filename,err=998)
        if(filename(1:1).ne.'h'.and.filename(1:1).ne.'s') then
         write(6,'(1x,''error, input file name '',
-     >   '' should start with h or s'')')
+     >   '' sould start with h or s'')')
         goto 999
        endif
        write(*,*) ' filling adc histograms'
@@ -102,7 +102,7 @@ c         write(13,'(1x,''adcmin='',f6.1)') adcmin(i)
 
 ! Do everything twice, 2nd time with tighter tolerance (ttol) on
 ! time differences, based on first pass
-      ttol=5.0
+      ttol=20.0
       do iloop=1,2
          write(*,*) ' loop = ',iloop
 ! Initialize the fitting arrays
@@ -128,7 +128,6 @@ c         write(13,'(1x,''adcmin='',f6.1)') adcmin(i)
           n=n+1
           read(string,'(1x,i1,2i3,5f10.3)') ipn,ipl,idt, 
      >      tr(n),p(n),zc(n),tc1(n),adc(n)
-
 ! linearize the detector numbers
           idet(n) = 100*(ipn-1) + 20*(ipl-1) + idt
           if(idet(n).lt.1.or.idet(n).gt.200) write(6,'(1x,
@@ -149,7 +148,6 @@ c          adc(n) = min(500, max(0., adc(n)))
 
 ! Loop over all pairs, if at least 6
  11     if(n.ge.6) then
-
 ! see if this is first time a detector is used
           do j=1,n
             nhit(idet(j))=nhit(idet(j))+1
@@ -158,7 +156,7 @@ c          adc(n) = min(500, max(0., adc(n)))
 ! Note that detector had has a fixed time offset (ip1) of zero
 ! since all times are relative)
             if(nhit(idet(j)).eq.1) then
-              if(idet(j).eq.4) then
+              if(idet(j).eq.10) then
                 ip1(idet(j))=0
               else
 
@@ -334,17 +332,17 @@ c          adc(n) = min(500, max(0., adc(n)))
       enddo
 
       write(10+iloop,'(/a,''hodo_pos_invadc_linear ='',3(f8.2,'',''),
-     >  f8.2)')filename(1:1),( -1./min(-0.02,vel(i)),i=1,80,20)
+     >  f8.2)')filename(1:1),( -1./min(-1./15.,vel(i)),i=1,80,20)
       do j=2,16
        write(10+iloop,'(1x,''                        '',3(f8.2,'',''),
-     >  f8.2)')(-1./min(-0.02,vel(i)),i=j,79+j,20)
+     >  f8.2)')(-1./min(-1./15.,vel(i)),i=j,79+j,20)
       enddo
 
       write(10+iloop,'(/a,''hodo_neg_invadc_linear ='',3(f8.2,'',''),
-     >  f8.2)')filename(1:1),( -1./min(-0.02,vel(i)),i=101,180,20)
+     >  f8.2)')filename(1:1),( -1./min(-1./15.,vel(i)),i=101,180,20)
       do j=2,16
        write(10+iloop,'(1x,''                        '',3(f8.2,'',''),
-     >  f8.2)')(-1./min(-0.02,vel(i)),i=100+j,179+j,20)
+     >  f8.2)')(-1./min(-1./15.,vel(i)),i=100+j,179+j,20)
       enddo
 
       write(10+iloop,'(/a,''hodo_pos_invadc_adc='',3(f9.2,'',''),

--- a/src/THcHitList.cxx
+++ b/src/THcHitList.cxx
@@ -203,7 +203,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata ) {
 	    Int_t reftime = evdata.GetData(d->crate, d->slot, d->refchan, 0);
 	    rawhit->SetReference(signal, reftime);
 	  } else {
-	    cout << "HitList: refchan " << d->refchan <<
+	    cout << "HitList(event=" << evdata.GetEvNum() << "): refchan " << d->refchan <<
 	      " missing for (" << d->crate << ", " << d->slot <<
 	      ", " << chan << ")" << endl;
 	  }
@@ -212,7 +212,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata ) {
 	    if(fRefIndexMaps[d->refindex].hashit) {
 	      rawhit->SetReference(signal, fRefIndexMaps[d->refindex].reftime);
 	    } else {
-	      cout << "HitList: refindex " << d->refindex <<
+	      cout << "HitList(event=" << evdata.GetEvNum() << "): refindex " << d->refindex <<
           " (" << fRefIndexMaps[d->refindex].crate <<
           ", " << fRefIndexMaps[d->refindex].slot <<
           ", " << fRefIndexMaps[d->refindex].channel << ")" <<
@@ -223,7 +223,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata ) {
 	}
       } else {			// This is a Flash ADC
 
-        if (fPSE125 && fPSE125->IsPresent(d->crate)) {  // Set F250 parameters.
+        if (fPSE125) {  // Set F250 parameters.
           rawhit->SetF250Params(
             fPSE125->GetNSA(d->crate),
             fPSE125->GetNSB(d->crate),

--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -126,6 +126,7 @@ protected:
   // Calibration
 
   // Per-event data
+  Bool_t fSHMS;
   Bool_t fGoodStartTime;
   Double_t fStartTime;
   Double_t fFPTimeAll;
@@ -212,8 +213,9 @@ protected:
   Int_t        fNHodoscopes;
 
   Int_t        fDumpTOF;
-  ofstream      fDumpOut;
+  ofstream    fDumpOut;
   string       fTOFDumpFile;
+  Bool_t      fGoodEventTOFCalib;
 
 
   Int_t fHitSweet1X;

--- a/src/THcScintillatorPlane.cxx
+++ b/src/THcScintillatorPlane.cxx
@@ -214,15 +214,19 @@ Int_t THcScintillatorPlane::ReadDatabase( const TDatime& date )
     {"hodo_adc_mode", &fADCMode, kInt, 0, 1},
     {"hodo_pedestal_scale", &fADCPedScaleFactor, kDouble, 0, 1},
     {"hodo_adc_diag_cut", &fADCDiagCut, kInt, 0, 1},
-    {0}
+   {"cosmicflag",                       &fCosmicFlag,            kInt,            0,  1},
+     {0}
   };
 
   fTofUsingInvAdc = 1;
   fADCMode = kADCStandard;
   fADCPedScaleFactor = 1.0;
   fADCDiagCut = 50.0;
-  gHcParms->LoadParmValues((DBRequest*)&list,prefix);
-  // fetch the parameter from the temporary list
+  fCosmicFlag=0;
+   gHcParms->LoadParmValues((DBRequest*)&list,prefix);
+   if (fCosmicFlag==1) cout << " setup for cosmics in scint plane"<< endl;
+  cout << " cosmic flag = " << fCosmicFlag << endl;
+ // fetch the parameter from the temporary list
 
   // Retrieve parameters we need from parent class
   // Common for all planes
@@ -675,14 +679,24 @@ Int_t THcScintillatorPlane::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
 	  timec_neg -= (hit_position-fPosRight)/
 	    fHodoNegInvAdcLinear[index];
 	  scin_corrected_time = 0.5*(timec_pos+timec_neg);
+	  if (fCosmicFlag) {
+	  postime = timec_pos + (fZpos+(index%2)*fDzpos)/(29.979*fBetaNominal);
+	  negtime = timec_neg + (fZpos+(index%2)*fDzpos)/(29.979*fBetaNominal);
+	  } else {
 	  postime = timec_pos - (fZpos+(index%2)*fDzpos)/(29.979*fBetaNominal);
 	  negtime = timec_neg - (fZpos+(index%2)*fDzpos)/(29.979*fBetaNominal);
+	  }
 	} else {
 	  postime=timec_pos-(fPosLeft-hit_position)/fHodoVelLight[index];
 	  negtime=timec_neg-(hit_position-fPosRight)/fHodoVelLight[index];
 	  scin_corrected_time = 0.5*(postime+negtime);
-	  postime = postime-(fZpos+(index%2)*fDzpos)/(29.979*fBetaNominal);
-	  negtime = negtime-(fZpos+(index%2)*fDzpos)/(29.979*fBetaNominal);
+	  if (fCosmicFlag) {
+	  postime = timec_pos + (fZpos+(index%2)*fDzpos)/(29.979*fBetaNominal);
+	  negtime = timec_neg + (fZpos+(index%2)*fDzpos)/(29.979*fBetaNominal);
+	  } else {
+	  postime = timec_pos - (fZpos+(index%2)*fDzpos)/(29.979*fBetaNominal);
+	  negtime = timec_neg - (fZpos+(index%2)*fDzpos)/(29.979*fBetaNominal);
+	  }
 	}
 	//        cout << fNScinHits<< " " << timec_pos << " " << timec_neg << endl;
         ((THcHodoHit*) fHodoHits->At(fNScinHits))->SetPaddleCenter(fPosCenter[index]);

--- a/src/THcScintillatorPlane.h
+++ b/src/THcScintillatorPlane.h
@@ -94,6 +94,7 @@ class THcScintillatorPlane : public THaSubDetector {
   TClonesArray* frNegAdcPulseInt;
   TClonesArray* frNegAdcPulseAmp;
 
+  Int_t fCosmicFlag; //
   Int_t fPlaneNum;		/* Which plane am I 1-4 */
   UInt_t fTotPlanes;            /* so we can read variables that are not indexed by plane id */
   UInt_t fNelem;		/* Need since we don't inherit from


### PR DESCRIPTION
Temporarily set THcHodoscope.cxx so that only the first three planes are used to calculate the focal
plane time and beta.
In THcHodoscope , modified format for writing out the dump file used in hodo calibration.
Add cosmicflag to THcScintillatorPLane so the corrected time is done right for cosmics.
Modified hc_hodo_calib/tofcal.f so that it uses detector 10 as the reference
and that it writes out better defaults for parameters in there are not enough events for a PMT.