### PR TITLE
Modified THcDriftChamberPlane.cxx and THcDriftChamberPlane.h

### DIFF
--- a/src/THcDriftChamberPlane.h
+++ b/src/THcDriftChamberPlane.h
@@ -79,6 +79,7 @@ protected:
   Int_t fPlaneNum;
   Int_t fPlaneIndex;		/* Index of this plane within it's chamber */
   Int_t fChamberNum;
+  Int_t fUsingTzeroPerWire;
   Int_t fNRawhits;
   Int_t fNWires;
   Int_t fWireOrder;
@@ -103,6 +104,8 @@ protected:
   Double_t fCenter;
 
   Double_t fNSperChan;		/* TDC bin size */
+
+  Double_t* fTzeroWire;
 
   virtual Int_t  ReadDatabase( const TDatime& date );
   virtual Int_t  DefineVariables( EMode mode = kDefine );


### PR DESCRIPTION
Main purpose was to have option for per wire tzero offsets

Modified THcDriftChamberPlane.h
------------------------------
1) added fUsingTzeroPerWire as parameter flag to switch on per wire tzero offsets when parameter equals 1
2) fTzeroWire is array of tzero offsets for each wire in plane

Modified THcDriftChamberPlane.cxx
------------------------------
1) THcDriftChamberPlane::ReadDatabase
    a)set a default value of fUsingTzeroPerWire=0
    b)added to DBRequest list option to read in fUsingTzeroPerWire
    c) if fUsingTzeroPerWire=1 then separate DBRequest to read in fTzeroWire
   d) if fUsingTzeroPerWire=0 then all fTzeroWire=0

2) THcDriftChamberPlane::ProcessHits
------------------------------------
   a) Modify calcualation of drift time to subtract fTzeroWire
Double_t time = -StartTime- rawtdc*fNSperChan + fPlaneTimeZero - fTzeroWire[wireNum-1];