### PR TITLE
Modified THcHallCSpectrometer.cxx and THcHodoscope.cxx

### DIFF
--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -93,11 +93,8 @@ public:
   Int_t GetTdcOffset(Int_t ip) const { return fTdcOffset[ip];}
 
 
-  //  Double_t GetBeta() const {return fBeta[];}
+  Double_t GetBeta() const {return fBeta;}
 
-  // Not used
-  //Double_t GetBeta(Int_t itrack) const {return fBeta[itrack];} // Ahmed
-  //  Int_t GetEvent(){ return fCheckEvent;}
 
   Double_t GetHodoPosSigma(Int_t iii) const {return fHodoPosSigma[iii];}
   Double_t GetHodoNegSigma(Int_t iii) const {return fHodoNegSigma[iii];}
@@ -132,7 +129,7 @@ protected:
   Double_t fFPTimeAll;
   Int_t fNfptimes;
 
-  Double_t     fBetaP;
+  Double_t     fBeta;
 
   Double_t     fBetaNoTrk;
   Double_t     fBetaNoTrkChiSq;


### PR DESCRIPTION
The change was made so that NonTrackingDetector could have information
on the "best" track in their FineProcess method.

In THcHallCSpectrometer::FindVertices the "best" track will be selected
and the Track object will its SetIndex method to set the index to 0 for
the best track. The other track will have index=1 or greater.

In the NonTrackingDetector FineProcess, the track that is selected to
be the "best" can be found by looping through the tracks checking
track index using Track.GetIndex() for find the track with Index=0.

In  the NonTrackingDetector's CoarseProcess they need to set quantities
for the Track object needed for selection of "best" track for the
"prune" and "usingscin" track selection methods.

1) In THcHallCSpectrometer:
  a) Moved selection methods of "best" track from TrackCalc to FindVertices.
  b) Removed setting of Golden Track in the selection methods.
  c) Add setting of Track Index=0 for "best" track in each selection method.
  d) Modified TrackCalc method to loop through Track object and find
     the track with Index=0 and set the Golden Track equal to this Track.

2) In THcHodoscope.cxx
  a) Moved all calculations in FineProcess into CoarseProcess
  b) CoarseProcess calculates the scintillator Beta for each Track
     and does Track->SetBeta.
  c) In determination "zcor" for corrected hits times
      use fBetaNominal instead fBetap from track. Still use Track
      to get distance.
  c) Eliminate fBetap variable which was using the Track momentum
  d) Add variable fBeta which is just from scintillator times.
  e) In FineProcess fill fBeta with the the beta associated
     with the "best" track determined by selecting Track with index=0