### PR TITLE
Add method to THcRawAdcHit

### DIFF
--- a/src/THcRawAdcHit.h
+++ b/src/THcRawAdcHit.h
@@ -19,6 +19,7 @@ class THcRawAdcHit : public TObject {
     );
 
     Int_t GetRawData(UInt_t iPulse=0) const;
+    Double_t GetF250_PeakPedestalRatio() {return fPeakPedestalRatio;};
 
     Double_t GetAverage(UInt_t iSampleLow, UInt_t iSampleHigh) const;
     Int_t GetIntegral(UInt_t iSampleLow, UInt_t iSampleHigh) const;


### PR DESCRIPTION
Add method
GetF250_PeakPedestalRatio() {return fPeakPedestalRatio;};

so that a detector class can calculate the pedestal that was used
in determining the pedestal subtracted FADC Pulse Integral.

This is useful if the detector class wants to set a threshold
above the pedestal.