### PR TITLE
Modify THcDC and THcDriftChamberPlane to calculate per wire efficiency

### DIFF
--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -110,6 +110,8 @@ protected:
   Int_t fN_True_RawHits;
   Int_t fNSp;                   // Number of space points
   Double_t* fResiduals;         //[fNPlanes] Array of residuals
+  Double_t* fWire_hit_did;      //[fNPlanes]
+  Double_t* fWire_hit_should;   //[fNPlanes]
 
   Double_t fNSperChan;		/* TDC bin size */
   Double_t fWireVelocity;
@@ -183,7 +185,7 @@ protected:
   void Setup(const char* name, const char* description);
   void PrintSpacePoints();
   void PrintStubs();
-
+  void EfficiencyPerWire(Int_t golden_track_index);
   ClassDef(THcDC,0)   // Set of Drift Chambers detector
 };
 

--- a/src/THcDriftChamberPlane.cxx
+++ b/src/THcDriftChamberPlane.cxx
@@ -299,7 +299,13 @@ Int_t THcDriftChamberPlane::CoarseProcess( TClonesArray& tracks )
 
  return 0;
 }
-
+//
+Double_t THcDriftChamberPlane::CalcWireFromPos(Double_t pos) {
+  Double_t wire_num_calc=-1000;
+  if (fWireOrder==0) wire_num_calc = (pos+fCenter)/(fPitch)+fCentralWire;
+  if (fWireOrder==1) wire_num_calc = 1-((pos+fCenter)/(fPitch)+fCentralWire-fNWires);
+  return(wire_num_calc);
+}
 //_____________________________________________________________________________
 Int_t THcDriftChamberPlane::FineProcess( TClonesArray& tracks )
 {

--- a/src/THcDriftChamberPlane.h
+++ b/src/THcDriftChamberPlane.h
@@ -67,8 +67,8 @@ public:
   Double_t     GetPsi0() { return fPsi0; }
   Double_t*    GetStubCoef() { return fStubCoef; }
   Double_t*    GetPlaneCoef() { return fPlaneCoef; }
-
   THcDriftChamberPlane(); // for ROOT I/O
+  Double_t     CalcWireFromPos(Double_t pos);
 protected:
 
   TClonesArray* fParentHitList;
@@ -76,13 +76,13 @@ protected:
   TClonesArray* fHits;
   TClonesArray* fWires;
 
+  Int_t fWireOrder;
   Int_t fPlaneNum;
   Int_t fPlaneIndex;		/* Index of this plane within it's chamber */
   Int_t fChamberNum;
   Int_t fUsingTzeroPerWire;
   Int_t fNRawhits;
   Int_t fNWires;
-  Int_t fWireOrder;
   Int_t fTdcWinMin;
   Int_t fTdcWinMax;
   Double_t fPitch;


### PR DESCRIPTION
Main purpose is to calculate the DC efficiency per wire
using the track information of the golden track.


THcDC.h
-----------
1) add method EfficiciencyPerWire
2) Add variables fWire_hit_did and fWire_hit_should

THcDC.cxx
------------
1) fWire_hit_did and fWire_hit_should are fixed length arrays
   the size of NPlanes that in set in method Init
2) Add variables wireHitDid and wireHitShould to the tree
3) In method SetFocalPlaneBestTrack add call to EfficiencyPerWire method
4) added EfficiencyPerWire method which loops over the hits
    and compares the wire number for the hit to the the track
    position at the plane (convert back to wire number).
    Then fills fWire_hit_did with the wire number if
    equal to the wire position of the hit equals the track.
    Also does loop over all planes and fills fWire_hit_should
    with the wire number of the track in each plane.

THcDriftChamberPlane.h and cxx
---------------------
1) Added method CalcWireFromPos