### PR TITLE
THcScalerEvtHandler fixes

### DIFF
--- a/src/THcScalerEvtHandler.h
+++ b/src/THcScalerEvtHandler.h
@@ -34,10 +34,10 @@ public:
    virtual ~THcScalerEvtHandler();
 
    Int_t Analyze(THaEvData *evdata);
-  virtual void AddEventType(Int_t evtype);
+   virtual void AddEventType(Int_t evtype);
    virtual EStatus Init( const TDatime& run_time);
    virtual Int_t End( THaRunBase* r=0 );
-
+   virtual void SetUseFirstEvent(Bool_t b = kFALSE) {fUseFirstEvent = b;}
 
 private:
 
@@ -54,6 +54,7 @@ private:
    Double_t *dvars;
    Double_t *dvarsFirst;
    TTree *fScalerTree;
+   Bool_t fUseFirstEvent;
 
    THcScalerEvtHandler(const THcScalerEvtHandler& fh);
    THcScalerEvtHandler& operator=(const THcScalerEvtHandler& fh);


### PR DESCRIPTION
  Process slot with clock first so that time is available to other slots
  Add option to use data in first scaler event
     (handler->SetUseFirstEvent(Bool_t)) instead of subtracting first event
     from subsequent events