### PR TITLE
Modify THcDC and THcHallCSpectrometer

### DIFF
--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -38,6 +38,7 @@ public:
 
   //  Int_t GetNTracks() const { return fNDCTracks; }
   //  const TClonesArray* GetTrackHits() const { return fTrackProj; }
+  void SetFocalPlaneBestTrack(Int_t golden_track_index); // Called in THcHallCSpectrometer:
 
   Int_t GetNWires(Int_t plane) const { return fNWires[plane-1];}
   Int_t GetNChamber(Int_t plane) const { return fNChamber[plane-1];}

--- a/src/THcHallCSpectrometer.cxx
+++ b/src/THcHallCSpectrometer.cxx
@@ -117,8 +117,6 @@ Int_t THcHallCSpectrometer::ReadDatabase( const TDatime& date )
   cout << "In THcHallCSpectrometer::ReadDatabase()" << endl;
 #endif
 
-  // --------------- To get energy from THcShower ----------------------
-
   const char* detector_name = "hod";
   //THaApparatus* app = GetDetector();
   THaDetector* det = GetDetector("hod");
@@ -133,9 +131,13 @@ Int_t THcHallCSpectrometer::ReadDatabase( const TDatime& date )
   }
 
 
-  // fShower = static_cast<THcShower*>(det);     // fShower is a membervariable
-
-  // --------------- To get energy from THcShower ----------------------
+  THaDetector* detdc = GetDetector("dc");
+  if( dynamic_cast<THcDC*>(detdc) ) {
+    fDC = static_cast<THcDC*>(detdc);     // fHodo is a membervariable
+  } else {
+    Error("THcHallCSpectrometer", "Cannot find detector DC");
+    fDC = NULL;
+  }
 
 
   // Get the matrix element filename from the variable store
@@ -357,7 +359,7 @@ Int_t THcHallCSpectrometer::FindVertices( TClonesArray& tracks )
 
   }
 
-  if (fHodo==0 || ( fSelUsingScin == 0 ) && ( fSelUsingPrune == 0 ) ) {
+  if (fHodo==0 || (( fSelUsingScin == 0 ) && ( fSelUsingPrune == 0 )) ) {
     BestTrackSimple();
   } else if (fHodo!=0 && fSelUsingPrune !=0) {
     BestTrackUsingPrune();
@@ -380,6 +382,7 @@ Int_t THcHallCSpectrometer::TrackCalc()
       if (aTrack->GetIndex()==0) hit_gold_track=itrack;  
     }
     
+    fDC->SetFocalPlaneBestTrack(hit_gold_track);
     fGoldenTrack = static_cast<THaTrack*>( fTracks->At(hit_gold_track) );
     fTrkIfo      = *fGoldenTrack;
     fTrk         = fGoldenTrack;

--- a/src/THcHallCSpectrometer.h
+++ b/src/THcHallCSpectrometer.h
@@ -16,7 +16,7 @@
 #include "THcHitList.h"
 #include "THcRawHodoHit.h"
 #include "THcScintillatorPlane.h"
-#include "THcShower.h"
+#include "THcDC.h"
 
 //#include "THaTrackingDetector.h"
 //#include "THcHitList.h"
@@ -99,8 +99,8 @@ protected:
 
   //  Int_t**   fHodScinHit;                // [4] Array
 
-  THcShower* fShower;
   THcHodoscope* fHodo;
+  THcDC* fDC;
 
   Int_t fNReconTerms;
   struct reconTerm {


### PR DESCRIPTION
The purpose is to add a call in THcHallCSpectrometer:TrackCalc
to fill variables in THcDC for the golden track.

THcHallCSpectrometer.h
----------------------
1) Add object THcDC* fDC
2) Eliminate object fShower since it was not being used.

THcHallCSpectrometer.cxx
----------------------
1) in ReadDatabase method cast fDC if detector "dc" is defined
2) in FindVertices method add call
    to fDC->SetFocalPlaneBestTrack(hit_gold_track)
    where hit_gold_track is the HaTracks array index
    of the golden track

THcDC.h
-------
1) Add method SetFocalPlaneBestTrack

THcDC.cxx
---------
1) Eliminate filling of best focal plane quantities
   in CoarseTrack which defined "best" by lowest chi2
2) Create method SetFocalPlaneBestTrack
   a)fills the best focal plane quantities using the golden track
   b) fills fResiduals using golden track
3)Eliminate filling of fResiduals in TrackFit method