### PR TITLE
Update travis build to use Trusty Tahr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os: linux
 compiler: gcc
 language: cpp
+dist: trusty
 git:
   depth: 5
 before_install:
@@ -9,7 +10,7 @@ before_install:
   - sudo apt-get autoremove
   - sudo pip install --egg scons
 install:
-  - wget http://root.cern.ch/download/root_v5.34.32.Linux-ubuntu12-x86_64-gcc4.6.tar.gz -O /tmp/root.tar.gz
+  - wget https://root.cern.ch/download/root_v6.10.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
   - tar -xzf /tmp/root.tar.gz
   - source ./root/bin/thisroot.sh
   - source ./setup.sh
@@ -17,6 +18,7 @@ script:  scons
 branches:
   only:
     - develop
+    - travis
 notifications:
   email:
     recipients: saw@jlab.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ git:
   depth: 5
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y x11-common libx11-6 x11-utils gsl-bin libxpm4 libxft2 libpng3 libjpeg-turbo8 libjpeg8 libtiff4 libxml2 libldap-2.4-2 libkrb5-3 freeglut3 libfftw3-3 python libmysqlclient18 libgif4 libiodbc2 libxext6 libxmu6 libimlib2 gccxml wget libpopt-dev libc6-dev-i386
   - sudo apt-get autoremove
   - sudo pip install --egg scons
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ before_install:
   - sudo apt-get autoremove
   - sudo pip install --egg scons
 install:
-  - wget https://root.cern.ch/download/root_v6.10.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
+  - wget https://root.cern.ch/download/root_v6.10.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz -O /tmp/root.tar.gz
+  - pwd
   - tar -xzf /tmp/root.tar.gz
   - source ./root/bin/thisroot.sh
   - source ./setup.sh


### PR DESCRIPTION
Do travis build with Ubuntu 14.  Also now use ROOT 6 instead of ROOT 5.