### PR TITLE
Fix mistake in THcShowerArray and make the threshold a parameter

### DIFF
--- a/src/THcShowerArray.cxx
+++ b/src/THcShowerArray.cxx
@@ -128,6 +128,7 @@ Int_t THcShowerArray::ReadDatabase( const TDatime& date )
     {"cal_arr_ADCMode", &fADCMode, kInt, 0, 1},
     {"cal_arr_AdcTimeWindowMin", &fAdcTimeWindowMin, kDouble, 0, 1},
     {"cal_arr_AdcTimeWindowMax", &fAdcTimeWindowMax, kDouble, 0, 1},
+    {"cal_arr_AdcThreshold", &fAdcThreshold, kDouble, 0, 1},
     {"cal_ped_sample_low", &fPedSampLow, kInt, 0, 1},
     {"cal_ped_sample_high", &fPedSampHigh, kInt, 0, 1},
     {"cal_data_sample_low", &fDataSampLow, kInt, 0, 1},
@@ -138,6 +139,7 @@ Int_t THcShowerArray::ReadDatabase( const TDatime& date )
   fADCMode=kADCDynamicPedestal;
   fAdcTimeWindowMin=0;
   fAdcTimeWindowMax=10000;
+  fAdcThreshold=0.;
   fNelem = fNRows*fNColumns;
 
   fXPos = new Double_t* [fNRows];
@@ -791,7 +793,7 @@ Int_t THcShowerArray::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
     //
     for (UInt_t thit=0; thit<rawAdcHit.GetNPulses(); ++thit) {
       ((THcSignalHit*) frAdcPedRaw->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPedRaw());
-        fThresh[padnum]=rawAdcHit.GetPedRaw()*rawAdcHit.GetF250_PeakPedestalRatio()+250.;
+        fThresh[padnum-1]=rawAdcHit.GetPedRaw()*rawAdcHit.GetF250_PeakPedestalRatio()+fAdcThreshold;
      ((THcSignalHit*) frAdcPed->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPed());
 
       ((THcSignalHit*) frAdcPulseIntRaw->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPulseIntRaw(thit));

--- a/src/THcShowerArray.h
+++ b/src/THcShowerArray.h
@@ -113,6 +113,7 @@ protected:
   static const Int_t kADCSampIntDynPed=3;
   Double_t fAdcTimeWindowMin ;
   Double_t fAdcTimeWindowMax ;
+  Double_t fAdcThreshold ;
 Int_t fPedSampLow;		// Sample range for
   Int_t fPedSampHigh;		// dynamic pedestal
   Int_t fDataSampLow;		// Sample range for

--- a/src/THcShowerPlane.h
+++ b/src/THcShowerPlane.h
@@ -122,6 +122,8 @@ protected:
   Int_t fPedSampHigh;		// dynamic pedestal
   Int_t fDataSampLow;		// Sample range for
   Int_t fDataSampHigh;		// sample integration
+  Double_t fAdcNegThreshold;		// 
+  Double_t fAdcPosThreshold;		// 
 
   Double_t*   fA_Pos;         // [fNelem] ADC amplitudes of blocks
   Double_t*   fA_Neg;         // [fNelem] ADC amplitudes of blocks


### PR DESCRIPTION
THcShowerArray
1) in ProcessHits methodfFixed mistake in index of fThresh
   was using padnum instead of padnum-1
2) add parameter pcal_arr_AdcThreshold so that threshold
   can be set by a parameter. Default is zero which gives
   the best resolution.

THcShowerPlane
1) Added the parameter cal_AdcNegThreshold and cal_AdcPosThreshold
   so that the threshold can be set through a parameter
   Previously it was hardcoded.