### PR TITLE
Pooser aero work

### DIFF
--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -441,7 +441,7 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
   UInt_t nrPosAdcHits = 0;
   UInt_t nrNegAdcHits = 0;
 
-  cout << ":=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:" << endl;
+  //cout << ":=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:" << endl;
 
   while(ihit < fNhits) {
     THcAerogelHit* hit = (THcAerogelHit *) fRawHitList->At(ihit);
@@ -495,15 +495,15 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
     if(fPosNpe[npmt] > 0.3) {fNADCPosHits++; fNGoodHits++;}
     if(fNegNpe[npmt] > 0.3) {fNADCNegHits++; fNGoodHits++;}
     
-    cout << "\nPMT Num = " << npmt << endl; 
-    cout << "posAdcPulseInt = " << posAdcPulseInt << "\t" 
-    	 << "fPosGain = " << fPosGain[npmt] << "\t" 
-    	 << "fPosNpe = " << fPosNpe[npmt] << "\t" << endl;
-    cout << "negAdcPulseInt = " << negAdcPulseInt << "\t" 
-    	 << "fNegGain = " << fNegGain[npmt] << "\t" 
-    	 << "fNegNpe = " << fNegNpe[npmt] << "\t" << endl;
-    cout << "fPosNpeSum = " << fPosNpeSum << "\t" 
-    	 << "fNegNpeSum = " << fNegNpeSum << endl;
+    // cout << "\nPMT Num = " << npmt << endl; 
+    // cout << "posAdcPulseInt = " << posAdcPulseInt << "\t" 
+    // 	 << "fPosGain = " << fPosGain[npmt] << "\t" 
+    // 	 << "fPosNpe = " << fPosNpe[npmt] << "\t" << endl;
+    // cout << "negAdcPulseInt = " << negAdcPulseInt << "\t" 
+    // 	 << "fNegGain = " << fNegGain[npmt] << "\t" 
+    // 	 << "fNegNpe = " << fNegNpe[npmt] << "\t" << endl;
+    // cout << "fPosNpeSum = " << fPosNpeSum << "\t" 
+    // 	 << "fNegNpeSum = " << fNegNpeSum << endl;
     
     // 6 GeV calculations
     Int_t adc_pos;
@@ -597,7 +597,7 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
   // If total hits are 0, then give a noticable ridiculous NPE
   if(fNhits < 1) fNpeSum = 0.0;
   
-  cout << "\nfNpeSum = " << fNpeSum << "\n" << endl;
+  // cout << "\nfNpeSum = " << fNpeSum << "\n" << endl;
    
   // The following code is in the fortran.  It probably doesn't work
   // right because the arrays are not cleared first and the aero_ep,

--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -1,10 +1,10 @@
 /** \class THcAerogel
     \ingroup Detectors
 
-Class for an Aerogel detector consisting of pairs of PMT's
-attached to a diffuser box
-Will have a fixed number of pairs, but need to later make this
-configurable.
+    Class for an Aerogel detector consisting of pairs of PMT's
+    attached to a diffuser box
+    Will have a fixed number of pairs, but need to later make this
+    configurable.
 
 */
 
@@ -41,37 +41,33 @@ THcAerogel::THcAerogel( const char* name, const char* description,
   THaNonTrackingDetector(name,description,apparatus)
 {
   // Normal constructor with name and description
-  fPosTDCHits = new TClonesArray("THcSignalHit",16);
-  fNegTDCHits = new TClonesArray("THcSignalHit",16);
-  fPosADCHits = new TClonesArray("THcSignalHit",16);
-  fNegADCHits = new TClonesArray("THcSignalHit",16);
+  fPosTDCHits = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*16);
+  fNegTDCHits = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*16);
 
-  frPosAdcPedRaw = new TClonesArray("THcSignalHit", 16);
-  frPosAdcPulseIntRaw = new TClonesArray("THcSignalHit", 16);
-  frPosAdcPulseAmpRaw = new TClonesArray("THcSignalHit", 16);
-  frPosAdcPulseTimeRaw = new TClonesArray("THcSignalHit", 16);
+  fPosADCHits = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
+  fNegADCHits = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
 
-  frPosAdcPed = new TClonesArray("THcSignalHit", 16);
-  frPosAdcPulseInt = new TClonesArray("THcSignalHit", 16);
-  frPosAdcPulseAmp = new TClonesArray("THcSignalHit", 16);
+  frPosAdcPedRaw       = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
+  frPosAdcPulseIntRaw  = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
+  frPosAdcPulseAmpRaw  = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
+  frPosAdcPulseTimeRaw = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
+  frPosAdcPed          = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
+  frPosAdcPulseInt     = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
+  frPosAdcPulseAmp     = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
 
-  frNegAdcPedRaw = new TClonesArray("THcSignalHit", 16);
-  frNegAdcPulseIntRaw = new TClonesArray("THcSignalHit", 16);
-  frNegAdcPulseAmpRaw = new TClonesArray("THcSignalHit", 16);
-  frNegAdcPulseTimeRaw = new TClonesArray("THcSignalHit", 16);
-
-  frNegAdcPed = new TClonesArray("THcSignalHit", 16);
-  frNegAdcPulseInt = new TClonesArray("THcSignalHit", 16);
-  frNegAdcPulseAmp = new TClonesArray("THcSignalHit", 16);
+  frNegAdcPedRaw       = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
+  frNegAdcPulseIntRaw  = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
+  frNegAdcPulseAmpRaw  = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
+  frNegAdcPulseTimeRaw = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
+  frNegAdcPed          = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
+  frNegAdcPulseInt     = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
+  frNegAdcPulseAmp     = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
   
-  fPosAdcErrorFlag = new TClonesArray("THcSignalHit", 16);
-  fNegAdcErrorFlag = new TClonesArray("THcSignalHit", 16);
-
-  
+  fPosAdcErrorFlag = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
+  fNegAdcErrorFlag = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
 
   InitArrays();
 
-//  fTrackProj = new TClonesArray( "THaTrackProj", 5 );
 }
 
 //_____________________________________________________________________________
@@ -81,26 +77,25 @@ THcAerogel::THcAerogel( ) :
   // Constructor
   fPosTDCHits = NULL;
   fNegTDCHits = NULL;
+
   fPosADCHits = NULL;
   fNegADCHits = NULL;
 
-  frPosAdcPedRaw = NULL;
-  frPosAdcPulseIntRaw = NULL;
-  frPosAdcPulseAmpRaw = NULL;
+  frPosAdcPedRaw       = NULL;
+  frPosAdcPulseIntRaw  = NULL;
+  frPosAdcPulseAmpRaw  = NULL;
   frPosAdcPulseTimeRaw = NULL;
+  frPosAdcPed          = NULL;
+  frPosAdcPulseInt     = NULL;
+  frPosAdcPulseAmp     = NULL;
 
-  frPosAdcPed = NULL;
-  frPosAdcPulseInt = NULL;
-  frPosAdcPulseAmp = NULL;
-
-  frNegAdcPedRaw = NULL;
-  frNegAdcPulseIntRaw = NULL;
-  frNegAdcPulseAmpRaw = NULL;
+  frNegAdcPedRaw       = NULL;
+  frNegAdcPulseIntRaw  = NULL;
+  frNegAdcPulseAmpRaw  = NULL;
   frNegAdcPulseTimeRaw = NULL;
-
-  frNegAdcPed = NULL;
-  frNegAdcPulseInt = NULL;
-  frNegAdcPulseAmp = NULL;
+  frNegAdcPed          = NULL;
+  frNegAdcPulseInt     = NULL;
+  frNegAdcPulseAmp     = NULL;
 
   fPosAdcErrorFlag = NULL;
   fNegAdcErrorFlag = NULL;
@@ -115,29 +110,28 @@ THcAerogel::~THcAerogel()
   // Destructor
   delete fPosTDCHits; fPosTDCHits = NULL;
   delete fNegTDCHits; fNegTDCHits = NULL;
+
   delete fPosADCHits; fPosADCHits = NULL;
   delete fNegADCHits; fNegADCHits = NULL;
 
-  delete frPosAdcPedRaw; frPosAdcPedRaw = NULL;
-  delete frPosAdcPulseIntRaw; frPosAdcPulseIntRaw = NULL;
-  delete frPosAdcPulseAmpRaw; frPosAdcPulseAmpRaw = NULL;
+  delete frPosAdcPedRaw;       frPosAdcPedRaw       = NULL;
+  delete frPosAdcPulseIntRaw;  frPosAdcPulseIntRaw  = NULL;
+  delete frPosAdcPulseAmpRaw;  frPosAdcPulseAmpRaw  = NULL;
   delete frPosAdcPulseTimeRaw; frPosAdcPulseTimeRaw = NULL;
+  delete frPosAdcPed;          frPosAdcPed          = NULL;
+  delete frPosAdcPulseInt;     frPosAdcPulseInt     = NULL;
+  delete frPosAdcPulseAmp;     frPosAdcPulseAmp     = NULL;
 
-  delete frPosAdcPed; frPosAdcPed = NULL;
-  delete frPosAdcPulseInt; frPosAdcPulseInt = NULL;
-  delete frPosAdcPulseAmp; frPosAdcPulseAmp = NULL;
-
-  delete frNegAdcPedRaw; frNegAdcPedRaw = NULL;
-  delete frNegAdcPulseIntRaw; frNegAdcPulseIntRaw = NULL;
-  delete frNegAdcPulseAmpRaw; frNegAdcPulseAmpRaw = NULL;
+  delete frNegAdcPedRaw;       frNegAdcPedRaw       = NULL;
+  delete frNegAdcPulseIntRaw;  frNegAdcPulseIntRaw  = NULL;
+  delete frNegAdcPulseAmpRaw;  frNegAdcPulseAmpRaw  = NULL;
   delete frNegAdcPulseTimeRaw; frNegAdcPulseTimeRaw = NULL;
+  delete frNegAdcPed;          frNegAdcPed          = NULL;
+  delete frNegAdcPulseInt;     frNegAdcPulseInt     = NULL;
+  delete frNegAdcPulseAmp;     frNegAdcPulseAmp     = NULL;
 
-  delete frNegAdcPed; frNegAdcPed = NULL;
-  delete frNegAdcPulseInt; frNegAdcPulseInt = NULL;
-  delete frNegAdcPulseAmp; frNegAdcPulseAmp = NULL;
-
-  delete fPosAdcErrorFlag; fPosAdcErrorFlag= NULL;
-  delete fNegAdcErrorFlag; fNegAdcErrorFlag= NULL;
+  delete fPosAdcErrorFlag; fPosAdcErrorFlag = NULL;
+  delete fNegAdcErrorFlag; fNegAdcErrorFlag = NULL;
 
   DeleteArrays();
 
@@ -146,62 +140,66 @@ THcAerogel::~THcAerogel()
 //_____________________________________________________________________________
 void THcAerogel::InitArrays()
 {
-  fA_Pos = NULL;
-  fA_Neg = NULL;
+  fA_Pos   = NULL;
+  fA_Neg   = NULL;
   fA_Pos_p = NULL;
   fA_Neg_p = NULL;
-  fT_Pos = NULL;
-  fT_Neg = NULL;
+  fT_Pos   = NULL;
+  fT_Neg   = NULL;
+
   fPosGain = NULL;
   fNegGain = NULL;
+  fPosNpe  = NULL;
+  fNegNpe  = NULL;
+
   fPosPedLimit = NULL;
   fNegPedLimit = NULL;
-  fPosPedMean = NULL;
-  fNegPedMean = NULL;
-  fPosNpe = NULL;
-  fNegNpe = NULL;
-  fPosPedSum = NULL;
-  fPosPedSum2 = NULL;
+  fPosPedMean  = NULL;
+  fNegPedMean  = NULL;
+  fPosPedSum   = NULL;
+  fPosPedSum2  = NULL;
   fPosPedCount = NULL;
-  fNegPedSum = NULL;
-  fNegPedSum2 = NULL;
+  fNegPedSum   = NULL;
+  fNegPedSum2  = NULL;
   fNegPedCount = NULL;
-  fPosPed = NULL;
-  fPosSig = NULL;
-  fPosThresh = NULL;
-  fNegPed = NULL;
-  fNegSig = NULL;
-  fNegThresh = NULL;
+  fPosPed      = NULL;
+  fPosSig      = NULL;
+  fPosThresh   = NULL;
+  fNegPed      = NULL;
+  fNegSig      = NULL;
+  fNegThresh   = NULL;
 }
 //_____________________________________________________________________________
 void THcAerogel::DeleteArrays()
 {
-  delete [] fA_Pos; fA_Pos = NULL;
-  delete [] fA_Neg; fA_Neg = NULL;
+  delete [] fA_Pos;   fA_Pos   = NULL;
+  delete [] fA_Neg;   fA_Neg   = NULL;
   delete [] fA_Pos_p; fA_Pos_p = NULL;
   delete [] fA_Neg_p; fA_Neg_p = NULL;
-  delete [] fT_Pos; fT_Pos = NULL;
-  delete [] fT_Neg; fT_Neg = NULL;
+  delete [] fT_Pos;   fT_Pos   = NULL;
+  delete [] fT_Neg;   fT_Neg   = NULL;
+
   delete [] fPosGain; fPosGain = NULL;
   delete [] fNegGain; fNegGain = NULL;
+  delete [] fPosNpe;  fPosNpe  = NULL;
+  delete [] fNegNpe;  fNegNpe  = NULL;
+
   delete [] fPosPedLimit; fPosPedLimit = NULL;
   delete [] fNegPedLimit; fNegPedLimit = NULL;
-  delete [] fPosPedMean; fPosPedMean = NULL;
-  delete [] fNegPedMean; fNegPedMean = NULL;
-  delete [] fPosNpe; fPosNpe = NULL;
-  delete [] fNegNpe; fNegNpe = NULL;
-  delete [] fPosPedSum; fPosPedSum = NULL;
-  delete [] fPosPedSum2; fPosPedSum2 = NULL;
+  delete [] fPosPedMean;  fPosPedMean  = NULL;
+  delete [] fNegPedMean;  fNegPedMean  = NULL;
+  delete [] fPosPedSum;   fPosPedSum   = NULL;
+  delete [] fPosPedSum2;  fPosPedSum2  = NULL;
   delete [] fPosPedCount; fPosPedCount = NULL;
-  delete [] fNegPedSum; fNegPedSum = NULL;
-  delete [] fNegPedSum2; fNegPedSum2 = NULL;
+  delete [] fNegPedSum;   fNegPedSum   = NULL;
+  delete [] fNegPedSum2;  fNegPedSum2  = NULL;
   delete [] fNegPedCount; fNegPedCount = NULL;
-  delete [] fPosPed; fPosPed = NULL;
-  delete [] fPosSig; fPosSig = NULL;
-  delete [] fPosThresh; fPosThresh = NULL;
-  delete [] fNegPed; fNegPed = NULL;
-  delete [] fNegSig; fNegSig = NULL;
-  delete [] fNegThresh; fNegThresh = NULL;
+  delete [] fPosPed;      fPosPed      = NULL;
+  delete [] fPosSig;      fPosSig      = NULL;
+  delete [] fPosThresh;   fPosThresh   = NULL;
+  delete [] fNegPed;      fNegPed      = NULL;
+  delete [] fNegSig;      fNegSig      = NULL;
+  delete [] fNegThresh;   fNegThresh   = NULL;
 }
 
 //_____________________________________________________________________________
@@ -243,30 +241,32 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
   prefix[1]='\0';
 
   fNelem = 8;			// Default if not defined
-  Bool_t optional=true ;
+  Bool_t optional = true ;
   DBRequest listextra[]={
     {"aero_num_pairs", &fNelem, kInt, 0, optional},
     {0}
   };
+
   gHcParms->LoadParmValues((DBRequest*)&listextra, prefix);
 
   fPosNpe  = new Double_t[fNelem];
   fNegNpe  = new Double_t[fNelem];
   fPosGain = new Double_t[fNelem];
   fNegGain = new Double_t[fNelem];
-  
-  // 6 GeV variables
-  fA_Pos = new Float_t[fNelem];
-  fA_Neg = new Float_t[fNelem];
+
+  fA_Pos   = new Float_t[fNelem];
+  fA_Neg   = new Float_t[fNelem];
   fA_Pos_p = new Float_t[fNelem];
   fA_Neg_p = new Float_t[fNelem];
-  fT_Pos = new Float_t[fNelem];
-  fT_Neg = new Float_t[fNelem];
+
+  // 6 GeV variables
+  fTdcOffset   = 0; // Offset to make reference time subtracted times positve
   fPosPedLimit = new Int_t[fNelem];
   fNegPedLimit = new Int_t[fNelem];
-  fPosPedMean = new Double_t[fNelem];
-  fNegPedMean = new Double_t[fNelem];
-  fTdcOffset = 0; // Offset to make reference time subtracted times positve
+  fT_Pos       = new Float_t[fNelem];
+  fT_Neg       = new Float_t[fNelem];
+  fPosPedMean  = new Double_t[fNelem];
+  fNegPedMean  = new Double_t[fNelem];
 
   // Create arrays to hold pedestal results
   if (fSixGevData) InitializePedestals();
@@ -312,8 +312,8 @@ Int_t THcAerogel::DefineVariables( EMode mode )
 
   vector<RVarDef> vars;
 
-  vars.push_back({"posGain", "List of positive PMT gains.", "fPosGain"});
-  vars.push_back({"negGain", "List of negative PMT gains.", "fNegGain"});
+  vars.push_back({"posGain", "Positive PMT gains", "fPosGain"});
+  vars.push_back({"negGain", "Negative PMT gains", "fNegGain"});
   
   vars.push_back({"posNpe",    "Number of Positive PEs",       "fPosNpe"});
   vars.push_back({"negNpe",    "Number of Positive PEs",       "fNegNpe"});
@@ -323,43 +323,41 @@ Int_t THcAerogel::DefineVariables( EMode mode )
 
   vars.push_back({"nGoodHits", "Total number of good hits", "fNGoodHits"});
 
-  vars.push_back({"posAdcCounter",      "List of positive ADC counter numbers.",      "frPosAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
-  vars.push_back({"negAdcCounter",      "List of negative ADC counter numbers.",      "frNegAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
+  vars.push_back({"posAdcCounter",   "Positive ADC counter numbers",   "frPosAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
+  vars.push_back({"negAdcCounter",   "Negative ADC counter numbers",   "frNegAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
+  vars.push_back({"posAdcErrorFlag", "Error Flag for When FPGA Fails", "fPosAdcErrorFlag.THcSignalHit.GetData()"});
+  vars.push_back({"negAdcErrorFlag", "Error Flag for When FPGA Fails", "fNegAdcErrorFlag.THcSignalHit.GetData()"});
 
-  vars.push_back({"posAdcPedRaw",       "List of positive raw ADC pedestals",         "frPosAdcPedRaw.THcSignalHit.GetData()"});
-  vars.push_back({"posAdcPulseIntRaw",  "List of positive raw ADC pulse integrals.",  "frPosAdcPulseIntRaw.THcSignalHit.GetData()"});
-  vars.push_back({"posAdcPulseAmpRaw",  "List of positive raw ADC pulse amplitudes.", "frPosAdcPulseAmpRaw.THcSignalHit.GetData()"});
-  vars.push_back({"posAdcPulseTimeRaw", "List of positive raw ADC pulse times.",      "frPosAdcPulseTimeRaw.THcSignalHit.GetData()"});
+  vars.push_back({"posAdcPedRaw",       "Positive Raw ADC pedestals",        "frPosAdcPedRaw.THcSignalHit.GetData()"});
+  vars.push_back({"posAdcPulseIntRaw",  "Positive Raw ADC pulse integrals",  "frPosAdcPulseIntRaw.THcSignalHit.GetData()"});
+  vars.push_back({"posAdcPulseAmpRaw",  "Positive Raw ADC pulse amplitudes", "frPosAdcPulseAmpRaw.THcSignalHit.GetData()"});
+  vars.push_back({"posAdcPulseTimeRaw", "Positive Raw ADC pulse times",      "frPosAdcPulseTimeRaw.THcSignalHit.GetData()"});
+  vars.push_back({"posAdcPed",          "Positive ADC pedestals",            "frPosAdcPed.THcSignalHit.GetData()"});
+  vars.push_back({"posAdcPulseInt",     "Positive ADC pulse integrals",      "frPosAdcPulseInt.THcSignalHit.GetData()"});
+  vars.push_back({"posAdcPulseAmp",     "Positive ADC pulse amplitudes",     "frPosAdcPulseAmp.THcSignalHit.GetData()"});
 
-  vars.push_back({"posAdcPed",          "List of positive ADC pedestals",             "frPosAdcPed.THcSignalHit.GetData()"});
-  vars.push_back({"posAdcPulseInt",     "List of positive ADC pulse integrals.",      "frPosAdcPulseInt.THcSignalHit.GetData()"});
-  vars.push_back({"posAdcPulseAmp",     "List of positive ADC pulse amplitudes.",     "frPosAdcPulseAmp.THcSignalHit.GetData()"});
+  vars.push_back({"negAdcPedRaw",       "Negative Raw ADC pedestals",        "frNegAdcPedRaw.THcSignalHit.GetData()"});
+  vars.push_back({"negAdcPulseIntRaw",  "Negative Raw ADC pulse integrals",  "frNegAdcPulseIntRaw.THcSignalHit.GetData()"});
+  vars.push_back({"negAdcPulseAmpRaw",  "Negative Raw ADC pulse amplitudes", "frNegAdcPulseAmpRaw.THcSignalHit.GetData()"});
+  vars.push_back({"negAdcPulseTimeRaw", "Negative Raw ADC pulse times",      "frNegAdcPulseTimeRaw.THcSignalHit.GetData()"});
+  vars.push_back({"negAdcPed",          "Negative ADC pedestals",            "frNegAdcPed.THcSignalHit.GetData()"});
+  vars.push_back({"negAdcPulseInt",     "Negative ADC pulse integrals",      "frNegAdcPulseInt.THcSignalHit.GetData()"});
+  vars.push_back({"negAdcPulseAmp",     "Negative ADC pulse amplitudes",     "frNegAdcPulseAmp.THcSignalHit.GetData()"});
 
-  vars.push_back({"negAdcPedRaw",       "List of negative raw ADC pedestals",         "frNegAdcPedRaw.THcSignalHit.GetData()"});
-  vars.push_back({"negAdcPulseIntRaw",  "List of negative raw ADC pulse integrals.",  "frNegAdcPulseIntRaw.THcSignalHit.GetData()"});
-  vars.push_back({"negAdcPulseAmpRaw",  "List of negative raw ADC pulse amplitudes.", "frNegAdcPulseAmpRaw.THcSignalHit.GetData()"});
-  vars.push_back({"negAdcPulseTimeRaw", "List of negative raw ADC pulse times.",      "frNegAdcPulseTimeRaw.THcSignalHit.GetData()"});
-
-  vars.push_back({"negAdcPed",          "List of negative ADC pedestals",             "frNegAdcPed.THcSignalHit.GetData()"});
-  vars.push_back({"negAdcPulseInt",     "List of negative ADC pulse integrals.",      "frNegAdcPulseInt.THcSignalHit.GetData()"});
-  vars.push_back({"negAdcPulseAmp",     "List of negative ADC pulse amplitudes.",     "frNegAdcPulseAmp.THcSignalHit.GetData()"});
-
-  vars.push_back({"posAdcErrorFlag",    "Error Flag for When FPGA Fails",    "fPosAdcErrorFlag.THcSignalHit.GetData()"});
-  vars.push_back({"negAdcErrorFlag",    "Error Flag for When FPGA Fails",    "fNegAdcErrorFlag.THcSignalHit.GetData()"});
+  vars.push_back({"apos",          "Positive Raw ADC Amplitudes",            "fA_Pos"});
+  vars.push_back({"aneg",          "Negative Raw ADC Amplitudes",            "fA_Neg"});
+  vars.push_back({"apos_p",        "Positive Ped-subtracted ADC Amplitudes", "fA_Pos_p"});
+  vars.push_back({"aneg_p",        "Negative Ped-subtracted ADC Amplitudes", "fA_Neg_p"});
 
   if (fSixGevData) {
-    vars.push_back({"apos",          "Raw Positive ADC Amplitudes",            "fA_Pos"});
-    vars.push_back({"aneg",          "Raw Negative ADC Amplitudes",            "fA_Neg"});
-    vars.push_back({"apos_p",        "Ped-subtracted Positive ADC Amplitudes", "fA_Pos_p"});
-    vars.push_back({"aneg_p",        "Ped-subtracted Negative ADC Amplitudes", "fA_Neg_p"});
-    vars.push_back({"tpos",          "Raw Positive TDC",                       "fT_Pos"});
-    vars.push_back({"tneg",          "Raw Negative TDC",                       "fT_Neg"});
-    vars.push_back({"ntdc_pos_hits", "Number of Positive Tube Hits",           "fNTDCPosHits"});
-    vars.push_back({"ntdc_neg_hits", "Number of Negative Tube Hits",           "fNTDCNegHits"});
-    vars.push_back({"posadchits",    "List of Positive ADC hits",              "fPosADCHits.THcSignalHit.GetPaddleNumber()"});
-    vars.push_back({"negadchits",    "List of Negative ADC hits",              "fNegADCHits.THcSignalHit.GetPaddleNumber()"});
-    vars.push_back({"postdchits",    "List of Positive TDC hits",              "fPosTDCHits.THcSignalHit.GetPaddleNumber()"});
-    vars.push_back({"negtdchits",    "List of Negative TDC hits",              "fNegTDCHits.THcSignalHit.GetPaddleNumber()"});
+    vars.push_back({"tpos",          "Positive Raw TDC",             "fT_Pos"});
+    vars.push_back({"tneg",          "Negative Raw TDC",             "fT_Neg"});
+    vars.push_back({"ntdc_pos_hits", "Number of Positive Tube Hits", "fNTDCPosHits"});
+    vars.push_back({"ntdc_neg_hits", "Number of Negative Tube Hits", "fNTDCNegHits"});
+    vars.push_back({"posadchits",    "Positive ADC hits",            "fPosADCHits.THcSignalHit.GetPaddleNumber()"});
+    vars.push_back({"negadchits",    "Negative ADC hits",            "fNegADCHits.THcSignalHit.GetPaddleNumber()"});
+    vars.push_back({"postdchits",    "Positive TDC hits",            "fPosTDCHits.THcSignalHit.GetPaddleNumber()"});
+    vars.push_back({"negtdchits",    "Negative TDC hits",            "fNegTDCHits.THcSignalHit.GetPaddleNumber()"});
   }
   
   RVarDef end {0};
@@ -378,9 +376,7 @@ void THcAerogel::Clear(Option_t* opt)
   fPosADCHits->Clear();
   fNegADCHits->Clear();
 
-  // Clear Aerogel variables  from h_aero.f
-
-  fNhits = 0;	     // Don't really need to do this.  (Be sure this called before Decode)
+  fNhits = 0;	    
 
   fPosNpeSum = 0.0;
   fNegNpeSum = 0.0;
@@ -408,7 +404,6 @@ void THcAerogel::Clear(Option_t* opt)
   frPosAdcPulseIntRaw->Clear();
   frPosAdcPulseAmpRaw->Clear();
   frPosAdcPulseTimeRaw->Clear();
-
   frPosAdcPed->Clear();
   frPosAdcPulseInt->Clear();
   frPosAdcPulseAmp->Clear();
@@ -417,7 +412,6 @@ void THcAerogel::Clear(Option_t* opt)
   frNegAdcPulseIntRaw->Clear();
   frNegAdcPulseAmpRaw->Clear();
   frNegAdcPulseTimeRaw->Clear();
-
   frNegAdcPed->Clear();
   frNegAdcPulseInt->Clear();
   frNegAdcPulseAmp->Clear();
@@ -435,66 +429,64 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
 
   if (fSixGevData) {
     if(gHaCuts->Result("Pedestal_event")) {
-
       AccumulatePedestals(fRawHitList);
-
       fAnalyzePedestals = 1;	// Analyze pedestals first normal events
       return(0);
     }
 
     if(fAnalyzePedestals) {
-
       CalculatePedestals();
       Print("");
-
       fAnalyzePedestals = 0;	// Don't analyze pedestals next event
     }
   }
 
-  Int_t ihit = 0;
+  Int_t ihit          = 0;
   UInt_t nrPosAdcHits = 0;
   UInt_t nrNegAdcHits = 0;
 
   //cout << ":=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:" << endl;
 
   while(ihit < fNhits) {
-    THcAerogelHit* hit = (THcAerogelHit *) fRawHitList->At(ihit);
 
-    Int_t padnum = hit->fCounter;
+    THcAerogelHit* hit          = (THcAerogelHit*) fRawHitList->At(ihit);
+    Int_t          npmt         = hit->fCounter;
+    THcRawAdcHit&  rawPosAdcHit = hit->GetRawAdcHitPos();
+    THcRawAdcHit&  rawNegAdcHit = hit->GetRawAdcHitNeg();
 
-    THcRawAdcHit& rawPosAdcHit = hit->GetRawAdcHitPos();
     for (UInt_t thit=0; thit<rawPosAdcHit.GetNPulses(); ++thit) {
-      ((THcSignalHit*) frPosAdcPedRaw->ConstructedAt(nrPosAdcHits))->Set(padnum, rawPosAdcHit.GetPedRaw());
-      ((THcSignalHit*) frPosAdcPed->ConstructedAt(nrPosAdcHits))->Set(padnum, rawPosAdcHit.GetPed());
 
-      ((THcSignalHit*) frPosAdcPulseIntRaw->ConstructedAt(nrPosAdcHits))->Set(padnum, rawPosAdcHit.GetPulseIntRaw(thit));
-      ((THcSignalHit*) frPosAdcPulseInt->ConstructedAt(nrPosAdcHits))->Set(padnum, rawPosAdcHit.GetPulseInt(thit));
+      ((THcSignalHit*) frPosAdcPedRaw->ConstructedAt(nrPosAdcHits))->Set(npmt, rawPosAdcHit.GetPedRaw());
+      ((THcSignalHit*) frPosAdcPed->ConstructedAt(nrPosAdcHits))->Set(npmt, rawPosAdcHit.GetPed());
 
-      ((THcSignalHit*) frPosAdcPulseAmpRaw->ConstructedAt(nrPosAdcHits))->Set(padnum, rawPosAdcHit.GetPulseAmpRaw(thit));
-      ((THcSignalHit*) frPosAdcPulseAmp->ConstructedAt(nrPosAdcHits))->Set(padnum, rawPosAdcHit.GetPulseAmp(thit));
+      ((THcSignalHit*) frPosAdcPulseIntRaw->ConstructedAt(nrPosAdcHits))->Set(npmt, rawPosAdcHit.GetPulseIntRaw(thit));
+      ((THcSignalHit*) frPosAdcPulseInt->ConstructedAt(nrPosAdcHits))->Set(npmt, rawPosAdcHit.GetPulseInt(thit));
 
-      ((THcSignalHit*) frPosAdcPulseTimeRaw->ConstructedAt(nrPosAdcHits))->Set(padnum, rawPosAdcHit.GetPulseTimeRaw(thit));
+      ((THcSignalHit*) frPosAdcPulseAmpRaw->ConstructedAt(nrPosAdcHits))->Set(npmt, rawPosAdcHit.GetPulseAmpRaw(thit));
+      ((THcSignalHit*) frPosAdcPulseAmp->ConstructedAt(nrPosAdcHits))->Set(npmt, rawPosAdcHit.GetPulseAmp(thit));
 
-      if (rawPosAdcHit.GetPulseAmpRaw(thit) > 0)  ((THcSignalHit*) fPosAdcErrorFlag->ConstructedAt(nrPosAdcHits))->Set(padnum, 0);
-      if (rawPosAdcHit.GetPulseAmpRaw(thit) <= 0) ((THcSignalHit*) fPosAdcErrorFlag->ConstructedAt(nrPosAdcHits))->Set(padnum, 1);
+      ((THcSignalHit*) frPosAdcPulseTimeRaw->ConstructedAt(nrPosAdcHits))->Set(npmt, rawPosAdcHit.GetPulseTimeRaw(thit));
+
+      if (rawPosAdcHit.GetPulseAmpRaw(thit) > 0)  ((THcSignalHit*) fPosAdcErrorFlag->ConstructedAt(nrPosAdcHits))->Set(npmt, 0);
+      if (rawPosAdcHit.GetPulseAmpRaw(thit) <= 0) ((THcSignalHit*) fPosAdcErrorFlag->ConstructedAt(nrPosAdcHits))->Set(npmt, 1);
 
       ++nrPosAdcHits;
     }
-    THcRawAdcHit& rawNegAdcHit = hit->GetRawAdcHitNeg();
+
     for (UInt_t thit=0; thit<rawNegAdcHit.GetNPulses(); ++thit) {
-      ((THcSignalHit*) frNegAdcPedRaw->ConstructedAt(nrNegAdcHits))->Set(padnum, rawNegAdcHit.GetPedRaw());
-      ((THcSignalHit*) frNegAdcPed->ConstructedAt(nrNegAdcHits))->Set(padnum, rawNegAdcHit.GetPed());
+      ((THcSignalHit*) frNegAdcPedRaw->ConstructedAt(nrNegAdcHits))->Set(npmt, rawNegAdcHit.GetPedRaw());
+      ((THcSignalHit*) frNegAdcPed->ConstructedAt(nrNegAdcHits))->Set(npmt, rawNegAdcHit.GetPed());
 
-      ((THcSignalHit*) frNegAdcPulseIntRaw->ConstructedAt(nrNegAdcHits))->Set(padnum, rawNegAdcHit.GetPulseIntRaw(thit));
-      ((THcSignalHit*) frNegAdcPulseInt->ConstructedAt(nrNegAdcHits))->Set(padnum, rawNegAdcHit.GetPulseInt(thit));
+      ((THcSignalHit*) frNegAdcPulseIntRaw->ConstructedAt(nrNegAdcHits))->Set(npmt, rawNegAdcHit.GetPulseIntRaw(thit));
+      ((THcSignalHit*) frNegAdcPulseInt->ConstructedAt(nrNegAdcHits))->Set(npmt, rawNegAdcHit.GetPulseInt(thit));
 
-      ((THcSignalHit*) frNegAdcPulseAmpRaw->ConstructedAt(nrNegAdcHits))->Set(padnum, rawNegAdcHit.GetPulseAmpRaw(thit));
-      ((THcSignalHit*) frNegAdcPulseAmp->ConstructedAt(nrNegAdcHits))->Set(padnum, rawNegAdcHit.GetPulseAmp(thit));
+      ((THcSignalHit*) frNegAdcPulseAmpRaw->ConstructedAt(nrNegAdcHits))->Set(npmt, rawNegAdcHit.GetPulseAmpRaw(thit));
+      ((THcSignalHit*) frNegAdcPulseAmp->ConstructedAt(nrNegAdcHits))->Set(npmt, rawNegAdcHit.GetPulseAmp(thit));
 
-      ((THcSignalHit*) frNegAdcPulseTimeRaw->ConstructedAt(nrNegAdcHits))->Set(padnum, rawNegAdcHit.GetPulseTimeRaw(thit));
+      ((THcSignalHit*) frNegAdcPulseTimeRaw->ConstructedAt(nrNegAdcHits))->Set(npmt, rawNegAdcHit.GetPulseTimeRaw(thit));
 
-      if (rawNegAdcHit.GetPulseAmpRaw(thit) > 0)  ((THcSignalHit*) fNegAdcErrorFlag->ConstructedAt(nrNegAdcHits))->Set(padnum, 0);
-      if (rawNegAdcHit.GetPulseAmpRaw(thit) <= 0) ((THcSignalHit*) fNegAdcErrorFlag->ConstructedAt(nrNegAdcHits))->Set(padnum, 1);
+      if (rawNegAdcHit.GetPulseAmpRaw(thit) > 0)  ((THcSignalHit*) fNegAdcErrorFlag->ConstructedAt(nrNegAdcHits))->Set(npmt, 0);
+      if (rawNegAdcHit.GetPulseAmpRaw(thit) <= 0) ((THcSignalHit*) fNegAdcErrorFlag->ConstructedAt(nrNegAdcHits))->Set(npmt, 1);
 
       ++nrNegAdcHits;
     }
@@ -514,14 +506,14 @@ Int_t THcAerogel::CoarseProcess( TClonesArray&  ) //tracks
 {
   for(Int_t ihit=0; ihit < fNhits; ihit++) {
 
-    Int_t nPosTDCHits=0;
-    Int_t nNegTDCHits=0;
-    Int_t nPosADCHits=0;
-    Int_t nNegADCHits=0;
+    Int_t nPosTDCHits = 0;
+    Int_t nNegTDCHits = 0;
+    Int_t nPosADCHits = 0;
+    Int_t nNegADCHits = 0;
 
-    THcAerogelHit* hit = (THcAerogelHit *) fRawHitList->At(ihit);
-    THcRawAdcHit& rawPosAdcHit = hit->GetRawAdcHitPos();
-    THcRawAdcHit& rawNegAdcHit = hit->GetRawAdcHitNeg();
+    THcAerogelHit* hit = (THcAerogelHit*) fRawHitList->At(ihit);
+    THcRawAdcHit&  rawPosAdcHit = hit->GetRawAdcHitPos();
+    THcRawAdcHit&  rawNegAdcHit = hit->GetRawAdcHitNeg();
 
     // Fill the the per detector ADC arrays
     Int_t npmt = hit->fCounter - 1;
@@ -645,31 +637,32 @@ Int_t THcAerogel::FineProcess( TClonesArray& tracks )
 void THcAerogel::InitializePedestals( )
 {
   fNPedestalEvents = 0;
-  fMinPeds = 0;                    // Do not calculate pedestals by default
-  fPosPedSum = new Int_t [fNelem];
-  fPosPedSum2 = new Int_t [fNelem];
+  fMinPeds         = 0;                    // Do not calculate pedestals by default
+
+  fPosPedSum   = new Int_t [fNelem];
+  fPosPedSum2  = new Int_t [fNelem];
   fPosPedLimit = new Int_t [fNelem];
   fPosPedCount = new Int_t [fNelem];
-  fNegPedSum = new Int_t [fNelem];
-  fNegPedSum2 = new Int_t [fNelem];
+  fNegPedSum   = new Int_t [fNelem];
+  fNegPedSum2  = new Int_t [fNelem];
   fNegPedLimit = new Int_t [fNelem];
   fNegPedCount = new Int_t [fNelem];
+  fPosPed      = new Double_t [fNelem];
+  fNegPed      = new Double_t [fNelem];
+  fPosThresh   = new Double_t [fNelem];
+  fNegThresh   = new Double_t [fNelem];
 
-  fPosPed = new Double_t [fNelem];
-  fNegPed = new Double_t [fNelem];
-  fPosThresh = new Double_t [fNelem];
-  fNegThresh = new Double_t [fNelem];
   for(Int_t i=0;i<fNelem;i++) {
-    fPosPedSum[i] = 0;
-    fPosPedSum2[i] = 0;
+    fPosPedSum[i]   = 0;
+    fPosPedSum2[i]  = 0;
     fPosPedLimit[i] = 1000;   // In engine, this are set in parameter file
     fPosPedCount[i] = 0;
-    fNegPedSum[i] = 0;
-    fNegPedSum2[i] = 0;
+    fNegPedSum[i]   = 0;
+    fNegPedSum2[i]  = 0;
     fNegPedLimit[i] = 1000;   // In engine, this are set in parameter file
     fNegPedCount[i] = 0;
-    fPosPedMean[i] = 0;       // Default pedestal values
-    fNegPedMean[i] = 0;       // Default pedestal values
+    fPosPedMean[i]  = 0;       // Default pedestal values
+    fNegPedMean[i]  = 0;       // Default pedestal values
   }
 
 }
@@ -682,8 +675,8 @@ void THcAerogel::AccumulatePedestals(TClonesArray* rawhits)
   // calculating pedestals
 
   Int_t nrawhits = rawhits->GetLast()+1;
+  Int_t ihit     = 0;
 
-  Int_t ihit = 0;
   while(ihit < nrawhits) {
     THcAerogelHit* hit = (THcAerogelHit *) rawhits->At(ihit);
 
@@ -694,23 +687,19 @@ void THcAerogel::AccumulatePedestals(TClonesArray* rawhits)
       fPosPedSum[element]  += adcpos;
       fPosPedSum2[element] += adcpos*adcpos;
       fPosPedCount[element]++;
-      if(fPosPedCount[element] == fMinPeds/5) {
+      if(fPosPedCount[element] == fMinPeds/5) 
 	fPosPedLimit[element] = 100 + fPosPedSum[element]/fPosPedCount[element];
-      }
     }
     if(adcneg <= fNegPedLimit[element]) {
       fNegPedSum[element] += adcneg;
       fNegPedSum2[element] += adcneg*adcneg;
       fNegPedCount[element]++;
-      if(fNegPedCount[element] == fMinPeds/5) {
+      if(fNegPedCount[element] == fMinPeds/5) 
 	fNegPedLimit[element] = 100 + fNegPedSum[element]/fNegPedCount[element];
-      }
     }
     ihit++;
   }
-
   fNPedestalEvents++;
-
   return;
 }
 
@@ -724,13 +713,11 @@ void THcAerogel::CalculatePedestals( )
   for(Int_t i=0; i<fNelem;i++) {
 
     // Positive tubes
-    fPosPed[i] = ((Double_t) fPosPedSum[i]) / TMath::Max(1, fPosPedCount[i]);
+    fPosPed[i]    = ((Double_t) fPosPedSum[i]) / TMath::Max(1, fPosPedCount[i]);
     fPosThresh[i] = fPosPed[i] + 15;
-
     // Negative tubes
-    fNegPed[i] = ((Double_t) fNegPedSum[i]) / TMath::Max(1, fNegPedCount[i]);
+    fNegPed[i]    = ((Double_t) fNegPedSum[i]) / TMath::Max(1, fNegPedCount[i]);
     fNegThresh[i] = fNegPed[i] + 15;
-
     //    cout << i+1 << " " << fPosPed[i] << " " << fNegPed[i] << endl;
 
     // Just a copy for now, but allow the possibility that fXXXPedMean is set
@@ -738,17 +725,12 @@ void THcAerogel::CalculatePedestals( )
     // pedestal events.  (So that pedestals are sensible even if the pedestal events were
     // not acquired.)
     if(fMinPeds > 0) {
-      if(fPosPedCount[i] > fMinPeds) {
+      if(fPosPedCount[i] > fMinPeds)
 	fPosPedMean[i] = fPosPed[i];
-      }
-      if(fNegPedCount[i] > fMinPeds) {
+      if(fNegPedCount[i] > fMinPeds) 
 	fNegPedMean[i] = fNegPed[i];
-      }
     }
   }
-
-  //  cout << " " << endl;
-
 }
 
 //_____________________________________________________________________________
@@ -756,19 +738,14 @@ void THcAerogel::Print( const Option_t* opt) const {
   THaNonTrackingDetector::Print(opt);
 
   // Print out the pedestals
-
   cout << endl;
   cout << "Aerogel Pedestals" << endl;
   cout << "No.   Neg    Pos" << endl;
-  for(Int_t i=0; i<fNelem; i++){
-    cout << " " << i << "    " << fNegPedMean[i] << "    " << fPosPedMean[i]
-	 << endl;
-  }
+  for(Int_t i=0; i<fNelem; i++)
+    cout << " " << i << "\t" << fNegPedMean[i] << "\t" << fPosPedMean[i] << endl;
   cout << endl;
-
   cout << " fMinPeds = " << fMinPeds << endl;
   cout << endl;
-
 }
 
 ClassImp(THcAerogel)

--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -236,37 +236,39 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
     {"aero_num_pairs", &fNelem, kInt,0,optional},
     {0}
   };
-  gHcParms->LoadParmValues((DBRequest*)&listextra,prefix);
+  gHcParms->LoadParmValues((DBRequest*)&listextra, prefix);
 
+  fPosNpe  = new Double_t[fNelem];
+  fNegNpe  = new Double_t[fNelem];
+  fPosGain = new Double_t[fNelem];
+  fNegGain = new Double_t[fNelem];
+  
+  // 6 GeV variables
   fA_Pos = new Float_t[fNelem];
   fA_Neg = new Float_t[fNelem];
   fA_Pos_p = new Float_t[fNelem];
   fA_Neg_p = new Float_t[fNelem];
   fT_Pos = new Float_t[fNelem];
   fT_Neg = new Float_t[fNelem];
-
-  fPosGain = new Double_t[fNelem];
-  fNegGain = new Double_t[fNelem];
   fPosPedLimit = new Int_t[fNelem];
   fNegPedLimit = new Int_t[fNelem];
   fPosPedMean = new Double_t[fNelem];
   fNegPedMean = new Double_t[fNelem];
-
-  fTdcOffset = 0;		// Offset to make reference time subtracted times positve
+  fTdcOffset = 0; // Offset to make reference time subtracted times positve
 
   // Create arrays to hold pedestal results
-  InitializePedestals();
+  if (fSixGevData) InitializePedestals();
 
   DBRequest list[]={
     {"aero_pos_gain",      fPosGain,     kDouble, (UInt_t) fNelem},
     {"aero_neg_gain",      fNegGain,     kDouble, (UInt_t) fNelem},
-    {"aero_pos_ped_limit", fPosPedLimit, kInt,    (UInt_t) fNelem},
-    {"aero_neg_ped_limit", fNegPedLimit, kInt,    (UInt_t) fNelem},
+    {"aero_six_gev_data",  &fSixGevData, kInt,    0, 1},
+    {"aero_pos_ped_limit", fPosPedLimit, kInt,    (UInt_t) fNelem, optional},
+    {"aero_neg_ped_limit", fNegPedLimit, kInt,    (UInt_t) fNelem, optional},
     {"aero_pos_ped_mean",  fPosPedMean,  kDouble, (UInt_t) fNelem, optional},
     {"aero_neg_ped_mean",  fNegPedMean,  kDouble, (UInt_t) fNelem, optional},
     {"aero_tdc_offset",    &fTdcOffset,  kInt,    0,               optional},
     {"aero_min_peds",      &fMinPeds,    kInt,    0,               optional},
-    {"aero_six_gev_data",  &fSixGevData, kInt,    0, 1},
     {0}
   };
 
@@ -275,7 +277,6 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
   gHcParms->LoadParmValues((DBRequest*)&list, prefix);
 
   if (fSixGevData) cout << "6 GeV Data Analysis Flag Set To TRUE" << endl;
-  cout << "6 GeV Data Analysis Flag = " << fSixGevData << endl;
 
   fIsInit = true;
 
@@ -299,25 +300,16 @@ Int_t THcAerogel::DefineVariables( EMode mode )
 
   vector<RVarDef> vars;
 
-  vars.push_back({"posadchits", "List of Positive ADC hits", "fPosADCHits.THcSignalHit.GetPaddleNumber()"});
-  vars.push_back({"negadchits", "List of Negative ADC hits", "fNegADCHits.THcSignalHit.GetPaddleNumber()"});
-
-  vars.push_back({"apos",  "Raw Positive ADC Amplitudes",   "fA_Pos"});
-  vars.push_back({"aneg",  "Raw Negative ADC Amplitudes",   "fA_Neg"});
-
-  vars.push_back({"apos_p", "Ped-subtracted Positive ADC Amplitudes", "fA_Pos_p"});
-  vars.push_back({"aneg_p", "Ped-subtracted Negative ADC Amplitudes", "fA_Neg_p"});
-
-  vars.push_back({"pos_npe",     "PEs Positive Tube",       "fPosNpe"});
-  vars.push_back({"neg_npe",     "PEs Negative Tube",       "fNegNpe"});
-  vars.push_back({"pos_npe_sum", "Total Positive Tube PEs", "fPosNpeSum"});
-  vars.push_back({"neg_npe_sum", "Total Negative Tube PEs", "fNegNpeSum"});
-  vars.push_back({"npe_sum",     "Total PEs",               "fNpeSum"});
-
-  vars.push_back({"ngood_hits", "Total number of good hits", "fNGoodHits"});
-
   vars.push_back({"posGain", "List of positive PMT gains.", "fPosGain"});
   vars.push_back({"negGain", "List of negative PMT gains.", "fNegGain"});
+  
+  vars.push_back({"posNpe",    "Number of Positive PEs",       "fPosNpe"});
+  vars.push_back({"negNpe",    "Number of Positive PEs",       "fNegNpe"});
+  vars.push_back({"posNpeSum", "Total Number of Negative PEs", "fPosNpeSum"});
+  vars.push_back({"negNpeSum", "Total Number of Negative PEs", "fNegNpeSum"});
+  vars.push_back({"npeSum",    "Total Number of PEs",          "fNpeSum"});
+
+  vars.push_back({"nGoodHits", "Total number of good hits", "fNGoodHits"});
 
   vars.push_back({"posAdcCounter",      "List of positive ADC counter numbers.",      "frPosAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
   vars.push_back({"negAdcCounter",      "List of negative ADC counter numbers.",      "frNegAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
@@ -341,12 +333,18 @@ Int_t THcAerogel::DefineVariables( EMode mode )
   vars.push_back({"negAdcPulseAmp",     "List of negative ADC pulse amplitudes.",     "frNegAdcPulseAmp.THcSignalHit.GetData()"});
 
   if (fSixGevData) {
-    vars.push_back({"postdchits", "List of Positive TDC hits", "fPosTDCHits.THcSignalHit.GetPaddleNumber()"});
-    vars.push_back({"negtdchits", "List of Negative TDC hits", "fNegTDCHits.THcSignalHit.GetPaddleNumber()"});
-    vars.push_back({"tpos", "Raw Positive TDC", "fT_Pos"});
-    vars.push_back({"tneg", "Raw Negative TDC", "fT_Neg"});
-    vars.push_back({"ntdc_pos_hits", "Number of Positive Tube Hits", "fNTDCPosHits"});
-    vars.push_back({"ntdc_neg_hits", "Number of Negative Tube Hits", "fNTDCNegHits"});
+    vars.push_back({"apos",          "Raw Positive ADC Amplitudes",            "fA_Pos"});
+    vars.push_back({"aneg",          "Raw Negative ADC Amplitudes",            "fA_Neg"});
+    vars.push_back({"apos_p",        "Ped-subtracted Positive ADC Amplitudes", "fA_Pos_p"});
+    vars.push_back({"aneg_p",        "Ped-subtracted Negative ADC Amplitudes", "fA_Neg_p"});
+    vars.push_back({"tpos",          "Raw Positive TDC",                       "fT_Pos"});
+    vars.push_back({"tneg",          "Raw Negative TDC",                       "fT_Neg"});
+    vars.push_back({"ntdc_pos_hits", "Number of Positive Tube Hits",           "fNTDCPosHits"});
+    vars.push_back({"ntdc_neg_hits", "Number of Negative Tube Hits",           "fNTDCNegHits"});
+    vars.push_back({"posadchits",    "List of Positive ADC hits",              "fPosADCHits.THcSignalHit.GetPaddleNumber()"});
+    vars.push_back({"negadchits",    "List of Negative ADC hits",              "fNegADCHits.THcSignalHit.GetPaddleNumber()"});
+    vars.push_back({"postdchits",    "List of Positive TDC hits",              "fPosTDCHits.THcSignalHit.GetPaddleNumber()"});
+    vars.push_back({"negtdchits",    "List of Negative TDC hits",              "fNegTDCHits.THcSignalHit.GetPaddleNumber()"});
   }
   
   RVarDef end {0};
@@ -371,7 +369,7 @@ void THcAerogel::Clear(Option_t* opt)
 
   fPosNpeSum = 0.0;
   fNegNpeSum = 0.0;
-  fNpeSum = 0.0;
+  fNpeSum    = 0.0;
 
   fNGoodHits = 0;
 
@@ -416,22 +414,23 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
   // Get the Hall C style hitlist (fRawHitList) for this event
   fNhits = DecodeToHitList(evdata);
 
-  if(gHaCuts->Result("Pedestal_event")) {
+  if (fSixGevData) {
+    if(gHaCuts->Result("Pedestal_event")) {
 
-    AccumulatePedestals(fRawHitList);
+      AccumulatePedestals(fRawHitList);
 
-    fAnalyzePedestals = 1;	// Analyze pedestals first normal events
-    return(0);
+      fAnalyzePedestals = 1;	// Analyze pedestals first normal events
+      return(0);
+    }
+
+    if(fAnalyzePedestals) {
+
+      CalculatePedestals();
+      Print("");
+
+      fAnalyzePedestals = 0;	// Don't analyze pedestals next event
+    }
   }
-
-  if(fAnalyzePedestals) {
-
-    CalculatePedestals();
-    Print("");
-
-    fAnalyzePedestals = 0;	// Don't analyze pedestals next event
-  }
-
 
   Int_t ihit = 0;
   Int_t nPosTDCHits=0;
@@ -442,7 +441,7 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
   UInt_t nrPosAdcHits = 0;
   UInt_t nrNegAdcHits = 0;
 
-  cout << ":=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:" << endl;
+  cout << ":=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:" << endl;
 
   while(ihit < fNhits) {
     THcAerogelHit* hit = (THcAerogelHit *) fRawHitList->At(ihit);
@@ -480,109 +479,126 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
       ++nrNegAdcHits;
     }
 
+    // Fill the the per detector ADC arrays
+    Int_t npmt = hit->fCounter - 1;
+
+    Double_t posAdcPulseInt = rawPosAdcHit.GetPulseInt();
+    Double_t negAdcPulseInt = rawNegAdcHit.GetPulseInt();
+
+    fPosNpe[npmt] = posAdcPulseInt*fPosGain[npmt];
+    fNegNpe[npmt] = negAdcPulseInt*fNegGain[npmt];
+
+    fPosNpeSum += fPosNpe[npmt];
+    fNegNpeSum += fNegNpe[npmt];
+ 
+    // Sum positive and negative hits to fill tot_good_hits
+    if(fPosNpe[npmt] > 0.3) {fNADCPosHits++; fNGoodHits++;}
+    if(fNegNpe[npmt] > 0.3) {fNADCNegHits++; fNGoodHits++;}
+    
+    cout << "\nPMT Num = " << npmt << endl; 
+    cout << "posAdcPulseInt = " << posAdcPulseInt << "\t" 
+    	 << "fPosGain = " << fPosGain[npmt] << "\t" 
+    	 << "fPosNpe = " << fPosNpe[npmt] << "\t" << endl;
+    cout << "negAdcPulseInt = " << negAdcPulseInt << "\t" 
+    	 << "fNegGain = " << fNegGain[npmt] << "\t" 
+    	 << "fNegNpe = " << fNegNpe[npmt] << "\t" << endl;
+    cout << "fPosNpeSum = " << fPosNpeSum << "\t" 
+    	 << "fNegNpeSum = " << fNegNpeSum << endl;
+    
+    // 6 GeV calculations
     Int_t adc_pos;
     Int_t adc_neg;
     Int_t tdc_pos=-1;
     Int_t tdc_neg=-1;
-   // TDC positive hit
-    if(hit->GetRawTdcHitPos().GetNHits() >  0) {
-      THcSignalHit *sighit = (THcSignalHit*) fPosTDCHits->ConstructedAt(nPosTDCHits++);
-      tdc_pos = hit->GetRawTdcHitPos().GetTime()+fTdcOffset;
-      sighit->Set(hit->fCounter, tdc_pos);
-    }
-
-    // TDC negative hit
-    if(hit->GetRawTdcHitNeg().GetNHits() >  0) {
-      THcSignalHit *sighit = (THcSignalHit*) fNegTDCHits->ConstructedAt(nNegTDCHits++);
-      tdc_neg = hit->GetRawTdcHitNeg().GetTime()+fTdcOffset;
-      sighit->Set(hit->fCounter, tdc_neg);
-    }
-
-    // ADC positive hit
-    if((adc_pos = hit->GetRawAdcHitPos().GetPulseInt()) > 0) {
-      THcSignalHit *sighit = (THcSignalHit*) fPosADCHits->ConstructedAt(nPosADCHits++);
-      sighit->Set(hit->fCounter, adc_pos);
-    }
-
-    // ADC negative hit
-    if((adc_neg = hit->GetRawAdcHitNeg().GetPulseInt()) > 0) {
-      THcSignalHit *sighit = (THcSignalHit*) fNegADCHits->ConstructedAt(nNegADCHits++);
-      sighit->Set(hit->fCounter, adc_neg);
-    }
-
-    // For each TDC, identify the first hit that is positive.
-    tdc_pos = -1;
-    tdc_neg = -1;
-    for(UInt_t thit=0; thit<hit->GetRawTdcHitPos().GetNHits(); thit++) {
-      Int_t tdc = hit->GetRawTdcHitPos().GetTime(thit);
-      if(tdc >=0 ) {
-	tdc_pos = tdc;
-	break;
+    if (fSixGevData) {
+      // ADC positive hit
+      if((adc_pos = hit->GetRawAdcHitPos().GetPulseInt()) > 0) {
+	THcSignalHit *sighit = (THcSignalHit*) fPosADCHits->ConstructedAt(nPosADCHits++);
+	sighit->Set(hit->fCounter, adc_pos);
       }
-    }
-    for(UInt_t thit=0; thit<hit->GetRawTdcHitNeg().GetNHits(); thit++) {
-      Int_t tdc = hit->GetRawTdcHitNeg().GetTime(thit);
-      if(tdc >= 0) {
-	tdc_neg = tdc;
-	break;
+      // ADC negative hit
+      if((adc_neg = hit->GetRawAdcHitNeg().GetPulseInt()) > 0) {
+	THcSignalHit *sighit = (THcSignalHit*) fNegADCHits->ConstructedAt(nNegADCHits++);
+	sighit->Set(hit->fCounter, adc_neg);
       }
-    }
+      // TDC positive hit
+      if(hit->GetRawTdcHitPos().GetNHits() >  0) {
+	THcSignalHit *sighit = (THcSignalHit*) fPosTDCHits->ConstructedAt(nPosTDCHits++);
+	tdc_pos = hit->GetRawTdcHitPos().GetTime()+fTdcOffset;
+	sighit->Set(hit->fCounter, tdc_pos);
+      }
+      // TDC negative hit
+      if(hit->GetRawTdcHitNeg().GetNHits() >  0) {
+	THcSignalHit *sighit = (THcSignalHit*) fNegTDCHits->ConstructedAt(nNegTDCHits++);
+	tdc_neg = hit->GetRawTdcHitNeg().GetTime()+fTdcOffset;
+	sighit->Set(hit->fCounter, tdc_neg);
+      }    
+      // For each TDC, identify the first hit that is positive.
+      tdc_pos = -1;
+      tdc_neg = -1;
+      for(UInt_t thit=0; thit<hit->GetRawTdcHitPos().GetNHits(); thit++) {
+	Int_t tdc = hit->GetRawTdcHitPos().GetTime(thit);
+	if(tdc >=0 ) {
+	  tdc_pos = tdc;
+	  break;
+	}
+      }
+      for(UInt_t thit=0; thit<hit->GetRawTdcHitNeg().GetNHits(); thit++) {
+	Int_t tdc = hit->GetRawTdcHitNeg().GetTime(thit);
+	if(tdc >= 0) {
+	  tdc_neg = tdc;
+	  break;
+	}
+      }
 
-    // Fill the the per detector ADC and TDC arrays
-    Int_t npmt = hit->fCounter - 1;
-    
-    fA_Pos[npmt] = adc_pos;  cout << "pos npmt = " << npmt << ", adc_pos = " << adc_pos << endl;
-    fA_Neg[npmt] = adc_neg;  cout << "neg npmt = " << npmt << ", adc_neg = " << adc_neg << endl;
-    fA_Pos_p[npmt] = fA_Pos[npmt] - fPosPedMean[npmt];
-    fA_Neg_p[npmt] = fA_Neg[npmt] - fNegPedMean[npmt];
-    fT_Pos[npmt] = tdc_pos;
-    fT_Neg[npmt] = tdc_neg;
+      fA_Pos[npmt] = adc_pos;  
+      fA_Neg[npmt] = adc_neg;  
+      fA_Pos_p[npmt] = fA_Pos[npmt] - fPosPedMean[npmt];
+      fA_Neg_p[npmt] = fA_Neg[npmt] - fNegPedMean[npmt];
+      fT_Pos[npmt] = tdc_pos;
+      fT_Neg[npmt] = tdc_neg;
 
-    if(fA_Pos[npmt] < 8000) {
-      fPosNpe[npmt] = fPosGain[npmt]*fA_Pos_p[npmt];
-    } else {
-      fPosNpe[npmt] = 100.0;
-    }
+      if(fA_Pos[npmt] < 8000) {
+	fPosNpe[npmt] = fPosGain[npmt]*fA_Pos_p[npmt];
+      } else {
+	fPosNpe[npmt] = 100.0;
+      }
 
-    if(fA_Neg[npmt] < 8000) {
-      fNegNpe[npmt] = fNegGain[npmt]*fA_Neg_p[npmt];
-    } else {
-      fNegNpe[npmt] = 100.0;
-    }
+      if(fA_Neg[npmt] < 8000) {
+	fNegNpe[npmt] = fNegGain[npmt]*fA_Neg_p[npmt];
+      } else {
+	fNegNpe[npmt] = 100.0;
+      }
 
-    fPosNpeSum += fPosNpe[npmt];
-    fNegNpeSum += fNegNpe[npmt];
+      fPosNpeSum += fPosNpe[npmt];
+      fNegNpeSum += fNegNpe[npmt];
 
-    // Sum positive and negative hits to fill tot_good_hits
-    if(fPosNpe[npmt] > 0.3) {
-      fNADCPosHits++;
-      fNGoodHits++;
-    }
-    if(fNegNpe[npmt] > 0.3) {
-      fNADCNegHits++;
-      fNGoodHits++;
-    }
-    if(fT_Pos[npmt] > 0 && fT_Pos[npmt] < 8000) {
-      fNTDCPosHits++;
-    }
-    if(fT_Neg[npmt] > 0 && fT_Neg[npmt] < 8000) {
-      fNTDCNegHits++;
-    }
+      // Sum positive and negative hits to fill tot_good_hits
+      if(fPosNpe[npmt] > 0.3) {fNADCPosHits++; fNGoodHits++;}
+      if(fNegNpe[npmt] > 0.3) {fNADCNegHits++; fNGoodHits++;}      
 
+      if(fT_Pos[npmt] > 0 && fT_Pos[npmt] < 8000) {
+	fNTDCPosHits++;
+      }
+      if(fT_Neg[npmt] > 0 && fT_Neg[npmt] < 8000) {
+	fNTDCNegHits++;
+      }
+
+    }
+   
     ihit++;
+   
   }
 
-  if(fPosNpeSum > 0.5 || fNegNpeSum > 0.5) {
-    fNpeSum = fPosNpeSum + fNegNpeSum;
-  } else {
-    fNpeSum = 0.0;
-  }
-
+  // Calculate total NPE sum
+  if(fPosNpeSum > 0.5 || fNegNpeSum > 0.5) fNpeSum = fPosNpeSum + fNegNpeSum;
+  else fNpeSum = 0.0;
+    
   // If total hits are 0, then give a noticable ridiculous NPE
-  if(fNhits < 1) {
-    fNpeSum = 0.0;
-  }
-
+  if(fNhits < 1) fNpeSum = 0.0;
+  
+  cout << "\nfNpeSum = " << fNpeSum << "\n" << endl;
+   
   // The following code is in the fortran.  It probably doesn't work
   // right because the arrays are not cleared first and the aero_ep,
   // aero_en, ... lines make no sense.
@@ -637,6 +653,7 @@ Int_t THcAerogel::FineProcess( TClonesArray& tracks )
 }
 
 //_____________________________________________________________________________
+// Method for initializing pedestals in the 6 GeV era
 void THcAerogel::InitializePedestals( )
 {
   fNPedestalEvents = 0;
@@ -667,11 +684,10 @@ void THcAerogel::InitializePedestals( )
     fNegPedMean[i] = 0;       // Default pedestal values
   }
 
-  fPosNpe = new Double_t [fNelem];
-  fNegNpe = new Double_t [fNelem];
 }
 
 //_____________________________________________________________________________
+// Method for accumulating pedestals in the 6 GeV era
 void THcAerogel::AccumulatePedestals(TClonesArray* rawhits)
 {
   // Extract data from the hit list, accumulating into arrays for
@@ -684,10 +700,10 @@ void THcAerogel::AccumulatePedestals(TClonesArray* rawhits)
     THcAerogelHit* hit = (THcAerogelHit *) rawhits->At(ihit);
 
     Int_t element = hit->fCounter - 1;
-    Int_t adcpos = hit->GetRawAdcHitPos().GetPulseInt();
-    Int_t adcneg = hit->GetRawAdcHitNeg().GetPulseInt();
+    Int_t adcpos  = hit->GetRawAdcHitPos().GetPulseInt();
+    Int_t adcneg  = hit->GetRawAdcHitNeg().GetPulseInt();
     if(adcpos <= fPosPedLimit[element]) {
-      fPosPedSum[element] += adcpos;
+      fPosPedSum[element]  += adcpos;
       fPosPedSum2[element] += adcpos*adcpos;
       fPosPedCount[element]++;
       if(fPosPedCount[element] == fMinPeds/5) {
@@ -711,6 +727,7 @@ void THcAerogel::AccumulatePedestals(TClonesArray* rawhits)
 }
 
 //_____________________________________________________________________________
+// Method for calculating pedestals in the 6 GeV era
 void THcAerogel::CalculatePedestals( )
 {
   // Use the accumulated pedestal data to calculate pedestals
@@ -745,6 +762,8 @@ void THcAerogel::CalculatePedestals( )
   //  cout << " " << endl;
 
 }
+
+//_____________________________________________________________________________
 void THcAerogel::Print( const Option_t* opt) const {
   THaNonTrackingDetector::Print(opt);
 

--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -20,7 +20,7 @@ configurable.
 #include "THcHitList.h"
 #include "THaApparatus.h"
 #include "VarDef.h"
-#include "VarType.h"
+#include "VarType.h" 
 #include "THaTrack.h"
 #include "TClonesArray.h"
 #include "TMath.h"

--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -5,7 +5,6 @@
     attached to a diffuser box
     Will have a fixed number of pairs, but need to later make this
     configurable.
-
 */
 
 #include "THcAerogel.h"
@@ -65,6 +64,27 @@ THcAerogel::THcAerogel( const char* name, const char* description,
   
   fPosAdcErrorFlag = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
   fNegAdcErrorFlag = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
+
+  fNumPosAdcHits         = vector<Int_t>    (MaxNumPosAeroPmt, 0.0);
+  fNumGoodPosAdcHits     = vector<Int_t>    (MaxNumPosAeroPmt, 0.0);
+  fNumNegAdcHits         = vector<Int_t>    (MaxNumNegAeroPmt, 0.0);
+  fNumGoodNegAdcHits     = vector<Int_t>    (MaxNumNegAeroPmt, 0.0);
+  fNumTracksMatched      = vector<Int_t>    (MaxNumPosAeroPmt, 0.0);
+  fNumTracksFired        = vector<Int_t>    (MaxNumPosAeroPmt, 0.0);
+  fPosNpe                = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
+  fNegNpe                = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
+
+  fGoodPosAdcPed         = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
+  fGoodPosAdcPulseInt    = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
+  fGoodPosAdcPulseIntRaw = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
+  fGoodPosAdcPulseAmp    = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
+  fGoodPosAdcPulseTime   = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
+
+  fGoodNegAdcPed         = vector<Double_t> (MaxNumNegAeroPmt, 0.0);
+  fGoodNegAdcPulseInt    = vector<Double_t> (MaxNumNegAeroPmt, 0.0);
+  fGoodNegAdcPulseIntRaw = vector<Double_t> (MaxNumNegAeroPmt, 0.0);
+  fGoodNegAdcPulseAmp    = vector<Double_t> (MaxNumNegAeroPmt, 0.0);
+  fGoodNegAdcPulseTime   = vector<Double_t> (MaxNumNegAeroPmt, 0.0);
 
   InitArrays();
 
@@ -149,8 +169,6 @@ void THcAerogel::InitArrays()
 
   fPosGain = NULL;
   fNegGain = NULL;
-  fPosNpe  = NULL;
-  fNegNpe  = NULL;
 
   fPosPedLimit = NULL;
   fNegPedLimit = NULL;
@@ -181,9 +199,7 @@ void THcAerogel::DeleteArrays()
 
   delete [] fPosGain; fPosGain = NULL;
   delete [] fNegGain; fNegGain = NULL;
-  delete [] fPosNpe;  fPosNpe  = NULL;
-  delete [] fNegNpe;  fNegNpe  = NULL;
-
+  
   delete [] fPosPedLimit; fPosPedLimit = NULL;
   delete [] fNegPedLimit; fNegPedLimit = NULL;
   delete [] fPosPedMean;  fPosPedMean  = NULL;
@@ -241,6 +257,8 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
   prefix[1]='\0';
 
   fNelem = 8;			// Default if not defined
+  fNRegions = 1;  // Default if not set in parameter file
+
   Bool_t optional = true ;
   DBRequest listextra[]={
     {"aero_num_pairs", &fNelem, kInt, 0, optional},
@@ -249,8 +267,6 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
 
   gHcParms->LoadParmValues((DBRequest*)&listextra, prefix);
 
-  fPosNpe  = new Double_t[fNelem];
-  fNegNpe  = new Double_t[fNelem];
   fPosGain = new Double_t[fNelem];
   fNegGain = new Double_t[fNelem];
 
@@ -271,26 +287,53 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
   // Create arrays to hold pedestal results
   if (fSixGevData) InitializePedestals();
 
+  // Region parameters
+  fRegionsValueMax = fNRegions * 8; 
+  fRegionValue     = new Double_t[fRegionsValueMax];
+
   DBRequest list[]={
-    {"aero_pos_gain",      fPosGain,     kDouble, (UInt_t) fNelem},
-    {"aero_neg_gain",      fNegGain,     kDouble, (UInt_t) fNelem},
-    {"aero_six_gev_data",  &fSixGevData, kInt,    0, 1},
-    {"aero_pos_ped_limit", fPosPedLimit, kInt,    (UInt_t) fNelem, optional},
-    {"aero_neg_ped_limit", fNegPedLimit, kInt,    (UInt_t) fNelem, optional},
-    {"aero_pos_ped_mean",  fPosPedMean,  kDouble, (UInt_t) fNelem, optional},
-    {"aero_neg_ped_mean",  fNegPedMean,  kDouble, (UInt_t) fNelem, optional},
-    {"aero_tdc_offset",    &fTdcOffset,  kInt,    0,               optional},
-    {"aero_min_peds",      &fMinPeds,    kInt,    0,               optional},
+    {"aero_num_regions",      &fNRegions,         kInt},
+    {"aero_red_chi2_min",     &fRedChi2Min,       kDouble},
+    {"aero_red_chi2_max",     &fRedChi2Max,       kDouble},
+    {"aero_beta_min",         &fBetaMin,          kDouble},
+    {"aero_beta_max",         &fBetaMax,          kDouble},
+    {"aero_enorm_min",        &fENormMin,         kDouble},
+    {"aero_enorm_max",        &fENormMax,         kDouble},
+    {"aero_diff_box_zpos",    &fDiffBoxZPos,      kDouble},
+    {"aero_npe_thresh",       &fNpeThresh,        kDouble},
+    {"aero_adcTimeWindowMin", &fAdcTimeWindowMin, kDouble},
+    {"aero_adcTimeWindowMax", &fAdcTimeWindowMax, kDouble},
+    {"aero_debug_adc",        &fDebugAdc,         kInt,    0, 1},
+    {"aero_six_gev_data",     &fSixGevData,       kInt,    0, 1},
+    {"aero_pos_gain",         fPosGain,           kDouble, (UInt_t) fNelem},
+    {"aero_neg_gain",         fNegGain,           kDouble, (UInt_t) fNelem},
+    {"aero_pos_ped_limit",    fPosPedLimit,       kInt,    (UInt_t) fNelem, optional},
+    {"aero_neg_ped_limit",    fNegPedLimit,       kInt,    (UInt_t) fNelem, optional},
+    {"aero_pos_ped_mean",     fPosPedMean,        kDouble, (UInt_t) fNelem, optional},
+    {"aero_neg_ped_mean",     fNegPedMean,        kDouble, (UInt_t) fNelem, optional},
+    {"aero_tdc_offset",       &fTdcOffset,        kInt,    0,               optional},
+    {"aero_min_peds",         &fMinPeds,          kInt,    0,               optional},
+    {"aero_region",           &fRegionValue[0],   kDouble, (UInt_t) fRegionsValueMax},
+
     {0}
   };
 
   fSixGevData = 0; // Set 6 GeV data parameter to false unless set in parameter file
+  fDebugAdc   = 0; // Set ADC debug parameter to false unless set in parameter file
 
   gHcParms->LoadParmValues((DBRequest*)&list, prefix);
 
   if (fSixGevData) cout << "6 GeV Data Analysis Flag Set To TRUE" << endl;
 
   fIsInit = true;
+
+  cout << " Track Matching Parameters for: " << GetName() << endl;
+  for (Int_t iregion = 0; iregion < fNRegions; iregion++) {
+    cout << "Region = " << iregion + 1 << endl;
+    for (Int_t ivalue = 0; ivalue < 8; ivalue++)
+      cout << fRegionValue[GetIndex(iregion, ivalue)] << "  ";
+    cout << endl;
+  }
 
   return kOK;
 }
@@ -314,6 +357,28 @@ Int_t THcAerogel::DefineVariables( EMode mode )
 
   vars.push_back({"posGain", "Positive PMT gains", "fPosGain"});
   vars.push_back({"negGain", "Negative PMT gains", "fNegGain"});
+  vars.push_back({"nGoodHits", "Total number of good hits", "fNGoodHits"});
+  vars.push_back({"apos",          "Positive Raw ADC Amplitudes",            "fA_Pos"});
+  vars.push_back({"aneg",          "Negative Raw ADC Amplitudes",            "fA_Neg"});
+  vars.push_back({"apos_p",        "Positive Ped-subtracted ADC Amplitudes", "fA_Pos_p"});
+  vars.push_back({"aneg_p",        "Negative Ped-subtracted ADC Amplitudes", "fA_Neg_p"});
+
+  vars.push_back({"numPosAdcHits",        "Number of Positive ADC Hits Per PMT",      "fNumPosAdcHits"});        // Aerogel occupancy
+  vars.push_back({"numGoodPosAdcHits",    "Number of Good Positive ADC Hits Per PMT", "fNumGoodPosAdcHits"});    // Aerogel occupancy
+  vars.push_back({"totNumPosAdcHits",     "Total Number of Positive ADC Hits",        "fTotNumPosAdcHits"});     // Aerogel multiplicity
+  vars.push_back({"totNumGoodPosAdcHits", "Total Number of Good Positive ADC Hits",   "fTotNumGoodPosAdcHits"}); // Aerogel multiplicity
+
+  vars.push_back({"numNegAdcHits",        "Number of Negative ADC Hits Per PMT",      "fNumNegAdcHits"});        // Aerogel occupancy
+  vars.push_back({"numGoodNegAdcHits",    "Number of Good Negative ADC Hits Per PMT", "fNumGoodNegAdcHits"});    // Aerogel occupancy
+  vars.push_back({"totNumNegAdcHits",     "Total Number of Negative ADC Hits",        "fTotNumNegAdcHits"});     // Aerogel multiplicity
+  vars.push_back({"totNumGoodNegAdcHits", "Total Number of Good Negative ADC Hits",   "fTotNumGoodNegAdcHits"}); // Aerogel multiplicity
+  
+  vars.push_back({"totnumAdcHits",       "Total Number of ADC Hits Per PMT",          "fTotNumAdcHits"});        // Aerogel multiplicity
+  vars.push_back({"totnumGoodAdcHits",   "TotalNumber of Good ADC Hits Per PMT",      "fTotNumGoodAdcHits"});    // Aerogel multiplicity
+  vars.push_back({"numTracksMatched",    "Number of Tracks Matched Per Region",       "fNumTracksMatched"});        
+  vars.push_back({"numTracksFired",      "Number of Tracks that Fired Per Region",    "fNumTracksFired"});                
+  vars.push_back({"totNumTracksMatched", "Total Number of Tracks Matched Per Region", "fTotNumTracksMatched"});
+  vars.push_back({"totNumTracksFired",   "Total Number of Tracks that Fired",         "fTotNumTracksFired"});
   
   vars.push_back({"posNpe",    "Number of Positive PEs",       "fPosNpe"});
   vars.push_back({"negNpe",    "Number of Positive PEs",       "fNegNpe"});
@@ -321,34 +386,41 @@ Int_t THcAerogel::DefineVariables( EMode mode )
   vars.push_back({"negNpeSum", "Total Number of Negative PEs", "fNegNpeSum"});
   vars.push_back({"npeSum",    "Total Number of PEs",          "fNpeSum"});
 
-  vars.push_back({"nGoodHits", "Total number of good hits", "fNGoodHits"});
-
   vars.push_back({"posAdcCounter",   "Positive ADC counter numbers",   "frPosAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
   vars.push_back({"negAdcCounter",   "Negative ADC counter numbers",   "frNegAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
   vars.push_back({"posAdcErrorFlag", "Error Flag for When FPGA Fails", "fPosAdcErrorFlag.THcSignalHit.GetData()"});
   vars.push_back({"negAdcErrorFlag", "Error Flag for When FPGA Fails", "fNegAdcErrorFlag.THcSignalHit.GetData()"});
 
-  vars.push_back({"posAdcPedRaw",       "Positive Raw ADC pedestals",        "frPosAdcPedRaw.THcSignalHit.GetData()"});
-  vars.push_back({"posAdcPulseIntRaw",  "Positive Raw ADC pulse integrals",  "frPosAdcPulseIntRaw.THcSignalHit.GetData()"});
-  vars.push_back({"posAdcPulseAmpRaw",  "Positive Raw ADC pulse amplitudes", "frPosAdcPulseAmpRaw.THcSignalHit.GetData()"});
-  vars.push_back({"posAdcPulseTimeRaw", "Positive Raw ADC pulse times",      "frPosAdcPulseTimeRaw.THcSignalHit.GetData()"});
-  vars.push_back({"posAdcPed",          "Positive ADC pedestals",            "frPosAdcPed.THcSignalHit.GetData()"});
-  vars.push_back({"posAdcPulseInt",     "Positive ADC pulse integrals",      "frPosAdcPulseInt.THcSignalHit.GetData()"});
-  vars.push_back({"posAdcPulseAmp",     "Positive ADC pulse amplitudes",     "frPosAdcPulseAmp.THcSignalHit.GetData()"});
+  vars.push_back({"goodPosAdcPed",         "Good Negative ADC pedestals",           "fGoodPosAdcPed"});
+  vars.push_back({"goodPosAdcPulseInt",    "Good Negative ADC pulse integrals",     "fGoodPosAdcPulseInt"});
+  vars.push_back({"goodPosAdcPulseIntRaw", "Good Negative ADC raw pulse integrals", "fGoodPosAdcPulseIntRaw"});
+  vars.push_back({"goodPosAdcPulseAmp",    "Good Negative ADC pulse amplitudes",    "fGoodPosAdcPulseAmp"});
+  vars.push_back({"goodPosAdcPulseTime",   "Good Negative ADC pulse times",         "fGoodPosAdcPulseTime"});
 
-  vars.push_back({"negAdcPedRaw",       "Negative Raw ADC pedestals",        "frNegAdcPedRaw.THcSignalHit.GetData()"});
-  vars.push_back({"negAdcPulseIntRaw",  "Negative Raw ADC pulse integrals",  "frNegAdcPulseIntRaw.THcSignalHit.GetData()"});
-  vars.push_back({"negAdcPulseAmpRaw",  "Negative Raw ADC pulse amplitudes", "frNegAdcPulseAmpRaw.THcSignalHit.GetData()"});
-  vars.push_back({"negAdcPulseTimeRaw", "Negative Raw ADC pulse times",      "frNegAdcPulseTimeRaw.THcSignalHit.GetData()"});
-  vars.push_back({"negAdcPed",          "Negative ADC pedestals",            "frNegAdcPed.THcSignalHit.GetData()"});
-  vars.push_back({"negAdcPulseInt",     "Negative ADC pulse integrals",      "frNegAdcPulseInt.THcSignalHit.GetData()"});
-  vars.push_back({"negAdcPulseAmp",     "Negative ADC pulse amplitudes",     "frNegAdcPulseAmp.THcSignalHit.GetData()"});
+  vars.push_back({"goodNegAdcPed",         "Good Negative ADC pedestals",           "fGoodNegAdcPed"});
+  vars.push_back({"goodNegAdcPulseInt",    "Good Negative ADC pulse integrals",     "fGoodNegAdcPulseInt"});
+  vars.push_back({"goodNegAdcPulseIntRaw", "Good Negative ADC raw pulse integrals", "fGoodNegAdcPulseIntRaw"});
+  vars.push_back({"goodNegAdcPulseAmp",    "Good Negative ADC pulse amplitudes",    "fGoodNegAdcPulseAmp"});
+  vars.push_back({"goodNegAdcPulseTime",   "Good Negative ADC pulse times",         "fGoodNegAdcPulseTime"});
 
-  vars.push_back({"apos",          "Positive Raw ADC Amplitudes",            "fA_Pos"});
-  vars.push_back({"aneg",          "Negative Raw ADC Amplitudes",            "fA_Neg"});
-  vars.push_back({"apos_p",        "Positive Ped-subtracted ADC Amplitudes", "fA_Pos_p"});
-  vars.push_back({"aneg_p",        "Negative Ped-subtracted ADC Amplitudes", "fA_Neg_p"});
+  if (fDebugAdc) {
+    vars.push_back({"posAdcPedRaw",       "Positive Raw ADC pedestals",        "frPosAdcPedRaw.THcSignalHit.GetData()"});
+    vars.push_back({"posAdcPulseIntRaw",  "Positive Raw ADC pulse integrals",  "frPosAdcPulseIntRaw.THcSignalHit.GetData()"});
+    vars.push_back({"posAdcPulseAmpRaw",  "Positive Raw ADC pulse amplitudes", "frPosAdcPulseAmpRaw.THcSignalHit.GetData()"});
+    vars.push_back({"posAdcPulseTimeRaw", "Positive Raw ADC pulse times",      "frPosAdcPulseTimeRaw.THcSignalHit.GetData()"});
+    vars.push_back({"posAdcPed",          "Positive ADC pedestals",            "frPosAdcPed.THcSignalHit.GetData()"});
+    vars.push_back({"posAdcPulseInt",     "Positive ADC pulse integrals",      "frPosAdcPulseInt.THcSignalHit.GetData()"});
+    vars.push_back({"posAdcPulseAmp",     "Positive ADC pulse amplitudes",     "frPosAdcPulseAmp.THcSignalHit.GetData()"});
 
+    vars.push_back({"negAdcPedRaw",       "Negative Raw ADC pedestals",        "frNegAdcPedRaw.THcSignalHit.GetData()"});
+    vars.push_back({"negAdcPulseIntRaw",  "Negative Raw ADC pulse integrals",  "frNegAdcPulseIntRaw.THcSignalHit.GetData()"});
+    vars.push_back({"negAdcPulseAmpRaw",  "Negative Raw ADC pulse amplitudes", "frNegAdcPulseAmpRaw.THcSignalHit.GetData()"});
+    vars.push_back({"negAdcPulseTimeRaw", "Negative Raw ADC pulse times",      "frNegAdcPulseTimeRaw.THcSignalHit.GetData()"});
+    vars.push_back({"negAdcPed",          "Negative ADC pedestals",            "frNegAdcPed.THcSignalHit.GetData()"});
+    vars.push_back({"negAdcPulseInt",     "Negative ADC pulse integrals",      "frNegAdcPulseInt.THcSignalHit.GetData()"});
+    vars.push_back({"negAdcPulseAmp",     "Negative ADC pulse amplitudes",     "frNegAdcPulseAmp.THcSignalHit.GetData()"});
+  }
+  
   if (fSixGevData) {
     vars.push_back({"tpos",          "Positive Raw TDC",             "fT_Pos"});
     vars.push_back({"tneg",          "Negative Raw TDC",             "fT_Neg"});
@@ -378,9 +450,18 @@ void THcAerogel::Clear(Option_t* opt)
 
   fNhits = 0;	    
 
+  fNpeSum    = 0.0;
   fPosNpeSum = 0.0;
   fNegNpeSum = 0.0;
-  fNpeSum    = 0.0;
+
+  fTotNumAdcHits        = 0;
+  fTotNumGoodAdcHits    = 0;
+  fTotNumPosAdcHits     = 0;
+  fTotNumNegAdcHits     = 0;
+  fTotNumGoodPosAdcHits = 0;
+  fTotNumGoodNegAdcHits = 0;
+  fTotNumTracksMatched  = 0;
+  fTotNumTracksFired    = 0;
 
   fNGoodHits = 0;
 
@@ -396,8 +477,6 @@ void THcAerogel::Clear(Option_t* opt)
     fA_Neg_p[itube] = 0;
     fT_Pos[itube] = 0;
     fT_Neg[itube] = 0;
-    fPosNpe[itube] = 0.0;
-    fNegNpe[itube] = 0.0;
   }
 
   frPosAdcPedRaw->Clear();
@@ -418,6 +497,37 @@ void THcAerogel::Clear(Option_t* opt)
 
   fPosAdcErrorFlag->Clear();
   fNegAdcErrorFlag->Clear();
+
+  for (UInt_t ielem = 0; ielem < fNumPosAdcHits.size(); ielem++)
+    fNumPosAdcHits.at(ielem) = 0;
+  for (UInt_t ielem = 0; ielem < fNumNegAdcHits.size(); ielem++)
+    fNumNegAdcHits.at(ielem) = 0;
+  for (UInt_t ielem = 0; ielem < fNumGoodPosAdcHits.size(); ielem++)
+    fNumGoodPosAdcHits.at(ielem) = 0;
+  for (UInt_t ielem = 0; ielem < fNumGoodNegAdcHits.size(); ielem++)
+    fNumGoodNegAdcHits.at(ielem) = 0;
+  for (UInt_t ielem = 0; ielem < fNumTracksMatched.size(); ielem++)
+    fNumTracksMatched.at(ielem) = 0;
+  for (UInt_t ielem = 0; ielem < fNumTracksFired.size(); ielem++)
+    fNumTracksFired.at(ielem) = 0;
+
+  for (UInt_t ielem = 0; ielem < fGoodPosAdcPed.size(); ielem++) {
+    fGoodPosAdcPed.at(ielem)         = 0.0;
+    fGoodPosAdcPulseInt.at(ielem)    = 0.0;
+    fGoodPosAdcPulseIntRaw.at(ielem) = 0.0;
+    fGoodPosAdcPulseAmp.at(ielem)    = 0.0;
+    fGoodPosAdcPulseTime.at(ielem)   = 0.0;
+    fPosNpe.at(ielem)                = 0.0;
+  }
+
+  for (UInt_t ielem = 0; ielem < fGoodNegAdcPed.size(); ielem++) {
+    fGoodNegAdcPed.at(ielem)         = 0.0;
+    fGoodNegAdcPulseInt.at(ielem)    = 0.0;
+    fGoodNegAdcPulseIntRaw.at(ielem) = 0.0;
+    fGoodNegAdcPulseAmp.at(ielem)    = 0.0;
+    fGoodNegAdcPulseTime.at(ielem)   = 0.0;
+    fNegNpe.at(ielem)                = 0.0;
+  }
 
 }
 
@@ -471,6 +581,9 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
       if (rawPosAdcHit.GetPulseAmpRaw(thit) <= 0) ((THcSignalHit*) fPosAdcErrorFlag->ConstructedAt(nrPosAdcHits))->Set(npmt, 1);
 
       ++nrPosAdcHits;
+      fTotNumAdcHits++;
+      fTotNumPosAdcHits++;
+      fNumPosAdcHits.at(npmt-1) = npmt;
     }
 
     for (UInt_t thit=0; thit<rawNegAdcHit.GetNPulses(); ++thit) {
@@ -489,6 +602,9 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
       if (rawNegAdcHit.GetPulseAmpRaw(thit) <= 0) ((THcSignalHit*) fNegAdcErrorFlag->ConstructedAt(nrNegAdcHits))->Set(npmt, 1);
 
       ++nrNegAdcHits;
+      fTotNumAdcHits++;
+      fTotNumNegAdcHits++;
+      fNumNegAdcHits.at(npmt-1) = npmt;
     }
     ihit++;
   }
@@ -504,137 +620,223 @@ Int_t THcAerogel::ApplyCorrections( void )
 //_____________________________________________________________________________
 Int_t THcAerogel::CoarseProcess( TClonesArray&  ) //tracks
 {
-  for(Int_t ihit=0; ihit < fNhits; ihit++) {
 
-    Int_t nPosTDCHits = 0;
-    Int_t nNegTDCHits = 0;
-    Int_t nPosADCHits = 0;
-    Int_t nNegADCHits = 0;
+    // Loop over the elements in the TClonesArray
+    for(Int_t ielem = 0; ielem < frPosAdcPulseInt->GetEntries(); ielem++) {
 
-    THcAerogelHit* hit = (THcAerogelHit*) fRawHitList->At(ihit);
-    THcRawAdcHit&  rawPosAdcHit = hit->GetRawAdcHitPos();
-    THcRawAdcHit&  rawNegAdcHit = hit->GetRawAdcHitNeg();
+      Int_t    npmt         = ((THcSignalHit*) frPosAdcPulseInt->ConstructedAt(ielem))->GetPaddleNumber() - 1;
+      Double_t pulsePed     = ((THcSignalHit*) frPosAdcPed->ConstructedAt(ielem))->GetData();
+      Double_t pulseInt     = ((THcSignalHit*) frPosAdcPulseInt->ConstructedAt(ielem))->GetData();
+      Double_t pulseIntRaw  = ((THcSignalHit*) frPosAdcPulseIntRaw->ConstructedAt(ielem))->GetData();
+      Double_t pulseAmp     = ((THcSignalHit*) frPosAdcPulseAmp->ConstructedAt(ielem))->GetData();
+      Double_t pulseTime    = ((THcSignalHit*) frPosAdcPulseTimeRaw->ConstructedAt(ielem))->GetData();
+      Bool_t   errorFlag    = ((THcSignalHit*) fPosAdcErrorFlag->ConstructedAt(ielem))->GetData();  
+      Bool_t   pulseTimeCut = pulseTime > fAdcTimeWindowMin && pulseTime < fAdcTimeWindowMax;
 
-    // Fill the the per detector ADC arrays
-    Int_t npmt = hit->fCounter - 1;
+      // By default, the last hit within the timing cut will be considered "good"
+      if (!errorFlag && pulseTimeCut) {
+    	fGoodPosAdcPed.at(npmt)         = pulsePed;
+    	fGoodPosAdcPulseInt.at(npmt)    = pulseInt;
+    	fGoodPosAdcPulseIntRaw.at(npmt) = pulseIntRaw;
+    	fGoodPosAdcPulseAmp.at(npmt)    = pulseAmp;
+    	fGoodPosAdcPulseTime.at(npmt)   = pulseTime;
+      
+    	fPosNpe.at(npmt) = fPosGain[npmt]*fGoodPosAdcPulseInt.at(npmt);
+	fPosNpeSum += fPosNpe.at(npmt);
+    	fNpeSum += fPosNpeSum;
 
-    Double_t posAdcPulseInt = rawPosAdcHit.GetPulseInt();
-    Double_t negAdcPulseInt = rawNegAdcHit.GetPulseInt();
-
-    fPosNpe[npmt] = posAdcPulseInt*fPosGain[npmt];
-    fNegNpe[npmt] = negAdcPulseInt*fNegGain[npmt];
-
-    fPosNpeSum += fPosNpe[npmt];
-    fNegNpeSum += fNegNpe[npmt];
- 
-    // Sum positive and negative hits to fill tot_good_hits
-    if(fPosNpe[npmt] > 0.3) {fNADCPosHits++; fNGoodHits++;}
-    if(fNegNpe[npmt] > 0.3) {fNADCNegHits++; fNGoodHits++;}
-    
-    // cout << "\nPMT Num = " << npmt << endl; 
-    // cout << "posAdcPulseInt = " << posAdcPulseInt << "\t" 
-    // 	 << "fPosGain = " << fPosGain[npmt] << "\t" 
-    // 	 << "fPosNpe = " << fPosNpe[npmt] << "\t" << endl;
-    // cout << "negAdcPulseInt = " << negAdcPulseInt << "\t" 
-    // 	 << "fNegGain = " << fNegGain[npmt] << "\t" 
-    // 	 << "fNegNpe = " << fNegNpe[npmt] << "\t" << endl;
-    // cout << "fPosNpeSum = " << fPosNpeSum << "\t" 
-    // 	 << "fNegNpeSum = " << fNegNpeSum << endl;
-    
-    // 6 GeV calculations
-    Int_t adc_pos;
-    Int_t adc_neg;
-    Int_t tdc_pos=-1;
-    Int_t tdc_neg=-1;
-    if (fSixGevData) {
-      // ADC positive hit
-      if((adc_pos = hit->GetRawAdcHitPos().GetPulseInt()) > 0) {
-	THcSignalHit *sighit = (THcSignalHit*) fPosADCHits->ConstructedAt(nPosADCHits++);
-	sighit->Set(hit->fCounter, adc_pos);
+	fTotNumGoodAdcHits++;
+    	fTotNumGoodPosAdcHits++;
+    	fNumGoodPosAdcHits.at(npmt) = npmt + 1;
       }
-      // ADC negative hit
-      if((adc_neg = hit->GetRawAdcHitNeg().GetPulseInt()) > 0) {
-	THcSignalHit *sighit = (THcSignalHit*) fNegADCHits->ConstructedAt(nNegADCHits++);
-	sighit->Set(hit->fCounter, adc_neg);
-      }
-      // TDC positive hit
-      if(hit->GetRawTdcHitPos().GetNHits() >  0) {
-	THcSignalHit *sighit = (THcSignalHit*) fPosTDCHits->ConstructedAt(nPosTDCHits++);
-	tdc_pos = hit->GetRawTdcHitPos().GetTime()+fTdcOffset;
-	sighit->Set(hit->fCounter, tdc_pos);
-      }
-      // TDC negative hit
-      if(hit->GetRawTdcHitNeg().GetNHits() >  0) {
-	THcSignalHit *sighit = (THcSignalHit*) fNegTDCHits->ConstructedAt(nNegTDCHits++);
-	tdc_neg = hit->GetRawTdcHitNeg().GetTime()+fTdcOffset;
-	sighit->Set(hit->fCounter, tdc_neg);
-      }    
-      // For each TDC, identify the first hit that is positive.
-      tdc_pos = -1;
-      tdc_neg = -1;
-      for(UInt_t thit=0; thit<hit->GetRawTdcHitPos().GetNHits(); thit++) {
-	Int_t tdc = hit->GetRawTdcHitPos().GetTime(thit);
-	if(tdc >=0 ) {
-	  tdc_pos = tdc;
-	  break;
-	}
-      }
-      for(UInt_t thit=0; thit<hit->GetRawTdcHitNeg().GetNHits(); thit++) {
-	Int_t tdc = hit->GetRawTdcHitNeg().GetTime(thit);
-	if(tdc >= 0) {
-	  tdc_neg = tdc;
-	  break;
-	}
-      }
-
-      fA_Pos[npmt] = adc_pos;  
-      fA_Neg[npmt] = adc_neg;  
-      fA_Pos_p[npmt] = fA_Pos[npmt] - fPosPedMean[npmt];
-      fA_Neg_p[npmt] = fA_Neg[npmt] - fNegPedMean[npmt];
-      fT_Pos[npmt] = tdc_pos;
-      fT_Neg[npmt] = tdc_neg;
-
-      if(fA_Pos[npmt] < 8000) {
-	fPosNpe[npmt] = fPosGain[npmt]*fA_Pos_p[npmt];
-      } else {
-	fPosNpe[npmt] = 100.0;
-      }
-
-      if(fA_Neg[npmt] < 8000) {
-	fNegNpe[npmt] = fNegGain[npmt]*fA_Neg_p[npmt];
-      } else {
-	fNegNpe[npmt] = 100.0;
-      }
-
-      fPosNpeSum += fPosNpe[npmt];
-      fNegNpeSum += fNegNpe[npmt];
-
-      // Sum positive and negative hits to fill tot_good_hits
-      if(fPosNpe[npmt] > 0.3) {fNADCPosHits++; fNGoodHits++;}
-      if(fNegNpe[npmt] > 0.3) {fNADCNegHits++; fNGoodHits++;}      
-
-      if(fT_Pos[npmt] > 0 && fT_Pos[npmt] < 8000) {
-	fNTDCPosHits++;
-      }
-      if(fT_Neg[npmt] > 0 && fT_Neg[npmt] < 8000) {
-	fNTDCNegHits++;
-      }
-
     }
-  }
 
-  return 0;
+    // Loop over the elements in the TClonesArray
+    for(Int_t ielem = 0; ielem < frNegAdcPulseInt->GetEntries(); ielem++) {
+
+      Int_t    npmt         = ((THcSignalHit*) frNegAdcPulseInt->ConstructedAt(ielem))->GetPaddleNumber() - 1;
+      Double_t pulsePed     = ((THcSignalHit*) frNegAdcPed->ConstructedAt(ielem))->GetData();
+      Double_t pulseInt     = ((THcSignalHit*) frNegAdcPulseInt->ConstructedAt(ielem))->GetData();
+      Double_t pulseIntRaw  = ((THcSignalHit*) frNegAdcPulseIntRaw->ConstructedAt(ielem))->GetData();
+      Double_t pulseAmp     = ((THcSignalHit*) frNegAdcPulseAmp->ConstructedAt(ielem))->GetData();
+      Double_t pulseTime    = ((THcSignalHit*) frNegAdcPulseTimeRaw->ConstructedAt(ielem))->GetData();
+      Bool_t   errorFlag    = ((THcSignalHit*) fNegAdcErrorFlag->ConstructedAt(ielem))->GetData();  
+      Bool_t   pulseTimeCut = pulseTime > fAdcTimeWindowMin && pulseTime < fAdcTimeWindowMax;
+
+      // By default, the last hit within the timing cut will be considered "good"
+      if (!errorFlag && pulseTimeCut) {
+    	fGoodNegAdcPed.at(npmt)         = pulsePed;
+    	fGoodNegAdcPulseInt.at(npmt)    = pulseInt;
+    	fGoodNegAdcPulseIntRaw.at(npmt) = pulseIntRaw;
+    	fGoodNegAdcPulseAmp.at(npmt)    = pulseAmp;
+    	fGoodNegAdcPulseTime.at(npmt)   = pulseTime;
+      
+    	fNegNpe.at(npmt) = fNegGain[npmt]*fGoodNegAdcPulseInt.at(npmt);
+	fNegNpeSum += fNegNpe.at(npmt);
+    	fNpeSum += fNegNpeSum;
+
+	fTotNumGoodAdcHits++;
+   	fTotNumGoodNegAdcHits++;
+    	fNumGoodNegAdcHits.at(npmt) = npmt + 1;
+      }
+    }
+
+    for(Int_t ihit=0; ihit < fNhits; ihit++) {
+
+      Int_t nPosTDCHits = 0;
+      Int_t nNegTDCHits = 0;
+      Int_t nPosADCHits = 0;
+      Int_t nNegADCHits = 0;
+ 
+      // 6 GeV calculations
+      Int_t adc_pos;
+      Int_t adc_neg;
+      Int_t tdc_pos = -1;
+      Int_t tdc_neg = -1;
+      if (fSixGevData) {
+	THcAerogelHit* hit = (THcAerogelHit*) fRawHitList->At(ihit);
+	Int_t npmt = hit->fCounter - 1;
+
+	// // Sum positive and negative hits to fill tot_good_hits
+	// if(fPosNpe.at(npmt) > 0.3) {fNADCPosHits++; fNGoodHits++;}
+	// if(fNegNpe.at(npmt) > 0.3) {fNADCNegHits++; fNGoodHits++;}
+
+	// ADC positive hit
+	if((adc_pos = hit->GetRawAdcHitPos().GetPulseInt()) > 0) {
+	  THcSignalHit *sighit = (THcSignalHit*) fPosADCHits->ConstructedAt(nPosADCHits++);
+	  sighit->Set(hit->fCounter, adc_pos);
+	}
+	// ADC negative hit
+	if((adc_neg = hit->GetRawAdcHitNeg().GetPulseInt()) > 0) {
+	  THcSignalHit *sighit = (THcSignalHit*) fNegADCHits->ConstructedAt(nNegADCHits++);
+	  sighit->Set(hit->fCounter, adc_neg);
+	}
+	// TDC positive hit
+	if(hit->GetRawTdcHitPos().GetNHits() >  0) {
+	  THcSignalHit *sighit = (THcSignalHit*) fPosTDCHits->ConstructedAt(nPosTDCHits++);
+	  tdc_pos = hit->GetRawTdcHitPos().GetTime()+fTdcOffset;
+	  sighit->Set(hit->fCounter, tdc_pos);
+	}
+	// TDC negative hit
+	if(hit->GetRawTdcHitNeg().GetNHits() >  0) {
+	  THcSignalHit *sighit = (THcSignalHit*) fNegTDCHits->ConstructedAt(nNegTDCHits++);
+	  tdc_neg = hit->GetRawTdcHitNeg().GetTime()+fTdcOffset;
+	  sighit->Set(hit->fCounter, tdc_neg);
+	}    
+	// For each TDC, identify the first hit that is positive.
+	tdc_pos = -1;
+	tdc_neg = -1;
+	for(UInt_t thit=0; thit<hit->GetRawTdcHitPos().GetNHits(); thit++) {
+	  Int_t tdc = hit->GetRawTdcHitPos().GetTime(thit);
+	  if(tdc >=0 ) {
+	    tdc_pos = tdc;
+	    break;
+	  }
+	}
+	for(UInt_t thit=0; thit<hit->GetRawTdcHitNeg().GetNHits(); thit++) {
+	  Int_t tdc = hit->GetRawTdcHitNeg().GetTime(thit);
+	  if(tdc >= 0) {
+	    tdc_neg = tdc;
+	    break;
+	  }
+	}
+
+	fA_Pos[npmt] = adc_pos;  
+	fA_Neg[npmt] = adc_neg;  
+	fA_Pos_p[npmt] = fA_Pos[npmt] - fPosPedMean[npmt];
+	fA_Neg_p[npmt] = fA_Neg[npmt] - fNegPedMean[npmt];
+	fT_Pos[npmt] = tdc_pos;
+	fT_Neg[npmt] = tdc_neg;
+
+	if(fA_Pos[npmt] < 8000) fPosNpe[npmt] = fPosGain[npmt]*fA_Pos_p[npmt];
+	else fPosNpe[npmt] = 100.0;
+      
+	if(fA_Neg[npmt] < 8000) fNegNpe[npmt] = fNegGain[npmt]*fA_Neg_p[npmt];
+	else fNegNpe[npmt] = 100.0;
+      
+	fPosNpeSum += fPosNpe[npmt];
+	fNegNpeSum += fNegNpe[npmt];
+
+	// Sum positive and negative hits to fill tot_good_hits
+	if(fPosNpe[npmt] > 0.3) {fNADCPosHits++; fNGoodHits++;}
+	if(fNegNpe[npmt] > 0.3) {fNADCNegHits++; fNGoodHits++;}      
+
+	if(fT_Pos[npmt] > 0 && fT_Pos[npmt] < 8000) fNTDCPosHits++;
+	if(fT_Neg[npmt] > 0 && fT_Neg[npmt] < 8000) fNTDCNegHits++;
+      }
+    }
+    return 0;
 }
 
 //_____________________________________________________________________________
 Int_t THcAerogel::FineProcess( TClonesArray& tracks )
 {
+
+  Int_t nTracks = tracks.GetLast() + 1;
+
+  for (Int_t itrack = 0; itrack < nTracks; itrack++) {
+
+    THaTrack* track = dynamic_cast<THaTrack*> (tracks[itrack]);
+    if (track->GetIndex() != 0) continue;  // Select the best track
+
+    Double_t trackChi2    = track->GetChi2();
+    Int_t    trackNDoF    = track->GetNDoF();
+    Double_t trackRedChi2 = trackChi2/trackNDoF;
+    Double_t trackBeta    = track->GetBeta();
+    Double_t trackEnergy  = track->GetEnergy();
+    Double_t trackMom     = track->GetP();
+    Double_t trackENorm   = trackEnergy/trackMom;
+    Double_t trackXfp     = track->GetX();
+    Double_t trackYfp     = track->GetY();
+    Double_t trackTheta   = track->GetTheta();
+    Double_t trackPhi     = track->GetPhi();
+
+    Bool_t trackRedChi2Cut = trackRedChi2 > fRedChi2Min && trackRedChi2 < fRedChi2Max;
+    Bool_t trackBetaCut    = trackBeta    > fBetaMin    && trackBeta    < fBetaMax;
+    Bool_t trackENormCut   = trackENorm   > fENormMin   && trackENorm   < fENormMax;
+
+    if (trackRedChi2Cut && trackBetaCut && trackENormCut) {
+
+      // Project the track to the Aerogel diffuser box plane
+      Double_t xAtAero = trackXfp + trackTheta * fDiffBoxZPos;
+      Double_t yAtAero = trackYfp + trackPhi   * fDiffBoxZPos;
+
+      // cout << "Aerogel Detector: " << GetName() << endl;
+      // cout << "nTracks = " << nTracks << "\t" << "trackChi2 = " << trackChi2 
+      // 	   << "\t" << "trackNDof = " << trackNDoF << "\t" << "trackRedChi2 = " << trackRedChi2 << endl;
+      // cout << "trackBeta = " << trackBeta << "\t" << "trackEnergy = " << trackEnergy << "\t"
+      // 	   << "trackMom = " << trackMom << "\t" << "trackENorm = " << trackENorm << endl;
+      // cout << "trackXfp = " << trackXfp << "\t" << "trackYfp = " << trackYfp << "\t"
+      // 	   << "trackTheta = " << trackTheta << "\t" << "trackPhi = " << trackPhi << endl;
+      // cout << "fDiffBoxZPos = " << fDiffBoxZPos << "\t" << "xAtAero = " << xAtAero << "\t" << "yAtAero = " << yAtAero << endl;
+      // cout << "=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:" << endl;
+      
+
+      for (Int_t iregion = 0; iregion < fNRegions; iregion++) {
+
+      	if ((TMath::Abs(fRegionValue[GetIndex(iregion, 0)] - xAtAero)    < fRegionValue[GetIndex(iregion, 4)]) &&
+      	    (TMath::Abs(fRegionValue[GetIndex(iregion, 1)] - yAtAero)    < fRegionValue[GetIndex(iregion, 5)]) &&
+      	    (TMath::Abs(fRegionValue[GetIndex(iregion, 2)] - trackTheta) < fRegionValue[GetIndex(iregion, 6)]) &&
+      	    (TMath::Abs(fRegionValue[GetIndex(iregion, 3)] - trackPhi)   < fRegionValue[GetIndex(iregion, 7)])) {
+
+	  fTotNumTracksMatched++;
+      	  fNumTracksMatched.at(iregion) = iregion + 1;
+	  
+      	  if (fNpeSum > fNpeThresh) {
+      	    fTotNumTracksFired++;
+      	    fNumTracksFired.at(iregion) = iregion + 1;
+      	  }  // NPE threshold cut
+      	}  // Regional cuts
+      }  // Loop over regions
+    }  // Tracking cuts
+  }  // Track loop
+
   return 0;
 }
 
 //_____________________________________________________________________________
 // Method for initializing pedestals in the 6 GeV era
-void THcAerogel::InitializePedestals( )
+void THcAerogel::InitializePedestals()
 {
   fNPedestalEvents = 0;
   fMinPeds         = 0;                    // Do not calculate pedestals by default
@@ -705,7 +907,7 @@ void THcAerogel::AccumulatePedestals(TClonesArray* rawhits)
 
 //_____________________________________________________________________________
 // Method for calculating pedestals in the 6 GeV era
-void THcAerogel::CalculatePedestals( )
+void THcAerogel::CalculatePedestals()
 {
   // Use the accumulated pedestal data to calculate pedestals
   // Later add check to see if pedestals have drifted ("Danger Will Robinson!")
@@ -734,7 +936,14 @@ void THcAerogel::CalculatePedestals( )
 }
 
 //_____________________________________________________________________________
-void THcAerogel::Print( const Option_t* opt) const {
+Int_t THcAerogel::GetIndex(Int_t nRegion, Int_t nValue) {
+
+  return fNRegions * nValue + nRegion;
+
+}
+
+//_____________________________________________________________________________
+void THcAerogel::Print(const Option_t* opt) const {
   THaNonTrackingDetector::Print(opt);
 
   // Print out the pedestals

--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -63,6 +63,9 @@ THcAerogel::THcAerogel( const char* name, const char* description,
   frNegAdcPed = new TClonesArray("THcSignalHit", 16);
   frNegAdcPulseInt = new TClonesArray("THcSignalHit", 16);
   frNegAdcPulseAmp = new TClonesArray("THcSignalHit", 16);
+  
+  fPosAdcErrorFlag = new TClonesArray("THcSignalHit", 16);
+  fNegAdcErrorFlag = new TClonesArray("THcSignalHit", 16);
 
   InitArrays();
 
@@ -97,6 +100,9 @@ THcAerogel::THcAerogel( ) :
   frNegAdcPulseInt = NULL;
   frNegAdcPulseAmp = NULL;
 
+  fPosAdcErrorFlag = NULL;
+  fNegAdcErrorFlag = NULL;
+
   InitArrays();
 
 }
@@ -127,6 +133,9 @@ THcAerogel::~THcAerogel()
   delete frNegAdcPed; frNegAdcPed = NULL;
   delete frNegAdcPulseInt; frNegAdcPulseInt = NULL;
   delete frNegAdcPulseAmp; frNegAdcPulseAmp = NULL;
+
+  delete fPosAdcErrorFlag; fPosAdcErrorFlag= NULL;
+  delete fNegAdcErrorFlag; fNegAdcErrorFlag= NULL;
 
   DeleteArrays();
 
@@ -333,6 +342,9 @@ Int_t THcAerogel::DefineVariables( EMode mode )
   vars.push_back({"negAdcPulseInt",     "List of negative ADC pulse integrals.",      "frNegAdcPulseInt.THcSignalHit.GetData()"});
   vars.push_back({"negAdcPulseAmp",     "List of negative ADC pulse amplitudes.",     "frNegAdcPulseAmp.THcSignalHit.GetData()"});
 
+  vars.push_back({"posAdcErrorFlag",    "Error Flag for When FPGA Fails",    "fPosAdcErrorFlag.THcSignalHit.GetData()"});
+  vars.push_back({"negAdcErrorFlag",    "Error Flag for When FPGA Fails",    "fNegAdcErrorFlag.THcSignalHit.GetData()"});
+
   if (fSixGevData) {
     vars.push_back({"apos",          "Raw Positive ADC Amplitudes",            "fA_Pos"});
     vars.push_back({"aneg",          "Raw Negative ADC Amplitudes",            "fA_Neg"});
@@ -407,6 +419,10 @@ void THcAerogel::Clear(Option_t* opt)
   frNegAdcPed->Clear();
   frNegAdcPulseInt->Clear();
   frNegAdcPulseAmp->Clear();
+
+  fPosAdcErrorFlag->Clear();
+  fNegAdcErrorFlag->Clear();
+
 }
 
 //_____________________________________________________________________________
@@ -457,6 +473,9 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
 
       ((THcSignalHit*) frPosAdcPulseTimeRaw->ConstructedAt(nrPosAdcHits))->Set(padnum, rawPosAdcHit.GetPulseTimeRaw(thit));
 
+      if (rawPosAdcHit.GetPulseAmpRaw(thit) > 0)  ((THcSignalHit*) fPosAdcErrorFlag->ConstructedAt(nrPosAdcHits))->Set(padnum, 0);
+      if (rawPosAdcHit.GetPulseAmpRaw(thit) <= 0) ((THcSignalHit*) fPosAdcErrorFlag->ConstructedAt(nrPosAdcHits))->Set(padnum, 1);
+
       ++nrPosAdcHits;
     }
     THcRawAdcHit& rawNegAdcHit = hit->GetRawAdcHitNeg();
@@ -471,6 +490,9 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
       ((THcSignalHit*) frNegAdcPulseAmp->ConstructedAt(nrNegAdcHits))->Set(padnum, rawNegAdcHit.GetPulseAmp(thit));
 
       ((THcSignalHit*) frNegAdcPulseTimeRaw->ConstructedAt(nrNegAdcHits))->Set(padnum, rawNegAdcHit.GetPulseTimeRaw(thit));
+
+      if (rawNegAdcHit.GetPulseAmpRaw(thit) > 0)  ((THcSignalHit*) fNegAdcErrorFlag->ConstructedAt(nrNegAdcHits))->Set(padnum, 0);
+      if (rawNegAdcHit.GetPulseAmpRaw(thit) <= 0) ((THcSignalHit*) fNegAdcErrorFlag->ConstructedAt(nrNegAdcHits))->Set(padnum, 1);
 
       ++nrNegAdcHits;
     }

--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -67,6 +67,8 @@ THcAerogel::THcAerogel( const char* name, const char* description,
   fPosAdcErrorFlag = new TClonesArray("THcSignalHit", 16);
   fNegAdcErrorFlag = new TClonesArray("THcSignalHit", 16);
 
+  
+
   InitArrays();
 
 //  fTrackProj = new TClonesArray( "THaTrackProj", 5 );

--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -430,6 +430,8 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
   UInt_t nrPosAdcHits = 0;
   UInt_t nrNegAdcHits = 0;
 
+  cout << ":=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:" << endl;
+
   while(ihit < fNhits) {
     THcAerogelHit* hit = (THcAerogelHit *) fRawHitList->At(ihit);
 
@@ -516,9 +518,9 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
 
     // Fill the the per detector ADC and TDC arrays
     Int_t npmt = hit->fCounter - 1;
-
-    fA_Pos[npmt] = adc_pos;
-    fA_Neg[npmt] = adc_neg;
+    
+    fA_Pos[npmt] = adc_pos;  cout << "pos npmt = " << npmt << ", adc_pos = " << adc_pos << endl;
+    fA_Neg[npmt] = adc_neg;  cout << "neg npmt = " << npmt << ", adc_neg = " << adc_neg << endl;
     fA_Pos_p[npmt] = fA_Pos[npmt] - fPosPedMean[npmt];
     fA_Neg_p[npmt] = fA_Neg[npmt] - fNegPedMean[npmt];
     fT_Pos[npmt] = tdc_pos;

--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -23,7 +23,6 @@
 #include "THaTrack.h"
 #include "TClonesArray.h"
 #include "TMath.h"
-
 #include "THaTrackProj.h"
 #include "THcRawAdcHit.h"
 
@@ -39,13 +38,8 @@ THcAerogel::THcAerogel( const char* name, const char* description,
                         THaApparatus* apparatus ) :
   THaNonTrackingDetector(name,description,apparatus)
 {
+
   // Normal constructor with name and description
-  fPosTDCHits = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*16);
-  fNegTDCHits = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*16);
-
-  fPosADCHits = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
-  fNegADCHits = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
-
   frPosAdcPedRaw       = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
   frPosAdcPulseIntRaw  = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
   frPosAdcPulseAmpRaw  = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
@@ -53,7 +47,6 @@ THcAerogel::THcAerogel( const char* name, const char* description,
   frPosAdcPed          = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
   frPosAdcPulseInt     = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
   frPosAdcPulseAmp     = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
-
   frNegAdcPedRaw       = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
   frNegAdcPulseIntRaw  = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
   frNegAdcPulseAmpRaw  = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
@@ -61,9 +54,8 @@ THcAerogel::THcAerogel( const char* name, const char* description,
   frNegAdcPed          = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
   frNegAdcPulseInt     = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
   frNegAdcPulseAmp     = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
-  
-  fPosAdcErrorFlag = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
-  fNegAdcErrorFlag = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
+  fPosAdcErrorFlag     = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
+  fNegAdcErrorFlag     = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
 
   fNumPosAdcHits         = vector<Int_t>    (MaxNumPosAeroPmt, 0.0);
   fNumGoodPosAdcHits     = vector<Int_t>    (MaxNumPosAeroPmt, 0.0);
@@ -73,18 +65,25 @@ THcAerogel::THcAerogel( const char* name, const char* description,
   fNumTracksFired        = vector<Int_t>    (MaxNumPosAeroPmt, 0.0);
   fPosNpe                = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
   fNegNpe                = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
-
   fGoodPosAdcPed         = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
   fGoodPosAdcPulseInt    = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
   fGoodPosAdcPulseIntRaw = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
   fGoodPosAdcPulseAmp    = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
   fGoodPosAdcPulseTime   = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
-
   fGoodNegAdcPed         = vector<Double_t> (MaxNumNegAeroPmt, 0.0);
   fGoodNegAdcPulseInt    = vector<Double_t> (MaxNumNegAeroPmt, 0.0);
   fGoodNegAdcPulseIntRaw = vector<Double_t> (MaxNumNegAeroPmt, 0.0);
   fGoodNegAdcPulseAmp    = vector<Double_t> (MaxNumNegAeroPmt, 0.0);
   fGoodNegAdcPulseTime   = vector<Double_t> (MaxNumNegAeroPmt, 0.0);
+
+  // 6 GeV variables
+  fPosTDCHits = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*16);
+  fNegTDCHits = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*16);
+  fPosADCHits = new TClonesArray("THcSignalHit", MaxNumPosAeroPmt*MaxNumAdcPulse);
+  fNegADCHits = new TClonesArray("THcSignalHit", MaxNumNegAeroPmt*MaxNumAdcPulse);
+
+  fPosNpeSixGev = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
+  fNegNpeSixGev = vector<Double_t> (MaxNumPosAeroPmt, 0.0);
 
   InitArrays();
 
@@ -95,12 +94,6 @@ THcAerogel::THcAerogel( ) :
   THaNonTrackingDetector()
 {
   // Constructor
-  fPosTDCHits = NULL;
-  fNegTDCHits = NULL;
-
-  fPosADCHits = NULL;
-  fNegADCHits = NULL;
-
   frPosAdcPedRaw       = NULL;
   frPosAdcPulseIntRaw  = NULL;
   frPosAdcPulseAmpRaw  = NULL;
@@ -108,7 +101,6 @@ THcAerogel::THcAerogel( ) :
   frPosAdcPed          = NULL;
   frPosAdcPulseInt     = NULL;
   frPosAdcPulseAmp     = NULL;
-
   frNegAdcPedRaw       = NULL;
   frNegAdcPulseIntRaw  = NULL;
   frNegAdcPulseAmpRaw  = NULL;
@@ -116,9 +108,14 @@ THcAerogel::THcAerogel( ) :
   frNegAdcPed          = NULL;
   frNegAdcPulseInt     = NULL;
   frNegAdcPulseAmp     = NULL;
+  fPosAdcErrorFlag     = NULL;
+  fNegAdcErrorFlag     = NULL;
 
-  fPosAdcErrorFlag = NULL;
-  fNegAdcErrorFlag = NULL;
+  // 6 GeV variables
+  fPosTDCHits = NULL;
+  fNegTDCHits = NULL;
+  fPosADCHits = NULL;
+  fNegADCHits = NULL;
 
   InitArrays();
 
@@ -128,12 +125,6 @@ THcAerogel::THcAerogel( ) :
 THcAerogel::~THcAerogel()
 {
   // Destructor
-  delete fPosTDCHits; fPosTDCHits = NULL;
-  delete fNegTDCHits; fNegTDCHits = NULL;
-
-  delete fPosADCHits; fPosADCHits = NULL;
-  delete fNegADCHits; fNegADCHits = NULL;
-
   delete frPosAdcPedRaw;       frPosAdcPedRaw       = NULL;
   delete frPosAdcPulseIntRaw;  frPosAdcPulseIntRaw  = NULL;
   delete frPosAdcPulseAmpRaw;  frPosAdcPulseAmpRaw  = NULL;
@@ -141,7 +132,6 @@ THcAerogel::~THcAerogel()
   delete frPosAdcPed;          frPosAdcPed          = NULL;
   delete frPosAdcPulseInt;     frPosAdcPulseInt     = NULL;
   delete frPosAdcPulseAmp;     frPosAdcPulseAmp     = NULL;
-
   delete frNegAdcPedRaw;       frNegAdcPedRaw       = NULL;
   delete frNegAdcPulseIntRaw;  frNegAdcPulseIntRaw  = NULL;
   delete frNegAdcPulseAmpRaw;  frNegAdcPulseAmpRaw  = NULL;
@@ -149,9 +139,14 @@ THcAerogel::~THcAerogel()
   delete frNegAdcPed;          frNegAdcPed          = NULL;
   delete frNegAdcPulseInt;     frNegAdcPulseInt     = NULL;
   delete frNegAdcPulseAmp;     frNegAdcPulseAmp     = NULL;
-
-  delete fPosAdcErrorFlag; fPosAdcErrorFlag = NULL;
-  delete fNegAdcErrorFlag; fNegAdcErrorFlag = NULL;
+  delete fPosAdcErrorFlag;     fPosAdcErrorFlag     = NULL;
+  delete fNegAdcErrorFlag;     fNegAdcErrorFlag     = NULL;
+  
+  // 6 GeV variables
+  delete fPosTDCHits; fPosTDCHits = NULL;
+  delete fNegTDCHits; fNegTDCHits = NULL;
+  delete fPosADCHits; fPosADCHits = NULL;
+  delete fNegADCHits; fNegADCHits = NULL;
 
   DeleteArrays();
 
@@ -160,16 +155,16 @@ THcAerogel::~THcAerogel()
 //_____________________________________________________________________________
 void THcAerogel::InitArrays()
 {
-  fA_Pos   = NULL;
-  fA_Neg   = NULL;
-  fA_Pos_p = NULL;
-  fA_Neg_p = NULL;
-  fT_Pos   = NULL;
-  fT_Neg   = NULL;
-
   fPosGain = NULL;
   fNegGain = NULL;
 
+  // 6 GeV variables
+  fA_Pos       = NULL;
+  fA_Neg       = NULL;
+  fA_Pos_p     = NULL;
+  fA_Neg_p     = NULL;
+  fT_Pos       = NULL;
+  fT_Neg       = NULL;
   fPosPedLimit = NULL;
   fNegPedLimit = NULL;
   fPosPedMean  = NULL;
@@ -190,16 +185,16 @@ void THcAerogel::InitArrays()
 //_____________________________________________________________________________
 void THcAerogel::DeleteArrays()
 {
-  delete [] fA_Pos;   fA_Pos   = NULL;
-  delete [] fA_Neg;   fA_Neg   = NULL;
-  delete [] fA_Pos_p; fA_Pos_p = NULL;
-  delete [] fA_Neg_p; fA_Neg_p = NULL;
-  delete [] fT_Pos;   fT_Pos   = NULL;
-  delete [] fT_Neg;   fT_Neg   = NULL;
-
   delete [] fPosGain; fPosGain = NULL;
   delete [] fNegGain; fNegGain = NULL;
   
+  // 6 GeV variables
+  delete [] fA_Pos;       fA_Pos       = NULL;
+  delete [] fA_Neg;       fA_Neg       = NULL;
+  delete [] fA_Pos_p;     fA_Pos_p     = NULL;
+  delete [] fA_Neg_p;     fA_Neg_p     = NULL;
+  delete [] fT_Pos;       fT_Pos       = NULL;
+  delete [] fT_Neg;       fT_Neg       = NULL;
   delete [] fPosPedLimit; fPosPedLimit = NULL;
   delete [] fNegPedLimit; fNegPedLimit = NULL;
   delete [] fPosPedMean;  fPosPedMean  = NULL;
@@ -222,7 +217,7 @@ void THcAerogel::DeleteArrays()
 THaAnalysisObject::EStatus THcAerogel::Init( const TDatime& date )
 {
 
-  cout << "THcAerogel::Init " << GetName() << endl;
+  cout << "THcAerogel::Init for: " << GetName() << endl;
 
   char EngineDID[] = "xAERO";
   EngineDID[0] = toupper(GetApparatus()->GetName()[0]);
@@ -239,7 +234,7 @@ THaAnalysisObject::EStatus THcAerogel::Init( const TDatime& date )
   EStatus status;
   if( (status = THaNonTrackingDetector::Init( date )) )
     return fStatus=status;
-
+  
   return fStatus = kOK;
 }
 
@@ -249,36 +244,37 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
   // This function is called by THaDetectorBase::Init() once at the beginning
   // of the analysis.
 
-  cout << "THcAerogel::ReadDatabase " << GetName() << endl;
+  cout << "THcAerogel::ReadDatabase for: " << GetName() << endl;
 
   char prefix[2];
-
   prefix[0]=tolower(GetApparatus()->GetName()[0]);
   prefix[1]='\0';
 
-  fNelem = 8;			// Default if not defined
-  fNRegions = 1;  // Default if not set in parameter file
+  fNRegions = 1;   // Default if not set in parameter file
 
-  Bool_t optional = true ;
   DBRequest listextra[]={
-    {"aero_num_pairs", &fNelem, kInt, 0, optional},
+    {"aero_num_pairs", &fNelem, kInt},
     {0}
   };
 
   gHcParms->LoadParmValues((DBRequest*)&listextra, prefix);
 
+  Bool_t optional = true ;
+  
+  cout << "Number of " << GetApparatus()->GetName() << "." 
+       << GetName() << " PMT pairs defined = " << fNelem << endl;
+
   fPosGain = new Double_t[fNelem];
   fNegGain = new Double_t[fNelem];
-
-  fA_Pos   = new Float_t[fNelem];
-  fA_Neg   = new Float_t[fNelem];
-  fA_Pos_p = new Float_t[fNelem];
-  fA_Neg_p = new Float_t[fNelem];
 
   // 6 GeV variables
   fTdcOffset   = 0; // Offset to make reference time subtracted times positve
   fPosPedLimit = new Int_t[fNelem];
   fNegPedLimit = new Int_t[fNelem];
+  fA_Pos       = new Float_t[fNelem];
+  fA_Neg       = new Float_t[fNelem];
+  fA_Pos_p     = new Float_t[fNelem];
+  fA_Neg_p     = new Float_t[fNelem];
   fT_Pos       = new Float_t[fNelem];
   fT_Neg       = new Float_t[fNelem];
   fPosPedMean  = new Double_t[fNelem];
@@ -327,7 +323,8 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
 
   fIsInit = true;
 
-  cout << " Track Matching Parameters for: " << GetName() << endl;
+  cout << "Track Matching Parameters for: " << GetApparatus()->GetName() 
+       << "." << GetName() << endl;
   for (Int_t iregion = 0; iregion < fNRegions; iregion++) {
     cout << "Region = " << iregion + 1 << endl;
     for (Int_t ivalue = 0; ivalue < 8; ivalue++)
@@ -343,7 +340,7 @@ Int_t THcAerogel::DefineVariables( EMode mode )
 {
   // Initialize global variables for histogramming and tree
 
-  cout << "THcAerogel::DefineVariables called " << GetName() << endl;
+  cout << "THcAerogel::DefineVariables called for: " << GetName() << endl;
 
   if( mode == kDefine && fIsSetup ) return kOK;
   fIsSetup = ( mode == kDefine );
@@ -355,25 +352,16 @@ Int_t THcAerogel::DefineVariables( EMode mode )
 
   vector<RVarDef> vars;
 
-  vars.push_back({"posGain", "Positive PMT gains", "fPosGain"});
-  vars.push_back({"negGain", "Negative PMT gains", "fNegGain"});
-  vars.push_back({"nGoodHits", "Total number of good hits", "fNGoodHits"});
-  vars.push_back({"apos",          "Positive Raw ADC Amplitudes",            "fA_Pos"});
-  vars.push_back({"aneg",          "Negative Raw ADC Amplitudes",            "fA_Neg"});
-  vars.push_back({"apos_p",        "Positive Ped-subtracted ADC Amplitudes", "fA_Pos_p"});
-  vars.push_back({"aneg_p",        "Negative Ped-subtracted ADC Amplitudes", "fA_Neg_p"});
+  vars.push_back({"posAdcCounter",   "Positive ADC counter numbers",   "frPosAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
+  vars.push_back({"negAdcCounter",   "Negative ADC counter numbers",   "frNegAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
+  vars.push_back({"posAdcErrorFlag", "Error Flag for When FPGA Fails", "fPosAdcErrorFlag.THcSignalHit.GetData()"});
+  vars.push_back({"negAdcErrorFlag", "Error Flag for When FPGA Fails", "fNegAdcErrorFlag.THcSignalHit.GetData()"});
 
-  vars.push_back({"numPosAdcHits",        "Number of Positive ADC Hits Per PMT",      "fNumPosAdcHits"});        // Aerogel occupancy
   vars.push_back({"numGoodPosAdcHits",    "Number of Good Positive ADC Hits Per PMT", "fNumGoodPosAdcHits"});    // Aerogel occupancy
-  vars.push_back({"totNumPosAdcHits",     "Total Number of Positive ADC Hits",        "fTotNumPosAdcHits"});     // Aerogel multiplicity
-  vars.push_back({"totNumGoodPosAdcHits", "Total Number of Good Positive ADC Hits",   "fTotNumGoodPosAdcHits"}); // Aerogel multiplicity
-
-  vars.push_back({"numNegAdcHits",        "Number of Negative ADC Hits Per PMT",      "fNumNegAdcHits"});        // Aerogel occupancy
   vars.push_back({"numGoodNegAdcHits",    "Number of Good Negative ADC Hits Per PMT", "fNumGoodNegAdcHits"});    // Aerogel occupancy
-  vars.push_back({"totNumNegAdcHits",     "Total Number of Negative ADC Hits",        "fTotNumNegAdcHits"});     // Aerogel multiplicity
+  vars.push_back({"totNumGoodPosAdcHits", "Total Number of Good Positive ADC Hits",   "fTotNumGoodPosAdcHits"}); // Aerogel multiplicity
   vars.push_back({"totNumGoodNegAdcHits", "Total Number of Good Negative ADC Hits",   "fTotNumGoodNegAdcHits"}); // Aerogel multiplicity
   
-  vars.push_back({"totnumAdcHits",       "Total Number of ADC Hits Per PMT",          "fTotNumAdcHits"});        // Aerogel multiplicity
   vars.push_back({"totnumGoodAdcHits",   "TotalNumber of Good ADC Hits Per PMT",      "fTotNumGoodAdcHits"});    // Aerogel multiplicity
   vars.push_back({"numTracksMatched",    "Number of Tracks Matched Per Region",       "fNumTracksMatched"});        
   vars.push_back({"numTracksFired",      "Number of Tracks that Fired Per Region",    "fNumTracksFired"});                
@@ -381,15 +369,10 @@ Int_t THcAerogel::DefineVariables( EMode mode )
   vars.push_back({"totNumTracksFired",   "Total Number of Tracks that Fired",         "fTotNumTracksFired"});
   
   vars.push_back({"posNpe",    "Number of Positive PEs",       "fPosNpe"});
-  vars.push_back({"negNpe",    "Number of Positive PEs",       "fNegNpe"});
-  vars.push_back({"posNpeSum", "Total Number of Negative PEs", "fPosNpeSum"});
+  vars.push_back({"negNpe",    "Number of Negative PEs",       "fNegNpe"});
+  vars.push_back({"posNpeSum", "Total Number of Positive PEs", "fPosNpeSum"});
   vars.push_back({"negNpeSum", "Total Number of Negative PEs", "fNegNpeSum"});
   vars.push_back({"npeSum",    "Total Number of PEs",          "fNpeSum"});
-
-  vars.push_back({"posAdcCounter",   "Positive ADC counter numbers",   "frPosAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
-  vars.push_back({"negAdcCounter",   "Negative ADC counter numbers",   "frNegAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
-  vars.push_back({"posAdcErrorFlag", "Error Flag for When FPGA Fails", "fPosAdcErrorFlag.THcSignalHit.GetData()"});
-  vars.push_back({"negAdcErrorFlag", "Error Flag for When FPGA Fails", "fNegAdcErrorFlag.THcSignalHit.GetData()"});
 
   vars.push_back({"goodPosAdcPed",         "Good Negative ADC pedestals",           "fGoodPosAdcPed"});
   vars.push_back({"goodPosAdcPulseInt",    "Good Negative ADC pulse integrals",     "fGoodPosAdcPulseInt"});
@@ -404,6 +387,15 @@ Int_t THcAerogel::DefineVariables( EMode mode )
   vars.push_back({"goodNegAdcPulseTime",   "Good Negative ADC pulse times",         "fGoodNegAdcPulseTime"});
 
   if (fDebugAdc) {
+    vars.push_back({"posGain", "Positive PMT gains", "fPosGain"});
+    vars.push_back({"negGain", "Negative PMT gains", "fNegGain"});
+
+    vars.push_back({"numPosAdcHits",        "Number of Positive ADC Hits Per PMT",      "fNumPosAdcHits"});        // Aerogel occupancy
+    vars.push_back({"totNumPosAdcHits",     "Total Number of Positive ADC Hits",        "fTotNumPosAdcHits"});     // Aerogel multiplicity
+    vars.push_back({"numNegAdcHits",        "Number of Negative ADC Hits Per PMT",      "fNumNegAdcHits"});        // Aerogel occupancy
+    vars.push_back({"totNumNegAdcHits",     "Total Number of Negative ADC Hits",        "fTotNumNegAdcHits"});     // Aerogel multiplicity
+    vars.push_back({"totnumAdcHits",       "Total Number of ADC Hits Per PMT",          "fTotNumAdcHits"});        // Aerogel multiplicity
+    
     vars.push_back({"posAdcPedRaw",       "Positive Raw ADC pedestals",        "frPosAdcPedRaw.THcSignalHit.GetData()"});
     vars.push_back({"posAdcPulseIntRaw",  "Positive Raw ADC pulse integrals",  "frPosAdcPulseIntRaw.THcSignalHit.GetData()"});
     vars.push_back({"posAdcPulseAmpRaw",  "Positive Raw ADC pulse amplitudes", "frPosAdcPulseAmpRaw.THcSignalHit.GetData()"});
@@ -422,14 +414,24 @@ Int_t THcAerogel::DefineVariables( EMode mode )
   }
   
   if (fSixGevData) {
-    vars.push_back({"tpos",          "Positive Raw TDC",             "fT_Pos"});
-    vars.push_back({"tneg",          "Negative Raw TDC",             "fT_Neg"});
-    vars.push_back({"ntdc_pos_hits", "Number of Positive Tube Hits", "fNTDCPosHits"});
-    vars.push_back({"ntdc_neg_hits", "Number of Negative Tube Hits", "fNTDCNegHits"});
-    vars.push_back({"posadchits",    "Positive ADC hits",            "fPosADCHits.THcSignalHit.GetPaddleNumber()"});
-    vars.push_back({"negadchits",    "Negative ADC hits",            "fNegADCHits.THcSignalHit.GetPaddleNumber()"});
-    vars.push_back({"postdchits",    "Positive TDC hits",            "fPosTDCHits.THcSignalHit.GetPaddleNumber()"});
-    vars.push_back({"negtdchits",    "Negative TDC hits",            "fNegTDCHits.THcSignalHit.GetPaddleNumber()"});
+    vars.push_back({"apos",            "Positive Raw ADC Amplitudes",            "fA_Pos"});
+    vars.push_back({"aneg",            "Negative Raw ADC Amplitudes",            "fA_Neg"});
+    vars.push_back({"apos_p",          "Positive Ped-subtracted ADC Amplitudes", "fA_Pos_p"});
+    vars.push_back({"aneg_p",          "Negative Ped-subtracted ADC Amplitudes", "fA_Neg_p"});
+    vars.push_back({"tpos",            "Positive Raw TDC",                       "fT_Pos"});
+    vars.push_back({"tneg",            "Negative Raw TDC",                       "fT_Neg"});
+    vars.push_back({"ntdc_pos_hits",   "Number of Positive Tube Hits",           "fNTDCPosHits"});
+    vars.push_back({"ntdc_neg_hits",   "Number of Negative Tube Hits",           "fNTDCNegHits"});
+    vars.push_back({"posadchits",      "Positive ADC hits",                      "fPosADCHits.THcSignalHit.GetPaddleNumber()"});
+    vars.push_back({"negadchits",      "Negative ADC hits",                      "fNegADCHits.THcSignalHit.GetPaddleNumber()"});
+    vars.push_back({"postdchits",      "Positive TDC hits",                      "fPosTDCHits.THcSignalHit.GetPaddleNumber()"});
+    vars.push_back({"negtdchits",      "Negative TDC hits",                      "fNegTDCHits.THcSignalHit.GetPaddleNumber()"});
+    vars.push_back({"nGoodHits",       "Total number of good hits",              "fNGoodHits"});
+    vars.push_back({"posNpeSixGev",    "Number of Positive PEs",                 "fPosNpeSixGev"});
+    vars.push_back({"negNpeSixGev",    "Number of Negative PEs",                 "fNegNpeSixGev"});
+    vars.push_back({"posNpeSumSixGev", "Total Number of Positive PEs",           "fPosNpeSumSixGev"});
+    vars.push_back({"negNpeSumSixGev", "Total Number of Negative PEs",           "fNegNpeSumSixGev"});
+    vars.push_back({"npeSumSixGev",    "Total Number of PEs",                    "fNpeSumSixGev"});
   }
   
   RVarDef end {0};
@@ -443,17 +445,7 @@ inline
 void THcAerogel::Clear(Option_t* opt)
 {
   // Clear the hit lists
-  fPosTDCHits->Clear();
-  fNegTDCHits->Clear();
-  fPosADCHits->Clear();
-  fNegADCHits->Clear();
-
-  fNhits = 0;	    
-
-  fNpeSum    = 0.0;
-  fPosNpeSum = 0.0;
-  fNegNpeSum = 0.0;
-
+  fNhits                = 0;
   fTotNumAdcHits        = 0;
   fTotNumGoodAdcHits    = 0;
   fTotNumPosAdcHits     = 0;
@@ -463,21 +455,9 @@ void THcAerogel::Clear(Option_t* opt)
   fTotNumTracksMatched  = 0;
   fTotNumTracksFired    = 0;
 
-  fNGoodHits = 0;
-
-  fNADCPosHits = 0;
-  fNADCNegHits = 0;
-  fNTDCPosHits = 0;
-  fNTDCNegHits = 0;
-
-  for(Int_t itube = 0;itube < fNelem;itube++) {
-    fA_Pos[itube] = 0;
-    fA_Neg[itube] = 0;
-    fA_Pos_p[itube] = 0;
-    fA_Neg_p[itube] = 0;
-    fT_Pos[itube] = 0;
-    fT_Neg[itube] = 0;
-  }
+  fNpeSum    = 0.0;
+  fPosNpeSum = 0.0;
+  fNegNpeSum = 0.0;
 
   frPosAdcPedRaw->Clear();
   frPosAdcPulseIntRaw->Clear();
@@ -519,7 +499,6 @@ void THcAerogel::Clear(Option_t* opt)
     fGoodPosAdcPulseTime.at(ielem)   = 0.0;
     fPosNpe.at(ielem)                = 0.0;
   }
-
   for (UInt_t ielem = 0; ielem < fGoodNegAdcPed.size(); ielem++) {
     fGoodNegAdcPed.at(ielem)         = 0.0;
     fGoodNegAdcPulseInt.at(ielem)    = 0.0;
@@ -529,10 +508,38 @@ void THcAerogel::Clear(Option_t* opt)
     fNegNpe.at(ielem)                = 0.0;
   }
 
+  // 6 GeV variables
+  fNGoodHits       = 0;
+  fNADCPosHits     = 0;
+  fNADCNegHits     = 0;
+  fNTDCPosHits     = 0;
+  fNTDCNegHits     = 0;
+  fNpeSumSixGev    = 0.0;
+  fPosNpeSumSixGev = 0.0;
+  fNegNpeSumSixGev = 0.0;
+  fPosTDCHits->Clear();
+  fNegTDCHits->Clear();
+  fPosADCHits->Clear();
+  fNegADCHits->Clear();
+
+  for (UInt_t ielem = 0; ielem < fPosNpeSixGev.size(); ielem++)
+    fPosNpeSixGev.at(ielem) = 0.0;
+  for (UInt_t ielem = 0; ielem < fNegNpeSixGev.size(); ielem++)
+    fNegNpeSixGev.at(ielem) = 0.0;
+
+  for(Int_t itube = 0;itube < fNelem;itube++) {
+    fA_Pos[itube]   = 0;
+    fA_Neg[itube]   = 0;
+    fA_Pos_p[itube] = 0;
+    fA_Neg_p[itube] = 0;
+    fT_Pos[itube]   = 0;
+    fT_Neg[itube]   = 0;
+  }
+
 }
 
 //_____________________________________________________________________________
-Int_t THcAerogel::Decode( const THaEvData& evdata )
+Int_t THcAerogel::Decode( const THaEvData& evdata ) 
 {
   // Get the Hall C style hitlist (fRawHitList) for this event
   fNhits = DecodeToHitList(evdata);
@@ -543,7 +550,6 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
       fAnalyzePedestals = 1;	// Analyze pedestals first normal events
       return(0);
     }
-
     if(fAnalyzePedestals) {
       CalculatePedestals();
       Print("");
@@ -551,14 +557,11 @@ Int_t THcAerogel::Decode( const THaEvData& evdata )
     }
   }
 
-  Int_t ihit          = 0;
+  Int_t  ihit         = 0;
   UInt_t nrPosAdcHits = 0;
   UInt_t nrNegAdcHits = 0;
 
-  //cout << ":=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:" << endl;
-
   while(ihit < fNhits) {
-
     THcAerogelHit* hit          = (THcAerogelHit*) fRawHitList->At(ihit);
     Int_t          npmt         = hit->fCounter;
     THcRawAdcHit&  rawPosAdcHit = hit->GetRawAdcHitPos();
@@ -697,9 +700,9 @@ Int_t THcAerogel::CoarseProcess( TClonesArray&  ) //tracks
 	THcAerogelHit* hit = (THcAerogelHit*) fRawHitList->At(ihit);
 	Int_t npmt = hit->fCounter - 1;
 
-	// // Sum positive and negative hits to fill tot_good_hits
-	// if(fPosNpe.at(npmt) > 0.3) {fNADCPosHits++; fNGoodHits++;}
-	// if(fNegNpe.at(npmt) > 0.3) {fNADCNegHits++; fNGoodHits++;}
+	// Sum positive and negative hits to fill tot_good_hits
+	if(fPosNpe.at(npmt) > 0.3) {fNADCPosHits++; fNGoodHits++;}
+	if(fNegNpe.at(npmt) > 0.3) {fNADCNegHits++; fNGoodHits++;}
 
 	// ADC positive hit
 	if((adc_pos = hit->GetRawAdcHitPos().GetPulseInt()) > 0) {
@@ -748,22 +751,29 @@ Int_t THcAerogel::CoarseProcess( TClonesArray&  ) //tracks
 	fT_Pos[npmt] = tdc_pos;
 	fT_Neg[npmt] = tdc_neg;
 
-	if(fA_Pos[npmt] < 8000) fPosNpe[npmt] = fPosGain[npmt]*fA_Pos_p[npmt];
-	else fPosNpe[npmt] = 100.0;
+	if(fA_Pos[npmt] < 8000) fPosNpeSixGev[npmt] = fPosGain[npmt]*fA_Pos_p[npmt];
+	else fPosNpeSixGev[npmt] = 100.0;
       
-	if(fA_Neg[npmt] < 8000) fNegNpe[npmt] = fNegGain[npmt]*fA_Neg_p[npmt];
-	else fNegNpe[npmt] = 100.0;
+	if(fA_Neg[npmt] < 8000) fNegNpeSixGev[npmt] = fNegGain[npmt]*fA_Neg_p[npmt];
+	else fNegNpeSixGev[npmt] = 100.0;
       
-	fPosNpeSum += fPosNpe[npmt];
-	fNegNpeSum += fNegNpe[npmt];
+	fPosNpeSumSixGev += fPosNpeSixGev[npmt];
+	fNegNpeSumSixGev += fNegNpeSixGev[npmt];
 
 	// Sum positive and negative hits to fill tot_good_hits
-	if(fPosNpe[npmt] > 0.3) {fNADCPosHits++; fNGoodHits++;}
-	if(fNegNpe[npmt] > 0.3) {fNADCNegHits++; fNGoodHits++;}      
+	if(fPosNpeSixGev[npmt] > 0.3) {fNADCPosHits++; fNGoodHits++;}
+	if(fNegNpeSixGev[npmt] > 0.3) {fNADCNegHits++; fNGoodHits++;}      
 
 	if(fT_Pos[npmt] > 0 && fT_Pos[npmt] < 8000) fNTDCPosHits++;
 	if(fT_Neg[npmt] > 0 && fT_Neg[npmt] < 8000) fNTDCNegHits++;
       }
+
+      if (fPosNpeSumSixGev > 0.5 || fNegNpeSumSixGev > 0.5) 
+	fNpeSumSixGev = fPosNpeSumSixGev + fNegNpeSumSixGev;
+      else fNpeSumSixGev = 0.0;
+      // If total hits are 0, then give a noticable ridiculous NPE
+      if (fNhits < 1) fNpeSumSixGev = 0.0;
+
     }
     return 0;
 }
@@ -854,7 +864,7 @@ void THcAerogel::InitializePedestals()
   fPosThresh   = new Double_t [fNelem];
   fNegThresh   = new Double_t [fNelem];
 
-  for(Int_t i=0;i<fNelem;i++) {
+  for(Int_t i = 0;i < fNelem; i++) {
     fPosPedSum[i]   = 0;
     fPosPedSum2[i]  = 0;
     fPosPedLimit[i] = 1000;   // In engine, this are set in parameter file
@@ -936,14 +946,14 @@ void THcAerogel::CalculatePedestals()
 }
 
 //_____________________________________________________________________________
-Int_t THcAerogel::GetIndex(Int_t nRegion, Int_t nValue) {
-
+Int_t THcAerogel::GetIndex(Int_t nRegion, Int_t nValue) 
+{
   return fNRegions * nValue + nRegion;
-
 }
 
 //_____________________________________________________________________________
-void THcAerogel::Print(const Option_t* opt) const {
+void THcAerogel::Print(const Option_t* opt) const 
+{
   THaNonTrackingDetector::Print(opt);
 
   // Print out the pedestals

--- a/src/THcAerogel.h
+++ b/src/THcAerogel.h
@@ -39,6 +39,7 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   THcAerogel();  // for ROOT I/O
  protected:
   Int_t fAnalyzePedestals;
+  Int_t fSixGevData;
 
   // Parameters
   Double_t* fPosGain;

--- a/src/THcAerogel.h
+++ b/src/THcAerogel.h
@@ -15,26 +15,23 @@
 class THcAerogel : public THaNonTrackingDetector, public THcHitList {
 
  public:
-  THcAerogel( const char* name, const char* description = "",
-		THaApparatus* a = NULL );
+  THcAerogel(const char* name, const char* description = "", THaApparatus* a = NULL);
   virtual ~THcAerogel();
 
-  virtual void 	     Clear( Option_t* opt="" );
-  virtual Int_t      Decode( const THaEvData& );
-  void               InitArrays();
-  void               DeleteArrays();
-  virtual EStatus    Init( const TDatime& run_time );
-  virtual Int_t      ReadDatabase( const TDatime& date );
-  virtual Int_t      DefineVariables( EMode mode = kDefine );
-  virtual Int_t      CoarseProcess( TClonesArray& tracks );
-  virtual Int_t      FineProcess( TClonesArray& tracks );
+  virtual void 	  Clear(Option_t* opt="");
+  virtual void    Print(const Option_t* opt) const;
+  virtual void    AccumulatePedestals(TClonesArray* rawhits);
+  virtual void    CalculatePedestals();
+  virtual Int_t   Decode(const THaEvData&);
+  virtual Int_t   ReadDatabase(const TDatime& date);
+  virtual Int_t   DefineVariables(EMode mode = kDefine);
+  virtual Int_t   CoarseProcess(TClonesArray& tracks);
+  virtual Int_t   FineProcess(TClonesArray& tracks);
+  virtual Int_t   ApplyCorrections(void);
+  virtual EStatus Init(const TDatime& run_time);
 
-  virtual void AccumulatePedestals(TClonesArray* rawhits);
-  virtual void CalculatePedestals();
-
-  virtual Int_t      ApplyCorrections( void );
-
-  virtual void Print(const Option_t* opt) const;
+  void InitArrays();
+  void DeleteArrays();
 
   THcAerogel();  // for ROOT I/O
  protected:
@@ -55,14 +52,14 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   Float_t*   fT_Pos;         // [fNelem] Array of TDCs
   Float_t*   fT_Neg;         // [fNelem] Array of TDCs
 
+  Int_t    fNGoodHits;
+  Int_t    fNADCPosHits;
+  Int_t    fNADCNegHits;
+  Int_t    fNTDCPosHits;
+  Int_t    fNTDCNegHits;
   Double_t fPosNpeSum;
   Double_t fNegNpeSum;
   Double_t fNpeSum;
-  Int_t fNGoodHits;
-  Int_t fNADCPosHits;
-  Int_t fNADCNegHits;
-  Int_t fNTDCPosHits;
-  Int_t fNTDCNegHits;
 
   Double_t* fPosNpe;		// [fNelem] # Photoelectrons per positive tube
   Double_t* fNegNpe;		// [fNelem] # Photoelectrons per negative tube
@@ -73,35 +70,37 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   TClonesArray* fPosADCHits;
   TClonesArray* fNegADCHits;
 
-  // Pedestals
-  Int_t fNPedestalEvents;
-  Int_t fMinPeds;
-  Int_t *fPosPedSum;		/* Accumulators for pedestals */
-  Int_t *fPosPedSum2;
-  Int_t *fPosPedLimit;
-  Int_t *fPosPedCount;
-  Int_t *fNegPedSum;
-  Int_t *fNegPedSum2;
-  Int_t *fNegPedLimit;
-  Int_t *fNegPedCount;
-
+  // 6 GeV era variables
+  Int_t    fTdcOffset; /* Global TDC offset */
+  Int_t    fNPedestalEvents;
+  Int_t    fMinPeds;
+  Int_t    *fPosPedSum;		/* Accumulators for pedestals */
+  Int_t    *fPosPedSum2;
+  Int_t    *fPosPedLimit;
+  Int_t    *fPosPedCount;
+  Int_t    *fNegPedSum;
+  Int_t    *fNegPedSum2;
+  Int_t    *fNegPedLimit;
+  Int_t    *fNegPedCount;
   Double_t *fPosPed;
   Double_t *fPosSig;
   Double_t *fPosThresh;
   Double_t *fNegPed;
   Double_t *fNegSig;
   Double_t *fNegThresh;
-
   Double_t *fPosPedMean; 	/* Can be supplied in parameters and then */
   Double_t *fNegPedMean;	/* be overwritten from ped analysis */
 
-  Int_t fTdcOffset; /* Global TDC offset */
+  // Vector/TClonesArray length parameters
+  Int_t MaxNumPosAeroPmt = 8;
+  Int_t MaxNumNegAeroPmt = 8;
+  Int_t MaxNumAdcPulse   = 4;
 
+  // 12 GeV FADC variables
   TClonesArray* frPosAdcPedRaw;
   TClonesArray* frPosAdcPulseIntRaw;
   TClonesArray* frPosAdcPulseAmpRaw;
   TClonesArray* frPosAdcPulseTimeRaw;
-
   TClonesArray* frPosAdcPed;
   TClonesArray* frPosAdcPulseInt;
   TClonesArray* frPosAdcPulseAmp;
@@ -110,7 +109,6 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   TClonesArray* frNegAdcPulseIntRaw;
   TClonesArray* frNegAdcPulseAmpRaw;
   TClonesArray* frNegAdcPulseTimeRaw;
-
   TClonesArray* frNegAdcPed;
   TClonesArray* frNegAdcPulseInt;
   TClonesArray* frNegAdcPulseAmp;

--- a/src/THcAerogel.h
+++ b/src/THcAerogel.h
@@ -43,9 +43,9 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
 
   // 12 GeV variables
   // Vector/TClonesArray length parameters
-  Int_t MaxNumPosAeroPmt = 7;
-  Int_t MaxNumNegAeroPmt = 7;
-  Int_t MaxNumAdcPulse   = 4;
+  static const Int_t MaxNumPosAeroPmt = 7;
+  static const Int_t MaxNumNegAeroPmt = 7;
+  static const Int_t MaxNumAdcPulse   = 4;
   // Tracking variables
   Int_t     fNRegions;
   Int_t     fRegionsValueMax;

--- a/src/THcAerogel.h
+++ b/src/THcAerogel.h
@@ -30,33 +30,38 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   virtual Int_t   ApplyCorrections(void);
   virtual EStatus Init(const TDatime& run_time);
 
-  void InitArrays();
-  void DeleteArrays();
+  void  InitArrays();
+  void  DeleteArrays();
   Int_t GetIndex(Int_t nRegion, Int_t nValue);
 
   THcAerogel();  // for ROOT I/O
- protected:
-  Int_t fAnalyzePedestals;
-  Int_t fSixGevData;
 
-  // Parameters
+ protected:
 
   // Event information
   Int_t fNhits;
 
-  Float_t*   fA_Pos;         // [fNelem] Array of ADC amplitudes
-  Float_t*   fA_Neg;         // [fNelem] Array of ADC amplitudes
-  Float_t*   fA_Pos_p;	     // [fNelem] Array of ped-subtracted ADC amplitudes
-  Float_t*   fA_Neg_p;	     // [fNelem] Array of ped-subtracted ADC amplitudes
-  Float_t*   fT_Pos;         // [fNelem] Array of TDCs
-  Float_t*   fT_Neg;         // [fNelem] Array of TDCs
-
-  Int_t    fNGoodHits;
-  Int_t    fNADCPosHits;
-  Int_t    fNADCNegHits;
-  Int_t    fNTDCPosHits;
-  Int_t    fNTDCNegHits;
-
+  // 12 GeV variables
+  // Vector/TClonesArray length parameters
+  Int_t MaxNumPosAeroPmt = 7;
+  Int_t MaxNumNegAeroPmt = 7;
+  Int_t MaxNumAdcPulse   = 4;
+  // Tracking variables
+  Int_t     fNRegions;
+  Int_t     fRegionsValueMax;
+  Int_t     fDebugAdc;
+  Double_t  fRedChi2Min;
+  Double_t  fRedChi2Max;
+  Double_t  fBetaMin;
+  Double_t  fBetaMax;
+  Double_t  fENormMin;
+  Double_t  fENormMax;
+  Double_t  fDiffBoxZPos;
+  Double_t  fNpeThresh;
+  Double_t  fAdcTimeWindowMin;
+  Double_t  fAdcTimeWindowMax;
+  Double_t  *fRegionValue;
+  // Counting variables
   Int_t     fTotNumAdcHits;
   Int_t     fTotNumGoodAdcHits;
   Int_t     fTotNumPosAdcHits;
@@ -65,15 +70,33 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   Int_t     fTotNumGoodNegAdcHits;
   Int_t     fTotNumTracksMatched;
   Int_t     fTotNumTracksFired;
+  // NPE variables
   Double_t  fPosNpeSum;
   Double_t  fNegNpeSum;
   Double_t  fNpeSum;
-  Double_t* fPosGain;
-  Double_t* fNegGain;
-
+  Double_t  *fPosGain;
+  Double_t  *fNegGain;
+  // FADC data objects
+  TClonesArray* frPosAdcPedRaw;
+  TClonesArray* frPosAdcPulseIntRaw;
+  TClonesArray* frPosAdcPulseAmpRaw;
+  TClonesArray* frPosAdcPulseTimeRaw;
+  TClonesArray* frPosAdcPed;
+  TClonesArray* frPosAdcPulseInt;
+  TClonesArray* frPosAdcPulseAmp;
+  TClonesArray* frNegAdcPedRaw;
+  TClonesArray* frNegAdcPulseIntRaw;
+  TClonesArray* frNegAdcPulseAmpRaw;
+  TClonesArray* frNegAdcPulseTimeRaw;
+  TClonesArray* frNegAdcPed;
+  TClonesArray* frNegAdcPulseInt;
+  TClonesArray* frNegAdcPulseAmp;
+  TClonesArray* fPosAdcErrorFlag;
+  TClonesArray* fNegAdcErrorFlag;
+  // Individual PMT data objects
   vector<Int_t>    fNumPosAdcHits;
-  vector<Int_t>    fNumGoodPosAdcHits;
   vector<Int_t>    fNumNegAdcHits;
+  vector<Int_t>    fNumGoodPosAdcHits;
   vector<Int_t>    fNumGoodNegAdcHits;
   vector<Int_t>    fNumTracksMatched;
   vector<Int_t>    fNumTracksFired;
@@ -90,16 +113,20 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   vector<Double_t> fGoodNegAdcPulseAmp;
   vector<Double_t> fGoodNegAdcPulseTime;
 
-  // Hits
-  TClonesArray* fPosTDCHits;
-  TClonesArray* fNegTDCHits;
-  TClonesArray* fPosADCHits;
-  TClonesArray* fNegADCHits;
-
   // 6 GeV era variables
-  Int_t    fTdcOffset; /* Global TDC offset */
-  Int_t    fNPedestalEvents;
-  Int_t    fMinPeds;
+  Int_t     fAnalyzePedestals;
+  Int_t     fSixGevData;
+  Int_t     fNGoodHits;
+  Int_t     fNADCPosHits;
+  Int_t     fNADCNegHits;
+  Int_t     fNTDCPosHits;
+  Int_t     fNTDCNegHits;
+  Int_t     fTdcOffset; /* Global TDC offset */
+  Int_t     fNPedestalEvents;
+  Int_t     fMinPeds;
+  Double_t  fPosNpeSumSixGev;
+  Double_t  fNegNpeSumSixGev;
+  Double_t  fNpeSumSixGev;
   Int_t    *fPosPedSum;		/* Accumulators for pedestals */
   Int_t    *fPosPedSum2;
   Int_t    *fPosPedLimit;
@@ -108,6 +135,12 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   Int_t    *fNegPedSum2;
   Int_t    *fNegPedLimit;
   Int_t    *fNegPedCount;
+  Float_t  *fA_Pos;          // [fNelem] Array of ADC amplitudes
+  Float_t  *fA_Neg;          // [fNelem] Array of ADC amplitudes
+  Float_t  *fA_Pos_p;	     // [fNelem] Array of ped-subtracted ADC amplitudes
+  Float_t  *fA_Neg_p;	     // [fNelem] Array of ped-subtracted ADC amplitudes
+  Float_t  *fT_Pos;          // [fNelem] Array of TDCs
+  Float_t  *fT_Neg;          // [fNelem] Array of TDCs
   Double_t *fPosPed;
   Double_t *fPosSig;
   Double_t *fPosThresh;
@@ -117,46 +150,13 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   Double_t *fPosPedMean; 	/* Can be supplied in parameters and then */
   Double_t *fNegPedMean;	/* be overwritten from ped analysis */
 
-  // Vector/TClonesArray length parameters
-  Int_t MaxNumPosAeroPmt = 8;
-  Int_t MaxNumNegAeroPmt = 8;
-  Int_t MaxNumAdcPulse   = 4;
+  TClonesArray *fPosTDCHits;
+  TClonesArray *fNegTDCHits;
+  TClonesArray *fPosADCHits;
+  TClonesArray *fNegADCHits;
 
-  // Tracking variables
-  Int_t     fNRegions;
-  Int_t     fRegionsValueMax;
-  Int_t     fDebugAdc;
-  Double_t  fRedChi2Min;
-  Double_t  fRedChi2Max;
-  Double_t  fBetaMin;
-  Double_t  fBetaMax;
-  Double_t  fENormMin;
-  Double_t  fENormMax;
-  Double_t  fDiffBoxZPos;
-  Double_t  fNpeThresh;
-  Double_t  fAdcTimeWindowMin;
-  Double_t  fAdcTimeWindowMax;
-  Double_t* fRegionValue;
-
-  // 12 GeV FADC variables
-  TClonesArray* frPosAdcPedRaw;
-  TClonesArray* frPosAdcPulseIntRaw;
-  TClonesArray* frPosAdcPulseAmpRaw;
-  TClonesArray* frPosAdcPulseTimeRaw;
-  TClonesArray* frPosAdcPed;
-  TClonesArray* frPosAdcPulseInt;
-  TClonesArray* frPosAdcPulseAmp;
-
-  TClonesArray* frNegAdcPedRaw;
-  TClonesArray* frNegAdcPulseIntRaw;
-  TClonesArray* frNegAdcPulseAmpRaw;
-  TClonesArray* frNegAdcPulseTimeRaw;
-  TClonesArray* frNegAdcPed;
-  TClonesArray* frNegAdcPulseInt;
-  TClonesArray* frNegAdcPulseAmp;
-
-  TClonesArray* fPosAdcErrorFlag;
-  TClonesArray* fNegAdcErrorFlag;
+  vector<Double_t> fPosNpeSixGev;
+  vector<Double_t> fNegNpeSixGev;
 
   void Setup(const char* name, const char* description);
   virtual void  InitializePedestals( );

--- a/src/THcAerogel.h
+++ b/src/THcAerogel.h
@@ -32,6 +32,7 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
 
   void InitArrays();
   void DeleteArrays();
+  Int_t GetIndex(Int_t nRegion, Int_t nValue);
 
   THcAerogel();  // for ROOT I/O
  protected:
@@ -39,8 +40,6 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   Int_t fSixGevData;
 
   // Parameters
-  Double_t* fPosGain;
-  Double_t* fNegGain;
 
   // Event information
   Int_t fNhits;
@@ -57,12 +56,39 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   Int_t    fNADCNegHits;
   Int_t    fNTDCPosHits;
   Int_t    fNTDCNegHits;
-  Double_t fPosNpeSum;
-  Double_t fNegNpeSum;
-  Double_t fNpeSum;
 
-  Double_t* fPosNpe;		// [fNelem] # Photoelectrons per positive tube
-  Double_t* fNegNpe;		// [fNelem] # Photoelectrons per negative tube
+  Int_t     fTotNumAdcHits;
+  Int_t     fTotNumGoodAdcHits;
+  Int_t     fTotNumPosAdcHits;
+  Int_t     fTotNumGoodPosAdcHits;
+  Int_t     fTotNumNegAdcHits;
+  Int_t     fTotNumGoodNegAdcHits;
+  Int_t     fTotNumTracksMatched;
+  Int_t     fTotNumTracksFired;
+  Double_t  fPosNpeSum;
+  Double_t  fNegNpeSum;
+  Double_t  fNpeSum;
+  Double_t* fPosGain;
+  Double_t* fNegGain;
+
+  vector<Int_t>    fNumPosAdcHits;
+  vector<Int_t>    fNumGoodPosAdcHits;
+  vector<Int_t>    fNumNegAdcHits;
+  vector<Int_t>    fNumGoodNegAdcHits;
+  vector<Int_t>    fNumTracksMatched;
+  vector<Int_t>    fNumTracksFired;
+  vector<Double_t> fPosNpe;
+  vector<Double_t> fNegNpe;
+  vector<Double_t> fGoodPosAdcPed;
+  vector<Double_t> fGoodPosAdcPulseInt;
+  vector<Double_t> fGoodPosAdcPulseIntRaw;
+  vector<Double_t> fGoodPosAdcPulseAmp;
+  vector<Double_t> fGoodPosAdcPulseTime;
+  vector<Double_t> fGoodNegAdcPed;
+  vector<Double_t> fGoodNegAdcPulseInt;
+  vector<Double_t> fGoodNegAdcPulseIntRaw;
+  vector<Double_t> fGoodNegAdcPulseAmp;
+  vector<Double_t> fGoodNegAdcPulseTime;
 
   // Hits
   TClonesArray* fPosTDCHits;
@@ -95,6 +121,22 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   Int_t MaxNumPosAeroPmt = 8;
   Int_t MaxNumNegAeroPmt = 8;
   Int_t MaxNumAdcPulse   = 4;
+
+  // Tracking variables
+  Int_t     fNRegions;
+  Int_t     fRegionsValueMax;
+  Int_t     fDebugAdc;
+  Double_t  fRedChi2Min;
+  Double_t  fRedChi2Max;
+  Double_t  fBetaMin;
+  Double_t  fBetaMax;
+  Double_t  fENormMin;
+  Double_t  fENormMax;
+  Double_t  fDiffBoxZPos;
+  Double_t  fNpeThresh;
+  Double_t  fAdcTimeWindowMin;
+  Double_t  fAdcTimeWindowMax;
+  Double_t* fRegionValue;
 
   // 12 GeV FADC variables
   TClonesArray* frPosAdcPedRaw;

--- a/src/THcAerogel.h
+++ b/src/THcAerogel.h
@@ -115,10 +115,14 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   TClonesArray* frNegAdcPulseInt;
   TClonesArray* frNegAdcPulseAmp;
 
+  TClonesArray* fPosAdcErrorFlag;
+  TClonesArray* fNegAdcErrorFlag;
+
   void Setup(const char* name, const char* description);
   virtual void  InitializePedestals( );
 
   ClassDef(THcAerogel,0)   // Generic aerogel class
-};
+}
+;
 
 #endif

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -56,16 +56,16 @@ THcCherenkov::THcCherenkov( const char* name, const char* description,
   frAdcPulseAmp     = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
   fAdcErrorFlag     = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
   
-  fNumAdcHits          = vector<Int_t>   (MaxNumCerPmt, 0.0);
-  fNumGoodAdcHits      = vector<Int_t>   (MaxNumCerPmt, 0.0);
-  fNumTracksMatched    = vector<Int_t>   (MaxNumCerPmt, 0.0);
-  fNumTracksFired      = vector<Int_t>   (MaxNumCerPmt, 0.0);
-  fNpe                 = vector<Double_t>(MaxNumCerPmt, 0.0);
-  fGoodAdcPed          = vector<Double_t>(MaxNumCerPmt, 0.0);
-  fGoodAdcPulseInt     = vector<Double_t>(MaxNumCerPmt, 0.0);
-  fGoodAdcPulseIntRaw  = vector<Double_t>(MaxNumCerPmt, 0.0);
-  fGoodAdcPulseAmp     = vector<Double_t>(MaxNumCerPmt, 0.0);
-  fGoodAdcPulseTime    = vector<Double_t>(MaxNumCerPmt, 0.0);
+  fNumAdcHits         = vector<Int_t>    (MaxNumCerPmt, 0.0);
+  fNumGoodAdcHits     = vector<Int_t>    (MaxNumCerPmt, 0.0);
+  fNumTracksMatched   = vector<Int_t>    (MaxNumCerPmt, 0.0);
+  fNumTracksFired     = vector<Int_t>    (MaxNumCerPmt, 0.0);
+  fNpe                = vector<Double_t> (MaxNumCerPmt, 0.0);
+  fGoodAdcPed         = vector<Double_t> (MaxNumCerPmt, 0.0);
+  fGoodAdcPulseInt    = vector<Double_t> (MaxNumCerPmt, 0.0);
+  fGoodAdcPulseIntRaw = vector<Double_t> (MaxNumCerPmt, 0.0);
+  fGoodAdcPulseAmp    = vector<Double_t> (MaxNumCerPmt, 0.0);
+  fGoodAdcPulseTime   = vector<Double_t> (MaxNumCerPmt, 0.0);
     
   InitArrays();
 }
@@ -205,7 +205,7 @@ Int_t THcCherenkov::ReadDatabase( const TDatime& date )
     {0}
   };
 
-  fDebugAdc = 1; // Set ADC debug parameter to false unless set in parameter file
+  fDebugAdc = 0; // Set ADC debug parameter to false unless set in parameter file
 
   gHcParms->LoadParmValues((DBRequest*)&list, prefix.c_str());
 
@@ -301,16 +301,12 @@ void THcCherenkov::Clear(Option_t* opt)
 
   for (UInt_t ielem = 0; ielem < fNumAdcHits.size(); ielem++)
     fNumAdcHits.at(ielem) = 0;
-
   for (UInt_t ielem = 0; ielem < fNumGoodAdcHits.size(); ielem++)
     fNumGoodAdcHits.at(ielem) = 0;
-
   for (UInt_t ielem = 0; ielem < fNumTracksMatched.size(); ielem++)
     fNumTracksMatched.at(ielem) = 0;
-
   for (UInt_t ielem = 0; ielem < fNumTracksFired.size(); ielem++)
     fNumTracksFired.at(ielem) = 0;
-
   for (UInt_t ielem = 0; ielem < fGoodAdcPed.size(); ielem++) {
     fGoodAdcPed.at(ielem)         = 0.0;
     fGoodAdcPulseInt.at(ielem)    = 0.0;
@@ -479,7 +475,7 @@ Int_t THcCherenkov::FineProcess( TClonesArray& tracks )
 }
 
 //_____________________________________________________________________________
-void THcCherenkov::InitializePedestals( )
+void THcCherenkov::InitializePedestals()
 {
   fNPedestalEvents = 0;
   fMinPeds         = 500; 		// In engine, this is set in parameter file
@@ -528,7 +524,7 @@ void THcCherenkov::AccumulatePedestals(TClonesArray* rawhits)
 }
 
 //_____________________________________________________________________________
-void THcCherenkov::CalculatePedestals( )
+void THcCherenkov::CalculatePedestals()
 {
   // Use the accumulated pedestal data to calculate pedestals
   // Later add check to see if pedestals have drifted ("Danger Will Robinson!")
@@ -554,7 +550,7 @@ void THcCherenkov::CalculatePedestals( )
 }
 
 //_____________________________________________________________________________
-Int_t THcCherenkov::GetIndex( Int_t nRegion, Int_t nValue ) {
+Int_t THcCherenkov::GetIndex(Int_t nRegion, Int_t nValue) {
 
   return fNRegions * nValue + nRegion;
 
@@ -562,7 +558,7 @@ Int_t THcCherenkov::GetIndex( Int_t nRegion, Int_t nValue ) {
 
 
 //_____________________________________________________________________________
-void THcCherenkov::Print( const Option_t* opt) const {
+void THcCherenkov::Print(const Option_t* opt) const {
   THaNonTrackingDetector::Print(opt);
 
   // Print out the pedestals

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -251,17 +251,17 @@ Int_t THcCherenkov::DefineVariables( EMode mode )
 
   vars.push_back({"npe",          "Number of PEs",                  "fNpe"});
   vars.push_back({"npeSum",       "Total Number of PEs",            "fNpeSum"});
-  vars.push_back({"adcCounter",   "List of ADC counter numbers",    "frAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
+  vars.push_back({"adcCounter",   "ADC counter numbers",            "frAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
   vars.push_back({"adcErrorFlag", "Error Flag for When FPGA Fails", "fAdcErrorFlag.THcSignalHit.GetData()"});
 
   if (fDebugAdc) {   
-    vars.push_back({"adcPedRaw",       "List of raw ADC pedestals",        "frAdcPedRaw.THcSignalHit.GetData()"});
-    vars.push_back({"adcPulseIntRaw",  "List of raw ADC pulse integrals",  "frAdcPulseIntRaw.THcSignalHit.GetData()"});
-    vars.push_back({"adcPulseAmpRaw",  "List of raw ADC pulse amplitudes", "frAdcPulseAmpRaw.THcSignalHit.GetData()"});
-    vars.push_back({"adcPulseTimeRaw", "List of raw ADC pulse times",      "frAdcPulseTimeRaw.THcSignalHit.GetData()"});
-    vars.push_back({"adcPed",          "List of ADC pedestals",            "frAdcPed.THcSignalHit.GetData()"});
-    vars.push_back({"adcPulseInt",     "List of ADC pulse integrals",      "frAdcPulseInt.THcSignalHit.GetData()"});
-    vars.push_back({"adcPulseAmp",     "List of ADC pulse amplitudes",     "frAdcPulseAmp.THcSignalHit.GetData()"});
+    vars.push_back({"adcPedRaw",       "Raw ADC pedestals",        "frAdcPedRaw.THcSignalHit.GetData()"});
+    vars.push_back({"adcPulseIntRaw",  "Raw ADC pulse integrals",  "frAdcPulseIntRaw.THcSignalHit.GetData()"});
+    vars.push_back({"adcPulseAmpRaw",  "Raw ADC pulse amplitudes", "frAdcPulseAmpRaw.THcSignalHit.GetData()"});
+    vars.push_back({"adcPulseTimeRaw", "Raw ADC pulse times",      "frAdcPulseTimeRaw.THcSignalHit.GetData()"});
+    vars.push_back({"adcPed",          "ADC pedestals",            "frAdcPed.THcSignalHit.GetData()"});
+    vars.push_back({"adcPulseInt",     "ADC pulse integrals",      "frAdcPulseInt.THcSignalHit.GetData()"});
+    vars.push_back({"adcPulseAmp",     "ADC pulse amplitudes",     "frAdcPulseAmp.THcSignalHit.GetData()"});
   }
 
   vars.push_back({"goodAdcPed",          "Good ADC pedestals",           "fGoodAdcPed"});

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -1,9 +1,7 @@
 /** \class THcCherenkov
     \ingroup Detectors
 
-    Class for an Cherenkov detector consisting of two PMT's
-
-    3\author Zafar Ahmed
+    Class for Cherenkov detectors
 
 */
 
@@ -440,29 +438,39 @@ Int_t THcCherenkov::CoarseProcess( TClonesArray&  )
 Int_t THcCherenkov::FineProcess( TClonesArray& tracks )
 {
   
-  Int_t lastIndex = tracks.GetLast();
+  Int_t nTracks = tracks.GetLast() + 1;
 
-  if (lastIndex > -1) {
+  cout << "nTracks = " << nTracks << endl;
+
+  if (ntracks >= 1) {
 
     THaTrack* track = dynamic_cast<THaTrack*> (tracks.At(0));
     if (!track) return -1;
 
-    //if ( ( ( tracks.GetLast() + 1 ) == 1 ) &&
-    if ((lastIndex == 0) &&
-	( track->GetChi2()/track->GetNDoF() > 0. ) &&
+    Double_t trackChi2   = track->GetChi2();
+    Int_t    trackNDoF   = track->GetNDoF();
+    Double_t trackBeta   = track->GetBeta();
+    Double_t trackEnergy = track->GetEnergy();
+    Double_t trackMom    = track->GetP();
+    Double_t trackXfp    = track->GetX();
+    Double_t trackYfp    = track->GetY();
+    Double_t trackTheta  = track->GetTheta();
+    Double_t trackPhi    = track->GetPhi();
+
+    cout << "trackChi2 = " << trackChi2 << "\t" << "trackNDof = " << trackNDoF << "\t"
+	 << "trackBeta = " << trackBeta << "\t" << "trackEnergy = " << trackEnergy << "\t"
+	 << "trackMom = " << trackMom << endl;
+    cout << "trackXfp = " << trackXfp << "\t" << "trackYfp = " << trackYfp << "\t"
+	 << "trackTheta = " << trackTheta << "\t" << "trackPhi = " << trackPhi << endl;
+    cout << "=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:" << endl;
+
+    if (( track->GetChi2()/track->GetNDoF() > 0. ) &&
 	( track->GetChi2()/track->GetNDoF() <  fCerChi2Max ) &&
 	( track->GetBeta() > fCerBetaMin ) &&
 	( track->GetBeta() < fCerBetaMax ) &&
 	( ( track->GetEnergy() / track->GetP() ) > fCerETMin ) &&
 	( ( track->GetEnergy() / track->GetP() ) < fCerETMax )
 	) {
-
-      cout << track->GetChi2() << "\t" << track->GetNDoF() << "\t"
-	   << track->GetBeta() << "\t" << track->GetEnergy() << "\t"
-	   << track->GetP() << endl;
-
-      cout << track->GetX() << "\t" << track->GetY() << "\t" 
-	   << track->GetTheta() << "\t" << track->GetPhi() << endl;
 
       Double_t cerX = track->GetX() + track->GetTheta() * fCerMirrorZPos;
       Double_t cerY = track->GetY() + track->GetPhi()   * fCerMirrorZPos;

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -442,7 +442,7 @@ Int_t THcCherenkov::FineProcess( TClonesArray& tracks )
 
   cout << "nTracks = " << nTracks << endl;
 
-  if (ntracks >= 1) {
+  if (nTracks >= 1) {
 
     THaTrack* track = dynamic_cast<THaTrack*> (tracks.At(0));
     if (!track) return -1;

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -21,7 +21,6 @@
 #include "THaTrack.h"
 #include "TClonesArray.h"
 #include "TMath.h"
-
 #include "THaTrackProj.h"
 
 #include <algorithm>
@@ -30,14 +29,13 @@
 #include <cstdlib>
 #include <iostream>
 #include <string>
+#include <iomanip>
 
 using namespace std;
 
 using std::cout;
 using std::cin;
 using std::endl;
-
-#include <iomanip>
 using std::setw;
 using std::setprecision;
 
@@ -101,7 +99,6 @@ THcCherenkov::~THcCherenkov()
   delete fAdcErrorFlag;     fAdcErrorFlag     = NULL;
 
   DeleteArrays();
-
 }
 
 //_____________________________________________________________________________
@@ -121,7 +118,7 @@ void THcCherenkov::DeleteArrays()
 {
   delete [] fGain; fGain = NULL;
     
-  // 6 Gev pedestal variables
+  // 6 Gev variables
   delete [] fPedSum;   fPedSum   = NULL;
   delete [] fPedSum2;  fPedSum2  = NULL;
   delete [] fPedLimit; fPedLimit = NULL;
@@ -177,6 +174,9 @@ Int_t THcCherenkov::ReadDatabase( const TDatime& date )
 
   Bool_t optional = true;
 
+  cout << "Number of " << GetApparatus()->GetName() << "." 
+       << GetName() << " PMTs defined = " << fNelem << endl;
+
   // 6 GeV pedestal paramters
   fPedLimit = new Int_t[fNelem];
   fGain     = new Double_t[fNelem];
@@ -213,7 +213,7 @@ Int_t THcCherenkov::ReadDatabase( const TDatime& date )
 
   fIsInit = true;
 
-  cout << " Track Matching Parameters for: " << GetName() << endl;
+  cout << "Track Matching Parameters for: " << GetName() << endl;
   for (Int_t iregion = 0; iregion < fNRegions; iregion++) {
     cout << "Region = " << iregion + 1 << endl;
     for (Int_t ivalue = 0; ivalue < 8; ivalue++)
@@ -239,9 +239,10 @@ Int_t THcCherenkov::DefineVariables( EMode mode )
   // Register variables in global list
   vector<RVarDef> vars;
   
-  vars.push_back({"numAdcHits",        "Number of ADC Hits Per PMT",      "fNumAdcHits"});        // Cherenkov occupancy
+  vars.push_back({"adcCounter",   "ADC counter numbers",            "frAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
+  vars.push_back({"adcErrorFlag", "Error Flag for When FPGA Fails", "fAdcErrorFlag.THcSignalHit.GetData()"});
+
   vars.push_back({"numGoodAdcHits",    "Number of Good ADC Hits Per PMT", "fNumGoodAdcHits"});    // Cherenkov occupancy
-  vars.push_back({"totNumAdcHits",     "Total Number of ADC Hits",        "fTotNumAdcHits"});     // Cherenkov multiplicity
   vars.push_back({"totNumGoodAdcHits", "Total Number of Good ADC Hits",   "fTotNumGoodAdcHits"}); // Cherenkov multiplicity
 
   vars.push_back({"numTracksMatched",    "Number of Tracks Matched Per Region",       "fNumTracksMatched"});        
@@ -251,25 +252,25 @@ Int_t THcCherenkov::DefineVariables( EMode mode )
 
   vars.push_back({"npe",          "Number of PEs",                  "fNpe"});
   vars.push_back({"npeSum",       "Total Number of PEs",            "fNpeSum"});
-  vars.push_back({"adcCounter",   "ADC counter numbers",            "frAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
-  vars.push_back({"adcErrorFlag", "Error Flag for When FPGA Fails", "fAdcErrorFlag.THcSignalHit.GetData()"});
-
-  if (fDebugAdc) {   
-    vars.push_back({"adcPedRaw",       "Raw ADC pedestals",        "frAdcPedRaw.THcSignalHit.GetData()"});
-    vars.push_back({"adcPulseIntRaw",  "Raw ADC pulse integrals",  "frAdcPulseIntRaw.THcSignalHit.GetData()"});
-    vars.push_back({"adcPulseAmpRaw",  "Raw ADC pulse amplitudes", "frAdcPulseAmpRaw.THcSignalHit.GetData()"});
-    vars.push_back({"adcPulseTimeRaw", "Raw ADC pulse times",      "frAdcPulseTimeRaw.THcSignalHit.GetData()"});
-    vars.push_back({"adcPed",          "ADC pedestals",            "frAdcPed.THcSignalHit.GetData()"});
-    vars.push_back({"adcPulseInt",     "ADC pulse integrals",      "frAdcPulseInt.THcSignalHit.GetData()"});
-    vars.push_back({"adcPulseAmp",     "ADC pulse amplitudes",     "frAdcPulseAmp.THcSignalHit.GetData()"});
-  }
-
+  
   vars.push_back({"goodAdcPed",          "Good ADC pedestals",           "fGoodAdcPed"});
   vars.push_back({"goodAdcPulseInt",     "Good ADC pulse integrals",     "fGoodAdcPulseInt"});
   vars.push_back({"goodAdcPulseIntRaw",  "Good ADC raw pulse integrals", "fGoodAdcPulseIntRaw"});
   vars.push_back({"goodAdcPulseAmp",     "Good ADC pulse amplitudes",    "fGoodAdcPulseAmp"});
   vars.push_back({"goodAdcPulseTime",    "Good ADC pulse times",         "fGoodAdcPulseTime"});
-  
+
+  if (fDebugAdc) {   
+    vars.push_back({"numAdcHits",      "Number of ADC Hits Per PMT", "fNumAdcHits"});        // Cherenkov occupancy
+    vars.push_back({"totNumAdcHits",   "Total Number of ADC Hits",   "fTotNumAdcHits"});     // Cherenkov multiplicity
+    vars.push_back({"adcPedRaw",       "Raw ADC pedestals",          "frAdcPedRaw.THcSignalHit.GetData()"});
+    vars.push_back({"adcPulseIntRaw",  "Raw ADC pulse integrals",    "frAdcPulseIntRaw.THcSignalHit.GetData()"});
+    vars.push_back({"adcPulseAmpRaw",  "Raw ADC pulse amplitudes",   "frAdcPulseAmpRaw.THcSignalHit.GetData()"});
+    vars.push_back({"adcPulseTimeRaw", "Raw ADC pulse times",        "frAdcPulseTimeRaw.THcSignalHit.GetData()"});
+    vars.push_back({"adcPed",          "ADC pedestals",              "frAdcPed.THcSignalHit.GetData()"});
+    vars.push_back({"adcPulseInt",     "ADC pulse integrals",        "frAdcPulseInt.THcSignalHit.GetData()"});
+    vars.push_back({"adcPulseAmp",     "ADC pulse amplitudes",       "frAdcPulseAmp.THcSignalHit.GetData()"});
+  }
+ 
   RVarDef end {};
   vars.push_back(end);  
 
@@ -281,13 +282,13 @@ inline
 void THcCherenkov::Clear(Option_t* opt)
 {
   // Clear the hit lists
-  fNhits  = 0;	     
-  fNpeSum = 0.0;
-  
+  fNhits               = 0;	  
   fTotNumAdcHits       = 0;
   fTotNumGoodAdcHits   = 0;
   fTotNumTracksMatched = 0;
   fTotNumTracksFired   = 0;
+
+  fNpeSum = 0.0;
 
   frAdcPedRaw->Clear();
   frAdcPulseIntRaw->Clear();
@@ -482,15 +483,13 @@ void THcCherenkov::InitializePedestals()
   fPedSum          = new Int_t [fNelem];
   fPedSum2         = new Int_t [fNelem];
   fPedCount        = new Int_t [fNelem];
-
-  fPed    = new Double_t [fNelem];
-  fThresh = new Double_t [fNelem];
+  fPed             = new Double_t [fNelem];
+  fThresh          = new Double_t [fNelem];
   for(Int_t i = 0; i < fNelem; i++) {
     fPedSum[i]   = 0;
     fPedSum2[i]  = 0;
     fPedCount[i] = 0;
   }
-
 }
 
 //_____________________________________________________________________________
@@ -550,34 +549,29 @@ void THcCherenkov::CalculatePedestals()
 }
 
 //_____________________________________________________________________________
-Int_t THcCherenkov::GetIndex(Int_t nRegion, Int_t nValue) {
-
+Int_t THcCherenkov::GetIndex(Int_t nRegion, Int_t nValue) 
+{
   return fNRegions * nValue + nRegion;
-
 }
 
 
 //_____________________________________________________________________________
-void THcCherenkov::Print(const Option_t* opt) const {
+void THcCherenkov::Print(const Option_t* opt) const 
+{
   THaNonTrackingDetector::Print(opt);
-
   // Print out the pedestals
-
   cout << endl;
   cout << "Cherenkov Pedestals" << endl;
-
   // Ahmed
   cout << "No.   ADC" << endl;
-  for(Int_t i=0; i<fNelem; i++){
+  for(Int_t i=0; i<fNelem; i++)
     cout << " " << i << "    " << fPed[i] << endl;
-  }
-
   cout << endl;
 }
 
 //_____________________________________________________________________________
-Double_t THcCherenkov::GetCerNPE() {
-
+Double_t THcCherenkov::GetCerNPE() 
+{
   return fNpeSum;
 }
 

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -47,17 +47,14 @@ THcCherenkov::THcCherenkov( const char* name, const char* description,
   THaNonTrackingDetector(name,description,apparatus)
 {
   // Normal constructor with name and description
-  fADCHits = new TClonesArray("THcSignalHit", 16);
-
   frAdcPedRaw       = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
   frAdcPulseIntRaw  = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
   frAdcPulseAmpRaw  = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
   frAdcPulseTimeRaw = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
-
-  frAdcPed      = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
-  frAdcPulseInt = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
-  frAdcPulseAmp = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
-  fAdcErrorFlag = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
+  frAdcPed          = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
+  frAdcPulseInt     = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
+  frAdcPulseAmp     = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
+  fAdcErrorFlag     = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
   
   fNumAdcHits          = vector<Int_t>   (MaxNumCerPmt, 0.0);
   fNumGoodAdcHits      = vector<Int_t>   (MaxNumCerPmt, 0.0);
@@ -78,17 +75,14 @@ THcCherenkov::THcCherenkov( ) :
   THaNonTrackingDetector()
 {
   // Constructor
-  fADCHits = NULL;
-
   frAdcPedRaw       = NULL;
   frAdcPulseIntRaw  = NULL;
   frAdcPulseAmpRaw  = NULL;
   frAdcPulseTimeRaw = NULL;
-
-  frAdcPed      = NULL;
-  frAdcPulseInt = NULL;
-  frAdcPulseAmp = NULL;
-  fAdcErrorFlag = NULL;
+  frAdcPed          = NULL;
+  frAdcPulseInt     = NULL;
+  frAdcPulseAmp     = NULL;
+  fAdcErrorFlag     = NULL;
 
   InitArrays();
 }
@@ -97,17 +91,14 @@ THcCherenkov::THcCherenkov( ) :
 THcCherenkov::~THcCherenkov()
 {
   // Destructor
-  delete fADCHits; fADCHits = NULL;
-
   delete frAdcPedRaw;       frAdcPedRaw       = NULL;
   delete frAdcPulseIntRaw;  frAdcPulseIntRaw  = NULL;
   delete frAdcPulseAmpRaw;  frAdcPulseAmpRaw  = NULL;
   delete frAdcPulseTimeRaw; frAdcPulseTimeRaw = NULL;
-
-  delete frAdcPed;      frAdcPed      = NULL;
-  delete frAdcPulseInt; frAdcPulseInt = NULL;
-  delete frAdcPulseAmp; frAdcPulseAmp = NULL;
-  delete fAdcErrorFlag; fAdcErrorFlag = NULL;
+  delete frAdcPed;          frAdcPed          = NULL;
+  delete frAdcPulseInt;     frAdcPulseInt     = NULL;
+  delete frAdcPulseAmp;     frAdcPulseAmp     = NULL;
+  delete fAdcErrorFlag;     fAdcErrorFlag     = NULL;
 
   DeleteArrays();
 
@@ -116,14 +107,14 @@ THcCherenkov::~THcCherenkov()
 //_____________________________________________________________________________
 void THcCherenkov::InitArrays()
 {
-  fGain = NULL;
-  fPedSum = NULL;
-  fPedSum2 = NULL;
+  fGain     = NULL;
+  fPedSum   = NULL;
+  fPedSum2  = NULL;
   fPedLimit = NULL;
-  fPedMean = NULL;
+  fPedMean  = NULL;
   fPedCount = NULL;
-  fPed = NULL;
-  fThresh = NULL;
+  fPed      = NULL;
+  fThresh   = NULL;
 }
 //_____________________________________________________________________________
 void THcCherenkov::DeleteArrays()
@@ -131,13 +122,13 @@ void THcCherenkov::DeleteArrays()
   delete [] fGain; fGain = NULL;
     
   // 6 Gev pedestal variables
-  delete [] fPedSum; fPedSum = NULL;
-  delete [] fPedSum2; fPedSum2 = NULL;
+  delete [] fPedSum;   fPedSum   = NULL;
+  delete [] fPedSum2;  fPedSum2  = NULL;
   delete [] fPedLimit; fPedLimit = NULL;
-  delete [] fPedMean; fPedMean = NULL;
+  delete [] fPedMean;  fPedMean  = NULL;
   delete [] fPedCount; fPedCount = NULL;
-  delete [] fPed; fPed = NULL;
-  delete [] fThresh; fThresh = NULL;
+  delete [] fPed;      fPed      = NULL;
+  delete [] fThresh;   fThresh   = NULL;
 }
 
 //_____________________________________________________________________________
@@ -147,7 +138,7 @@ THaAnalysisObject::EStatus THcCherenkov::Init( const TDatime& date )
 
   string EngineDID = string(GetApparatus()->GetName()).substr(0, 1) + GetName();
   std::transform(EngineDID.begin(), EngineDID.end(), EngineDID.begin(), ::toupper);
-  if( gHcDetectorMap->FillMap(fDetMap, EngineDID.c_str()) < 0 ) {
+  if(gHcDetectorMap->FillMap(fDetMap, EngineDID.c_str()) < 0) {
     static const char* const here = "Init()";
     Error(Here(here), "Error filling detectormap for %s.", EngineDID.c_str());
     return kInitError;
@@ -158,7 +149,7 @@ THaAnalysisObject::EStatus THcCherenkov::Init( const TDatime& date )
   InitHitList(fDetMap, "THcCherenkovHit", fDetMap->GetTotNumChan()+1);
 
   EStatus status;
-  if( (status = THaNonTrackingDetector::Init( date )) )
+  if((status = THaNonTrackingDetector::Init( date )))
     return fStatus=status;
 
   return fStatus = kOK;
@@ -181,13 +172,14 @@ Int_t THcCherenkov::ReadDatabase( const TDatime& date )
     {"_tot_pmts", &fNelem, kInt},
     {0}
   };
+
   gHcParms->LoadParmValues(list_1, prefix.c_str());
 
   Bool_t optional = true;
 
   // 6 GeV pedestal paramters
-  fGain     = new Double_t[fNelem];
   fPedLimit = new Int_t[fNelem];
+  fGain     = new Double_t[fNelem];
   fPedMean  = new Double_t[fNelem];
 
   // Region parameters
@@ -257,19 +249,17 @@ Int_t THcCherenkov::DefineVariables( EMode mode )
   vars.push_back({"totNumTracksMatched", "Total Number of Tracks Matched Per Region", "fTotNumTracksMatched"});
   vars.push_back({"totNumTracksFired",   "Total Number of Tracks that Fired",         "fTotNumTracksFired"});
 
-  vars.push_back({"npe",             "Number of PEs",            "fNpe"});
-  vars.push_back({"npeSum",          "Total Number of PEs",      "fNpeSum"});
-
-  vars.push_back({"adcCounter",      "List of ADC counter numbers",      "frAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
-  vars.push_back({"adcErrorFlag",    "Error Flag for When FPGA Fails",    "fAdcErrorFlag.THcSignalHit.GetData()"});
+  vars.push_back({"npe",          "Number of PEs",                  "fNpe"});
+  vars.push_back({"npeSum",       "Total Number of PEs",            "fNpeSum"});
+  vars.push_back({"adcCounter",   "List of ADC counter numbers",    "frAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
+  vars.push_back({"adcErrorFlag", "Error Flag for When FPGA Fails", "fAdcErrorFlag.THcSignalHit.GetData()"});
 
   if (fDebugAdc) {   
     vars.push_back({"adcPedRaw",       "List of raw ADC pedestals",        "frAdcPedRaw.THcSignalHit.GetData()"});
     vars.push_back({"adcPulseIntRaw",  "List of raw ADC pulse integrals",  "frAdcPulseIntRaw.THcSignalHit.GetData()"});
     vars.push_back({"adcPulseAmpRaw",  "List of raw ADC pulse amplitudes", "frAdcPulseAmpRaw.THcSignalHit.GetData()"});
     vars.push_back({"adcPulseTimeRaw", "List of raw ADC pulse times",      "frAdcPulseTimeRaw.THcSignalHit.GetData()"});
-
-    vars.push_back({"adcPed",          "List of ADC pedestals",             "frAdcPed.THcSignalHit.GetData()"});
+    vars.push_back({"adcPed",          "List of ADC pedestals",            "frAdcPed.THcSignalHit.GetData()"});
     vars.push_back({"adcPulseInt",     "List of ADC pulse integrals",      "frAdcPulseInt.THcSignalHit.GetData()"});
     vars.push_back({"adcPulseAmp",     "List of ADC pulse amplitudes",     "frAdcPulseAmp.THcSignalHit.GetData()"});
   }
@@ -291,8 +281,6 @@ inline
 void THcCherenkov::Clear(Option_t* opt)
 {
   // Clear the hit lists
-  fADCHits->Clear();
-
   fNhits  = 0;	     
   fNpeSum = 0.0;
   
@@ -494,16 +482,16 @@ Int_t THcCherenkov::FineProcess( TClonesArray& tracks )
 void THcCherenkov::InitializePedestals( )
 {
   fNPedestalEvents = 0;
-  fMinPeds = 500; 		// In engine, this is set in parameter file
-  fPedSum = new Int_t [fNelem];
-  fPedSum2 = new Int_t [fNelem];
-  fPedCount = new Int_t [fNelem];
+  fMinPeds         = 500; 		// In engine, this is set in parameter file
+  fPedSum          = new Int_t [fNelem];
+  fPedSum2         = new Int_t [fNelem];
+  fPedCount        = new Int_t [fNelem];
 
-  fPed = new Double_t [fNelem];
+  fPed    = new Double_t [fNelem];
   fThresh = new Double_t [fNelem];
-  for(Int_t i=0;i<fNelem;i++) {
-    fPedSum[i] = 0;
-    fPedSum2[i] = 0;
+  for(Int_t i = 0; i < fNelem; i++) {
+    fPedSum[i]   = 0;
+    fPedSum2[i]  = 0;
     fPedCount[i] = 0;
   }
 
@@ -524,7 +512,7 @@ void THcCherenkov::AccumulatePedestals(TClonesArray* rawhits)
     Int_t element = hit->fCounter - 1;
     Int_t nadc = hit->GetRawAdcHitPos().GetPulseIntRaw();
     if(nadc <= fPedLimit[element]) {
-      fPedSum[element] += nadc;
+      fPedSum[element]  += nadc;
       fPedSum2[element] += nadc*nadc;
       fPedCount[element]++;
       if(fPedCount[element] == fMinPeds/5) {

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -61,8 +61,6 @@ THcCherenkov::THcCherenkov( const char* name, const char* description,
   frAdcPulseAmp = new TClonesArray("THcSignalHit", 16);
 
   InitArrays();
-
-
 }
 
 //_____________________________________________________________________________
@@ -82,6 +80,25 @@ THcCherenkov::THcCherenkov( ) :
   frAdcPulseAmp = NULL;
 
   InitArrays();
+}
+
+//_____________________________________________________________________________
+THcCherenkov::~THcCherenkov()
+{
+  // Destructor
+  delete fADCHits; fADCHits = NULL;
+
+  delete frAdcPedRaw; frAdcPedRaw = NULL;
+  delete frAdcPulseIntRaw; frAdcPulseIntRaw = NULL;
+  delete frAdcPulseAmpRaw; frAdcPulseAmpRaw = NULL;
+  delete frAdcPulseTimeRaw; frAdcPulseTimeRaw = NULL;
+
+  delete frAdcPed; frAdcPed = NULL;
+  delete frAdcPulseInt; frAdcPulseInt = NULL;
+  delete frAdcPulseAmp; frAdcPulseAmp = NULL;
+
+  DeleteArrays();
+
 }
 
 //_____________________________________________________________________________
@@ -117,24 +134,6 @@ void THcCherenkov::DeleteArrays()
   delete [] fPedCount; fPedCount = NULL;
   delete [] fPed; fPed = NULL;
   delete [] fThresh; fThresh = NULL;
-}
-//_____________________________________________________________________________
-THcCherenkov::~THcCherenkov()
-{
-  // Destructor
-  delete fADCHits; fADCHits = NULL;
-
-  delete frAdcPedRaw; frAdcPedRaw = NULL;
-  delete frAdcPulseIntRaw; frAdcPulseIntRaw = NULL;
-  delete frAdcPulseAmpRaw; frAdcPulseAmpRaw = NULL;
-  delete frAdcPulseTimeRaw; frAdcPulseTimeRaw = NULL;
-
-  delete frAdcPed; frAdcPed = NULL;
-  delete frAdcPulseInt; frAdcPulseInt = NULL;
-  delete frAdcPulseAmp; frAdcPulseAmp = NULL;
-
-  DeleteArrays();
-
 }
 
 //_____________________________________________________________________________
@@ -191,8 +190,6 @@ Int_t THcCherenkov::ReadDatabase( const TDatime& date )
   fGain = new Double_t[fNelem];
   fPedLimit = new Int_t[fNelem];
   fPedMean = new Double_t[fNelem];
-
- 
 
   fCerTrackCounter = new Int_t [fCerNRegions];
   fCerFiredCounter = new Int_t [fCerNRegions];
@@ -254,32 +251,34 @@ Int_t THcCherenkov::DefineVariables( EMode mode )
   // Do we need to put the number of pos/neg TDC/ADC hits into the variables?
   // No.  They show up in tree as Ndata.H.aero.postdchits for example
 
-  RVarDef vars[] = {
-    {"phototubes",      "Nuber of Cherenkov photo tubes",        "fNPMT"},
-    {"adc",             "Raw ADC values",                        "fADC"},
-    {"adc_hit",         "ADC hit flag =1 means hit",             "fADC_hit"},
-    {"adc_p",           "Pedestal Subtracted ADC values",        "fADC_P"},
-    {"npe",             "Number of Photo electrons",             "fNPE"},
-    {"npesum",          "Sum of Number of Photo electrons",      "fNPEsum"},
-    {"ncherhit",        "Number of Hits(Cherenkov)",             "fNCherHit"},
-    {"certrackcounter", "Tracks inside Cherenkov region",        "fCerTrackCounter"},
-    {"cerfiredcounter", "Tracks with engough Cherenkov NPEs ",   "fCerFiredCounter"},
+  vector<RVarDef> vars;
+  
+  vars.push_back({"phototubes",      "Nuber of Cherenkov photo tubes",        "fNPMT"});
+  vars.push_back({"adc",             "Raw ADC values",                        "fADC"});
+  vars.push_back({"adc_hit",         "ADC hit flag =1 means hit",             "fADC_hit"});
+  vars.push_back({"adc_p",           "Pedestal Subtracted ADC values",        "fADC_P"});
+  vars.push_back({"npe",             "Number of Photo electrons",             "fNPE"});
+  vars.push_back({"npesum",          "Sum of Number of Photo electrons",      "fNPEsum"});
+  vars.push_back({"ncherhit",        "Number of Hits(Cherenkov)",             "fNCherHit"});
+  vars.push_back({"certrackcounter", "Tracks inside Cherenkov region",        "fCerTrackCounter"});
+  vars.push_back({"cerfiredcounter", "Tracks with engough Cherenkov NPEs ",   "fCerFiredCounter"});
 
-    {"adcCounter",      "List of ADC counter numbers.",      "frAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"},
+  vars.push_back({"adcCounter",      "List of ADC counter numbers.",      "frAdcPulseIntRaw.THcSignalHit.GetPaddleNumber()"});
 
-    {"adcPedRaw",       "List of raw ADC pedestals",         "frAdcPedRaw.THcSignalHit.GetData()"},
-    {"adcPulseIntRaw",  "List of raw ADC pulse integrals.",  "frAdcPulseIntRaw.THcSignalHit.GetData()"},
-    {"adcPulseAmpRaw",  "List of raw ADC pulse amplitudes.", "frAdcPulseAmpRaw.THcSignalHit.GetData()"},
-    {"adcPulseTimeRaw", "List of raw ADC pulse times.",      "frAdcPulseTimeRaw.THcSignalHit.GetData()"},
+  vars.push_back({"adcPedRaw",       "List of raw ADC pedestals",         "frAdcPedRaw.THcSignalHit.GetData()"});
+  vars.push_back({"adcPulseIntRaw",  "List of raw ADC pulse integrals.",  "frAdcPulseIntRaw.THcSignalHit.GetData()"});
+  vars.push_back({"adcPulseAmpRaw",  "List of raw ADC pulse amplitudes.", "frAdcPulseAmpRaw.THcSignalHit.GetData()"});
+  vars.push_back({"adcPulseTimeRaw", "List of raw ADC pulse times.",      "frAdcPulseTimeRaw.THcSignalHit.GetData()"});
 
-    {"adcPed",          "List of ADC pedestals",             "frAdcPed.THcSignalHit.GetData()"},
-    {"adcPulseInt",     "List of ADC pulse integrals.",      "frAdcPulseInt.THcSignalHit.GetData()"},
-    {"adcPulseAmp",     "List of ADC pulse amplitudes.",     "frAdcPulseAmp.THcSignalHit.GetData()"},
+  vars.push_back({"adcPed",          "List of ADC pedestals",             "frAdcPed.THcSignalHit.GetData()"});
+  vars.push_back({"adcPulseInt",     "List of ADC pulse integrals.",      "frAdcPulseInt.THcSignalHit.GetData()"});
+  vars.push_back({"adcPulseAmp",     "List of ADC pulse amplitudes.",     "frAdcPulseAmp.THcSignalHit.GetData()"});
 
-    { 0 }
-  };
+  RVarDef end {};
+  vars.push_back(end);  
 
-  return DefineVarsFromList( vars, mode );
+  return DefineVarsFromList(vars.data(), mode);
+
 }
 //_____________________________________________________________________________
 inline
@@ -363,7 +362,6 @@ Int_t THcCherenkov::Decode( const THaEvData& evdata )
       THcSignalHit *sighit = (THcSignalHit*) fADCHits->ConstructedAt(nADCHits++);
       sighit->Set(hit->fCounter, hit->GetRawAdcHitPos().GetPulseIntRaw());
     }
-
     ihit++;
   }
   return ihit;

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -59,11 +59,9 @@ THcCherenkov::THcCherenkov( const char* name, const char* description,
   frAdcPed      = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
   frAdcPulseInt = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
   frAdcPulseAmp = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
-
   fAdcErrorFlag = new TClonesArray("THcSignalHit", MaxNumCerPmt*MaxNumAdcPulse);
 
-  fNpe = vector<Double_t>(MaxNumCerPmt, 0.0);
-
+  fNpe                 = vector<Double_t>(MaxNumCerPmt, 0.0);
   fGoodAdcPed          = vector<Double_t>(MaxNumCerPmt, 0.0);
   fGoodAdcPulseInt     = vector<Double_t>(MaxNumCerPmt, 0.0);
   fGoodAdcPulseIntRaw  = vector<Double_t>(MaxNumCerPmt, 0.0);
@@ -80,15 +78,14 @@ THcCherenkov::THcCherenkov( ) :
   // Constructor
   fADCHits = NULL;
 
-  frAdcPedRaw = NULL;
-  frAdcPulseIntRaw = NULL;
-  frAdcPulseAmpRaw = NULL;
+  frAdcPedRaw       = NULL;
+  frAdcPulseIntRaw  = NULL;
+  frAdcPulseAmpRaw  = NULL;
   frAdcPulseTimeRaw = NULL;
 
-  frAdcPed = NULL;
+  frAdcPed      = NULL;
   frAdcPulseInt = NULL;
   frAdcPulseAmp = NULL;
-
   fAdcErrorFlag = NULL;
 
   InitArrays();
@@ -100,16 +97,15 @@ THcCherenkov::~THcCherenkov()
   // Destructor
   delete fADCHits; fADCHits = NULL;
 
-  delete frAdcPedRaw; frAdcPedRaw = NULL;
-  delete frAdcPulseIntRaw; frAdcPulseIntRaw = NULL;
-  delete frAdcPulseAmpRaw; frAdcPulseAmpRaw = NULL;
+  delete frAdcPedRaw;       frAdcPedRaw       = NULL;
+  delete frAdcPulseIntRaw;  frAdcPulseIntRaw  = NULL;
+  delete frAdcPulseAmpRaw;  frAdcPulseAmpRaw  = NULL;
   delete frAdcPulseTimeRaw; frAdcPulseTimeRaw = NULL;
 
-  delete frAdcPed; frAdcPed = NULL;
+  delete frAdcPed;      frAdcPed      = NULL;
   delete frAdcPulseInt; frAdcPulseInt = NULL;
   delete frAdcPulseAmp; frAdcPulseAmp = NULL;
-
-  delete fAdcErrorFlag; fAdcErrorFlag= NULL;
+  delete fAdcErrorFlag; fAdcErrorFlag = NULL;
 
   DeleteArrays();
 
@@ -119,7 +115,6 @@ THcCherenkov::~THcCherenkov()
 void THcCherenkov::InitArrays()
 {
   fGain = NULL;
-  fCerWidth = NULL;
   fNPMT = NULL;
   fPedSum = NULL;
   fPedSum2 = NULL;
@@ -133,7 +128,6 @@ void THcCherenkov::InitArrays()
 void THcCherenkov::DeleteArrays()
 {
   delete [] fGain; fGain = NULL;
-  delete [] fCerWidth; fCerWidth = NULL;
   delete [] fNPMT; fNPMT = NULL;
   
   // 6 Gev pedestal variables
@@ -190,10 +184,11 @@ Int_t THcCherenkov::ReadDatabase( const TDatime& date )
   //    fNelem = 2;      // Default if not defined
   fCerNRegions = 3;
 
+  Bool_t optional = true;
+
   fNPMT = new Int_t[fNelem];
   fADC_hit = new Int_t[fNelem];
 
-  fCerWidth = new Double_t[fNelem];
   fGain = new Double_t[fNelem];
   fPedLimit = new Int_t[fNelem];
   fPedMean = new Double_t[fNelem];
@@ -209,9 +204,8 @@ Int_t THcCherenkov::ReadDatabase( const TDatime& date )
   fCerRegionValue = new Double_t [fCerRegionsValueMax];
 
   DBRequest list[]={
+    {"_ped_limit",   fPedLimit,           kInt,    (UInt_t) fNelem, optional},
     {"_adc_to_npe",  fGain,               kDouble, (UInt_t) fNelem},
-    {"_ped_limit",   fPedLimit,           kInt,    (UInt_t) fNelem},
-    {"_width",       fCerWidth,           kDouble, (UInt_t) fNelem},
     {"_chi2max",     &fCerChi2Max,        kDouble},
     {"_beta_min",    &fCerBetaMin,        kDouble},
     {"_beta_max",    &fCerBetaMax,        kDouble},
@@ -308,13 +302,11 @@ void THcCherenkov::Clear(Option_t* opt)
   // Clear the hit lists
   fADCHits->Clear();
 
-  // Clear Cherenkov variables  from h_trans_cer.f
-
   fNhits = 0;	     
   fNpeSum = 0.0;
   fNCherHit = 0;
 
-  for(Int_t itube = 0;itube < fNelem;itube++) {
+  for(Int_t itube = 0; itube < fNelem; itube++) {
     fNPMT[itube] = 0;
     fADC_hit[itube] = 0;
   }
@@ -327,7 +319,6 @@ void THcCherenkov::Clear(Option_t* opt)
   frAdcPed->Clear();
   frAdcPulseInt->Clear();
   frAdcPulseAmp->Clear();
-
   fAdcErrorFlag->Clear();
 
   for (UInt_t ielem = 0; ielem < fGoodAdcPed.size(); ielem++) {
@@ -336,8 +327,7 @@ void THcCherenkov::Clear(Option_t* opt)
     fGoodAdcPulseIntRaw.at(ielem) = 0.0;
     fGoodAdcPulseAmp.at(ielem)    = 0.0;
     fGoodAdcPulseTime.at(ielem)   = 0.0;
-    
-    fNpe.at(ielem) = 0.0;
+    fNpe.at(ielem)                = 0.0;
   }
 
 }
@@ -365,9 +355,9 @@ Int_t THcCherenkov::Decode( const THaEvData& evdata )
 
   while(ihit < fNhits) {
 
-    THcCherenkovHit* hit = (THcCherenkovHit *) fRawHitList->At(ihit);
-    Int_t padnum = hit->fCounter;
-    THcRawAdcHit& rawAdcHit = hit->GetRawAdcHitPos();
+    THcCherenkovHit* hit       = (THcCherenkovHit*) fRawHitList->At(ihit);
+    Int_t            padnum    = hit->fCounter;
+    THcRawAdcHit&    rawAdcHit = hit->GetRawAdcHitPos();
     
     for (UInt_t thit=0; thit<rawAdcHit.GetNPulses(); ++thit) {
            
@@ -387,7 +377,9 @@ Int_t THcCherenkov::Decode( const THaEvData& evdata )
       
       fADC_hit[padnum-1] = 1;  
 
-      //cout << "npmt = " << padnum-1 << "\t" << "thit = " << thit << "\t" << "frAdcPulseInt = " << rawAdcHit.GetPulseInt(thit) << endl;
+      // cout << "fNhits = " << fNhits << "\t" << "npmt = " << padnum-1 << "\t" 
+      // 	   << "thit = " << thit << "\t" 
+      // 	   << "frAdcPulseInt = " << rawAdcHit.GetPulseInt(thit) << endl;
 
       ++nrAdcHits;
     }
@@ -408,27 +400,26 @@ Int_t THcCherenkov::ApplyCorrections( void )
 }
 
 //_____________________________________________________________________________
-Int_t THcCherenkov::CoarseProcess( TClonesArray&  ) //tracks
+Int_t THcCherenkov::CoarseProcess( TClonesArray&  )
 {
   
-  //cout << "=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:=:" << endl;
-
   // Loop over the elements in the TClonesArray
   for(Int_t ielem = 0; ielem < frAdcPulseInt->GetEntries(); ielem++) {
 
-    Int_t    npmt        = ((THcSignalHit*) frAdcPulseInt->ConstructedAt(ielem))->GetPaddleNumber() - 1;
-    Double_t pulsePed    = ((THcSignalHit*) frAdcPed->ConstructedAt(ielem))->GetData();
-    Double_t pulseInt    = ((THcSignalHit*) frAdcPulseInt->ConstructedAt(ielem))->GetData();
-    Double_t pulseIntRaw = ((THcSignalHit*) frAdcPulseIntRaw->ConstructedAt(ielem))->GetData();
-    Double_t pulseAmp    = ((THcSignalHit*) frAdcPulseAmp->ConstructedAt(ielem))->GetData();
-    Double_t pulseTime   = ((THcSignalHit*) frAdcPulseTimeRaw->ConstructedAt(ielem))->GetData();
+    Int_t    npmt         = ((THcSignalHit*) frAdcPulseInt->ConstructedAt(ielem))->GetPaddleNumber() - 1;
+    Double_t pulsePed     = ((THcSignalHit*) frAdcPed->ConstructedAt(ielem))->GetData();
+    Double_t pulseInt     = ((THcSignalHit*) frAdcPulseInt->ConstructedAt(ielem))->GetData();
+    Double_t pulseIntRaw  = ((THcSignalHit*) frAdcPulseIntRaw->ConstructedAt(ielem))->GetData();
+    Double_t pulseAmp     = ((THcSignalHit*) frAdcPulseAmp->ConstructedAt(ielem))->GetData();
+    Double_t pulseTime    = ((THcSignalHit*) frAdcPulseTimeRaw->ConstructedAt(ielem))->GetData();
+    Bool_t   errorFlag    = ((THcSignalHit*) fAdcErrorFlag->ConstructedAt(ielem))->GetData();  
+    Bool_t   pulseTimeCut = pulseTime > 500 && pulseTime < 2500;
 
-    //cout << "fNhits = " << fNhits << "\t" << "nmpt = " << npmt << "\t" << "ielem = " << ielem << "\t" << "pulseInt = " << pulseInt << endl;
-    
-    Bool_t pulseAmpCut  = pulseAmp > 0;
-    Bool_t pulseTimeCut = pulseTime > 500 && pulseTime < 2500;
+    // cout << "npmt = " << npmt << "\t" << "ielem = " << ielem << "\t"
+    // 	 << "pulseInt = " << pulseInt << "\t" << endl;
 
-    if (pulseAmpCut && pulseTimeCut) {
+    // By default, the last hit within the timing cut will be considered "good"
+    if (!errorFlag && pulseTimeCut) {
       fGoodAdcPed.at(npmt)         = pulsePed;
       fGoodAdcPulseInt.at(npmt)    = pulseInt;
       fGoodAdcPulseIntRaw.at(npmt) = pulseIntRaw;
@@ -438,11 +429,8 @@ Int_t THcCherenkov::CoarseProcess( TClonesArray&  ) //tracks
       fNpe.at(npmt) = fGain[npmt]*fGoodAdcPulseInt.at(npmt);
       fNpeSum += fNpe.at(npmt);
     }
-
     fNPMT[npmt] = npmt + 1;
-
-    fNCherHit ++;
-    
+    fNCherHit ++;  
   }
 
   return 0;
@@ -451,23 +439,33 @@ Int_t THcCherenkov::CoarseProcess( TClonesArray&  ) //tracks
 //_____________________________________________________________________________
 Int_t THcCherenkov::FineProcess( TClonesArray& tracks )
 {
+  
+  Int_t lastIndex = tracks.GetLast();
 
-  if ( tracks.GetLast() > -1 ) {
+  if (lastIndex > -1) {
 
-    THaTrack* theTrack = dynamic_cast<THaTrack*>( tracks.At(0) );
-    if (!theTrack) return -1;
+    THaTrack* track = dynamic_cast<THaTrack*> (tracks.At(0));
+    if (!track) return -1;
 
-    if ( ( ( tracks.GetLast() + 1 ) == 1 ) &&
-	 ( theTrack->GetChi2()/theTrack->GetNDoF() > 0. ) &&
-	 ( theTrack->GetChi2()/theTrack->GetNDoF() <  fCerChi2Max ) &&
-	 ( theTrack->GetBeta() > fCerBetaMin ) &&
-	 ( theTrack->GetBeta() < fCerBetaMax ) &&
-	 ( ( theTrack->GetEnergy() / theTrack->GetP() ) > fCerETMin ) &&
-	 ( ( theTrack->GetEnergy() / theTrack->GetP() ) < fCerETMax )
-	 ) {
+    //if ( ( ( tracks.GetLast() + 1 ) == 1 ) &&
+    if ((lastIndex == 0) &&
+	( track->GetChi2()/track->GetNDoF() > 0. ) &&
+	( track->GetChi2()/track->GetNDoF() <  fCerChi2Max ) &&
+	( track->GetBeta() > fCerBetaMin ) &&
+	( track->GetBeta() < fCerBetaMax ) &&
+	( ( track->GetEnergy() / track->GetP() ) > fCerETMin ) &&
+	( ( track->GetEnergy() / track->GetP() ) < fCerETMax )
+	) {
 
-      Double_t cerX = theTrack->GetX() + theTrack->GetTheta() * fCerMirrorZPos;
-      Double_t cerY = theTrack->GetY() + theTrack->GetPhi()   * fCerMirrorZPos;
+      cout << track->GetChi2() << "\t" << track->GetNDoF() << "\t"
+	   << track->GetBeta() << "\t" << track->GetEnergy() << "\t"
+	   << track->GetP() << endl;
+
+      cout << track->GetX() << "\t" << track->GetY() << "\t" 
+	   << track->GetTheta() << "\t" << track->GetPhi() << endl;
+
+      Double_t cerX = track->GetX() + track->GetTheta() * fCerMirrorZPos;
+      Double_t cerY = track->GetY() + track->GetPhi()   * fCerMirrorZPos;
 
       for ( Int_t ir = 0; ir < fCerNRegions; ir++ ) {
 
@@ -477,9 +475,9 @@ Int_t THcCherenkov::FineProcess( TClonesArray& tracks )
 	       fCerRegionValue[GetCerIndex( ir, 4 )] ) &&
 	     ( TMath::Abs( fCerRegionValue[GetCerIndex( ir, 1 )] - cerY ) <
 	       fCerRegionValue[GetCerIndex( ir, 5 )] ) &&
-	     ( TMath::Abs( fCerRegionValue[GetCerIndex( ir, 2 )] - theTrack->GetTheta() ) <
+	     ( TMath::Abs( fCerRegionValue[GetCerIndex( ir, 2 )] - track->GetTheta() ) <
 	       fCerRegionValue[GetCerIndex( ir, 6 )] ) &&
-	     ( TMath::Abs( fCerRegionValue[GetCerIndex( ir, 3 )] - theTrack->GetPhi() ) <
+	     ( TMath::Abs( fCerRegionValue[GetCerIndex( ir, 3 )] - track->GetPhi() ) <
 	       fCerRegionValue[GetCerIndex( ir, 7 )] )
 	     ) {
 

--- a/src/THcCherenkov.h
+++ b/src/THcCherenkov.h
@@ -36,7 +36,7 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
 
   virtual void Print(const Option_t* opt) const;
 
-  Int_t GetCerIndex(Int_t nRegion, Int_t nValue);
+  Int_t GetIndex(Int_t nRegion, Int_t nValue);
 
   //  Double_t GetCerNPE() { return fNPEsum;}
   Double_t GetCerNPE();
@@ -51,18 +51,22 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   Int_t         fDebugAdc;
 
   // Parameters
-  Double_t*     fCerWidth;
+  Double_t*     fWidth;
 
   // Event information
   Int_t         fNhits;
-  Int_t*        fADC_hit;         // [fNelem] Array of flag if ADC hit 1 means  
-  Int_t*        fNPMT;            // [fNelem] Array of ADC amplitudes
   Double_t*     fGain;
-  Int_t         fNCherHit;
+    
+  Double_t  fNpeSum;
+  Int_t     fTotNumAdcHits;
+  Int_t     fTotNumGoodAdcHits;
+  Int_t     fTotNumTracksMatched;
+  Int_t     fTotNumTracksFired;
 
-  
-  Double_t      fNpeSum;
-
+  vector<Int_t>    fNumAdcHits;
+  vector<Int_t>    fNumGoodAdcHits;
+  vector<Int_t>    fNumTracksMatched;
+  vector<Int_t>    fNumTracksFired;
   vector<Double_t> fGoodAdcPed;
   vector<Double_t> fGoodAdcPulseInt;
   vector<Double_t> fGoodAdcPulseIntRaw;
@@ -70,18 +74,19 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   vector<Double_t> fGoodAdcPulseTime;
   vector<Double_t> fNpe;
 
-  Double_t*        fCerRegionValue;
-  Double_t         fCerChi2Max;
-  Double_t         fCerBetaMin;
-  Double_t         fCerBetaMax;
-  Double_t         fCerETMin;
-  Double_t         fCerETMax;
-  Double_t         fCerMirrorZPos;
-  Int_t            fCerNRegions;
-  Int_t            fCerRegionsValueMax;
-  Int_t*           fCerTrackCounter;     // [fCerNRegions] Array of Cher regions
-  Int_t*           fCerFiredCounter;     // [fCerNRegions] Array of Cher regions
-  Double_t         fCerThresh;
+  Double_t*        fRegionValue;
+  Double_t         fRedChi2Min;
+  Double_t         fRedChi2Max;
+  Double_t         fBetaMin;
+  Double_t         fBetaMax;
+  Double_t         fENormMin;
+  Double_t         fENormMax;
+  Double_t         fMirrorZPos;
+  Double_t         fNpeThresh;
+  Double_t         fAdcTimeWindowMin;
+  Double_t         fAdcTimeWindowMax;
+  Int_t            fNRegions;
+  Int_t            fRegionsValueMax;
 
   // Hits
   TClonesArray* fADCHits;

--- a/src/THcCherenkov.h
+++ b/src/THcCherenkov.h
@@ -38,8 +38,8 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   Double_t GetCerNPE();
 
   // Vector/TClonesArray length parameters
-  Int_t MaxNumCerPmt   = 4;
-  Int_t MaxNumAdcPulse = 4;
+  static const Int_t MaxNumCerPmt   = 4;
+  static const Int_t MaxNumAdcPulse = 4;
 
   THcCherenkov();  // for ROOT I/O
  protected:

--- a/src/THcCherenkov.h
+++ b/src/THcCherenkov.h
@@ -95,6 +95,8 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   TClonesArray* frAdcPulseInt;
   TClonesArray* frAdcPulseAmp;
 
+  TClonesArray* fAdcErrorFlag;
+
   void Setup(const char* name, const char* description);
   virtual void  InitializePedestals( );
 

--- a/src/THcCherenkov.h
+++ b/src/THcCherenkov.h
@@ -41,23 +41,34 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   //  Double_t GetCerNPE() { return fNPEsum;}
   Double_t GetCerNPE();
 
+  // Vector/TClonesArray length parameters
+  Int_t MaxNumCerPmt   = 4;
+  Int_t MaxNumAdcPulse = 4;
+
   THcCherenkov();  // for ROOT I/O
  protected:
   Int_t         fAnalyzePedestals;
+  Int_t         fDebugAdc;
 
   // Parameters
-  Double_t*     fGain;
   Double_t*     fCerWidth;
 
   // Event information
   Int_t         fNhits;
   Int_t*        fADC_hit;         // [fNelem] Array of flag if ADC hit 1 means  
   Int_t*        fNPMT;            // [fNelem] Array of ADC amplitudes
-  Double_t*     fADC;             // [fNelem] Array of ADC amplitudes
-  Double_t*     fADC_P;           // [fNelem] Array of ADC amplitudes
-  Double_t*     fNPE;             // [fNelem] Array of ADC amplitudes
-  Double_t      fNPEsum;
+  Double_t*     fGain;
   Int_t         fNCherHit;
+
+  
+  Double_t      fNpeSum;
+
+  vector<Double_t> fGoodAdcPed;
+  vector<Double_t> fGoodAdcPulseInt;
+  vector<Double_t> fGoodAdcPulseIntRaw;
+  vector<Double_t> fGoodAdcPulseAmp;
+  vector<Double_t> fGoodAdcPulseTime;
+  vector<Double_t> fNpe;
 
   Double_t*        fCerRegionValue;
   Double_t         fCerChi2Max;
@@ -75,7 +86,7 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   // Hits
   TClonesArray* fADCHits;
 
-  // Pedestals
+  // 6 Gev pedestal variables
   Int_t         fNPedestalEvents;
   Int_t         fMinPeds;
   Int_t*        fPedSum;	  /* Accumulators for pedestals */
@@ -86,6 +97,7 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   Double_t*     fPed;
   Double_t*     fThresh;
 
+  // 12 Gev FADC variables
   TClonesArray* frAdcPedRaw;
   TClonesArray* frAdcPulseIntRaw;
   TClonesArray* frAdcPulseAmpRaw;

--- a/src/THcCherenkov.h
+++ b/src/THcCherenkov.h
@@ -15,27 +15,23 @@
 class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
 
  public:
-  THcCherenkov( const char* name, const char* description = "",
-		THaApparatus* a = NULL );
+  THcCherenkov(const char* name, const char* description = "", THaApparatus* a = NULL);
   virtual ~THcCherenkov();
 
-  virtual void 	     Clear( Option_t* opt="" );
-  virtual Int_t      Decode( const THaEvData& );
-  virtual EStatus    Init( const TDatime& run_time );
-  void               InitArrays();
-  void               DeleteArrays();
-  virtual Int_t      ReadDatabase( const TDatime& date );
-  virtual Int_t      DefineVariables( EMode mode = kDefine );
-  virtual Int_t      CoarseProcess( TClonesArray& tracks );
-  virtual Int_t      FineProcess( TClonesArray& tracks );
+  virtual void 	  Clear(Option_t* opt="");
+  virtual void    Print(const Option_t* opt) const;
+  virtual void    AccumulatePedestals(TClonesArray* rawhits);
+  virtual void    CalculatePedestals();
+  virtual Int_t   Decode(const THaEvData&);
+  virtual Int_t   ReadDatabase(const TDatime& date);
+  virtual Int_t   DefineVariables(EMode mode = kDefine);
+  virtual Int_t   CoarseProcess(TClonesArray& tracks);
+  virtual Int_t   FineProcess(TClonesArray& tracks);
+  virtual Int_t   ApplyCorrections( void );
+  virtual EStatus Init(const TDatime& run_time);
 
-  virtual void AccumulatePedestals(TClonesArray* rawhits);
-  virtual void CalculatePedestals();
-
-  virtual Int_t      ApplyCorrections( void );
-
-  virtual void Print(const Option_t* opt) const;
-
+  void  InitArrays();
+  void  DeleteArrays();
   Int_t GetIndex(Int_t nRegion, Int_t nValue);
 
   //  Double_t GetCerNPE() { return fNPEsum;}
@@ -47,21 +43,17 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
 
   THcCherenkov();  // for ROOT I/O
  protected:
-  Int_t         fAnalyzePedestals;
-  Int_t         fDebugAdc;
+  Int_t     fAnalyzePedestals;
+  Int_t     fDebugAdc;
+  Double_t* fWidth;
 
-  // Parameters
-  Double_t*     fWidth;
-
-  // Event information
-  Int_t         fNhits;
-  Double_t*     fGain;
-    
-  Double_t  fNpeSum;
+  Int_t     fNhits; 
   Int_t     fTotNumAdcHits;
   Int_t     fTotNumGoodAdcHits;
   Int_t     fTotNumTracksMatched;
   Int_t     fTotNumTracksFired;
+  Double_t  fNpeSum;
+  Double_t* fGain;
 
   vector<Int_t>    fNumAdcHits;
   vector<Int_t>    fNumGoodAdcHits;
@@ -74,44 +66,39 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   vector<Double_t> fGoodAdcPulseTime;
   vector<Double_t> fNpe;
 
-  Double_t*        fRegionValue;
-  Double_t         fRedChi2Min;
-  Double_t         fRedChi2Max;
-  Double_t         fBetaMin;
-  Double_t         fBetaMax;
-  Double_t         fENormMin;
-  Double_t         fENormMax;
-  Double_t         fMirrorZPos;
-  Double_t         fNpeThresh;
-  Double_t         fAdcTimeWindowMin;
-  Double_t         fAdcTimeWindowMax;
-  Int_t            fNRegions;
-  Int_t            fRegionsValueMax;
-
-  // Hits
-  TClonesArray* fADCHits;
+  Int_t     fNRegions;
+  Int_t     fRegionsValueMax;
+  Double_t  fRedChi2Min;
+  Double_t  fRedChi2Max;
+  Double_t  fBetaMin;
+  Double_t  fBetaMax;
+  Double_t  fENormMin;
+  Double_t  fENormMax;
+  Double_t  fMirrorZPos;
+  Double_t  fNpeThresh;
+  Double_t  fAdcTimeWindowMin;
+  Double_t  fAdcTimeWindowMax;
+  Double_t* fRegionValue;
 
   // 6 Gev pedestal variables
-  Int_t         fNPedestalEvents;
-  Int_t         fMinPeds;
-  Int_t*        fPedSum;	  /* Accumulators for pedestals */
-  Int_t*        fPedSum2;
-  Int_t*        fPedLimit;
-  Double_t*     fPedMean; 	  /* Can be supplied in parameters and then */
-  Int_t*        fPedCount;
-  Double_t*     fPed;
-  Double_t*     fThresh;
+  Int_t     fNPedestalEvents;
+  Int_t     fMinPeds;
+  Int_t*    fPedSum;	  /* Accumulators for pedestals */
+  Int_t*    fPedSum2;
+  Int_t*    fPedLimit;
+  Int_t*    fPedCount;
+  Double_t* fPedMean; 	  /* Can be supplied in parameters and then */
+  Double_t* fPed;
+  Double_t* fThresh;
 
   // 12 Gev FADC variables
   TClonesArray* frAdcPedRaw;
   TClonesArray* frAdcPulseIntRaw;
   TClonesArray* frAdcPulseAmpRaw;
   TClonesArray* frAdcPulseTimeRaw;
-
   TClonesArray* frAdcPed;
   TClonesArray* frAdcPulseInt;
   TClonesArray* frAdcPulseAmp;
-
   TClonesArray* fAdcErrorFlag;
 
   void Setup(const char* name, const char* description);


### PR DESCRIPTION
- Rework of aerogel and Cherenkov classes as was discussed in the software meeting on 3/29/17.
- As of now, the size of the TClonesArray objects are hard-coded in the respective header files.  This is not okay in the long run.  Ideally, the size of the TClonesArrays should be defined by the parameter which dictates how many readout detectors exist for the respective detector.  I tried doing this in the Init method however, podd complained regarding the size of the TClonesArrays in the DEF-file histograms.  I was unsuccessful in my first attempt.  This should be addressed in the future even though things work for now.