### PR TITLE
Add THcRunParms.  Get beam energy without db_run.dat

### DIFF
--- a/examples/db_run.dat
+++ b/examples/db_run.dat
@@ -1,7 +1,0 @@
-# Test run database
-
-# DAQ04
---------[ 2000-01-01 01:00:00 ]
-
-#A1 2202 pedestal
-ebeam           = 4.02187

--- a/examples/hodtest.C
+++ b/examples/hodtest.C
@@ -86,7 +86,10 @@
   // We just set up one, but this could be many.
   char RunFileName[100];
   sprintf(RunFileName,RunFileNamePattern,RunNumber);
+  
   THaRun* run = new THaRun(RunFileName);
+  run->SetRunParamClass("THcRunParameters");
+  // Perhaps we should make a THcRun that does this
 
   // Eventually need to learn to skip over, or properly analyze
   // the pedestal events

--- a/src/THcRunParameters.cxx
+++ b/src/THcRunParameters.cxx
@@ -1,0 +1,62 @@
+/** \class THcRunParameters
+    \ingroup Base
+
+Get the run parameters from the Hall C style parameter database
+so that db_run.dat is not needed in hcana.
+
+\author S. A. Wood 15-June-2017
+
+*/
+#include "THcRunParameters.h"
+#include "THaAnalysisObject.h"
+#include "TMath.h"
+#include "THcParmList.h"
+#include "THcGlobals.h"
+#include <iostream>
+/*#include "TDatime.h"
+#include "TError.h"
+#include "TMath.h"
+#include "THaEvData.h"
+#include <iostream>
+*/
+
+using namespace std;
+
+//_____________________________________________________________________________
+THcRunParameters::THcRunParameters()
+{
+  // Default constructor
+  THaRunParameters::THaRunParameters();
+
+}
+//_____________________________________________________________________________
+THcRunParameters::~THcRunParameters()
+{
+  // Destructor
+}
+Int_t THcRunParameters::ReadDatabase( const TDatime& date )
+{
+  // Query the run database for the beam and target parameters
+  // The date/time is ignored as it is assumed that run number
+  // parameter lookup has already occured.
+
+  // Return 0 if success, <0 if file error, >0 if not all required data found.
+  Double_t P, E, M = 0.511e-3, Q = -1.0, dE = 0.0;
+
+   DBRequest request[] = {
+     { "gpbeam",  &P },
+     { "mbeam",  &M,  kDouble, 0, 1 },
+     { "qbeam",  &Q,  kDouble, 0, 1 },
+     { "dEbeam", &dE, kDouble, 0, 1 },
+     { 0 }
+   };
+
+   gHcParms->LoadParmValues((DBRequest*)&request, "");
+
+   E = TMath::Sqrt(P*P+M*M);
+   Int_t iq = int(Q);
+   SetBeam( E, M, iq, dE );
+
+   return 0;
+ }
+ ClassImp(THcRunParameters)

--- a/src/THcRunParameters.cxx
+++ b/src/THcRunParameters.cxx
@@ -23,12 +23,11 @@ so that db_run.dat is not needed in hcana.
 using namespace std;
 
 //_____________________________________________________________________________
-THcRunParameters::THcRunParameters()
+THcRunParameters::THcRunParameters() : THaRunParameters()
 {
   // Default constructor
-  THaRunParameters::THaRunParameters();
-
 }
+
 //_____________________________________________________________________________
 THcRunParameters::~THcRunParameters()
 {

--- a/src/THcRunParameters.h
+++ b/src/THcRunParameters.h
@@ -1,0 +1,22 @@
+#ifndef ROOT_THcRunParameters
+#define ROOT_THcRunParameters
+
+//////////////////////////////////////////////////////////////////////////
+//
+// THaRunParameters
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "THaRunParameters.h"
+
+class THcRunParameters : public THaRunParameters {
+public:
+  THcRunParameters();
+  virtual ~THcRunParameters();
+
+  virtual Int_t ReadDatabase( const TDatime& date);
+
+  ClassDef(THcRunParameters,0)
+};
+
+#endif


### PR DESCRIPTION
  With this commit, db_run.dat is not needed in hcana
  If THcRunParms is used, hcana will get the beam momentum from the
  parameter "gpbeam" instead of db_run.dat.  To use, use the
  THaRun::SetRunParamClass method to set the run parameter class
  to "THcRunParameters".

  THaRun* run = new THaRun(RunFileName);
  run->SetRunParamClass("THcRunParameters");