### PR TITLE
Modify THcDC::CoarseTrack and THcDC::TrackFit

### DIFF
--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -147,8 +147,12 @@ protected:
   Double_t* fPlaneTimeZero;
   Double_t* fSigma;
   Double_t** fPlaneCoeffs;
-
-  // For accumulating statitics for efficiencies
+  //
+  Double_t fX_fp_best;
+  Double_t fY_fp_best;
+  Double_t fXp_fp_best;
+  Double_t fYp_fp_best;
+ // For accumulating statitics for efficiencies
   Int_t fTotEvents;
   Int_t* fNChamHits;
   Int_t* fPlaneEvents;


### PR DESCRIPTION
Add variables fX_fp_best,fY_fp_best,fXp_fp_best,fYp_fp_best to THcDC.h
Modified THcDC::CoarseTrack so that the variables are filled with the
quantities from the track with the smallest chi-squared.
Modified THcDC::TrackFit so that the fResidual per plane is filled with
for the track with the lowest chi-squared.
Modified THcDC::DefineVariables so that access the variables as
dc.x_fp,dc.y_fp,dc.xp_fp and dc.yp_fp