### PR TITLE
Modify THcHodoscope.cxx

### DIFF
--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -201,8 +201,6 @@ protected:
   Int_t        fTestSum;
   Int_t        fTrackEffTestNScinPlanes;
   Int_t        fGoodScinHits;
-  Int_t        fScinShould;
-  Int_t        fScinDid;
   Int_t*       fxLoScin;
   Int_t*       fxHiScin;
   Int_t*       fyLoScin;


### PR DESCRIPTION
The change was in part of code which calculates the fiducial
 area of the scintillators where the drift chamber should
 have had a track. This sets fGoodScintHits=1 or 0
 Used to calculate the DC track efficiency

1) Eliminate variables fScinShould and fScindid. These will
   be defined in the cuts file.
2) Eliminate code which determined bestXpScin and bestYpScin since
   since these variables were never used.
3) Initialized  fHitSweet1X,fHitSweet1Y,fHitSweet2X and
   fHitSweet2Y to zero.
4) Change so that loops over number of paddles do not
    assume that X (Y) planes for Ch1 and Ch2 have same number
    of paddles.