### PR TITLE
THcScalerEvtHandler changes and podd update

### DIFF
--- a/src/THcScalerEvtHandler.cxx
+++ b/src/THcScalerEvtHandler.cxx
@@ -273,10 +273,6 @@ Int_t THcScalerEvtHandler::Analyze(THaEvData *evdata)
   return 1;
 }
 
-void THcScalerEvtHandler::AddEventType(Int_t evtype)
-{
-  eventtypes.push_back(evtype);
-}
 
 THaAnalysisObject::EStatus THcScalerEvtHandler::Init(const TDatime& date)
 {

--- a/src/THcScalerEvtHandler.cxx
+++ b/src/THcScalerEvtHandler.cxx
@@ -61,19 +61,16 @@ using namespace Decoder;
 static const UInt_t ICOUNT    = 1;
 static const UInt_t IRATE     = 2;
 static const UInt_t MAXCHAN   = 32;
-static const UInt_t MAXTEVT   = 5000;
 static const UInt_t defaultDT = 4;
 
 THcScalerEvtHandler::THcScalerEvtHandler(const char *name, const char* description)
   : THaEvtTypeHandler(name,description), evcount(0), ifound(0), fNormIdx(-1),
     dvars(0), dvarsFirst(0), fScalerTree(0), fUseFirstEvent(kFALSE)
 {
-  rdata = new UInt_t[MAXTEVT];
 }
 
 THcScalerEvtHandler::~THcScalerEvtHandler()
 {
-  delete [] rdata;
   if (fScalerTree) {
     delete fScalerTree;
   }
@@ -130,19 +127,11 @@ Int_t THcScalerEvtHandler::Analyze(THaEvData *evdata)
 
   // Parse the data, load local data arrays.
 
-  Int_t ndata = evdata->GetEvLength();
-  if (ndata >= static_cast<Int_t>(MAXTEVT)) {
-    cout << "THcScalerEvtHandler:: ERROR: Event length crazy "<<endl;
-    ndata = MAXTEVT-1;
-  }
+  UInt_t *rdata = (UInt_t*) evdata->GetRawDataBuffer();
 
   if (fDebugFile) *fDebugFile<<"\n\nTHcScalerEvtHandler :: Debugging event type "<<dec<<evdata->GetEvType()<<endl<<endl;
 
-  // local copy of data
-  // Why do we need a local copy of the data?
-  for (Int_t i=0; i<ndata; i++) rdata[i] = evdata->GetRawData(i);
-
-  UInt_t *p = rdata;
+  UInt_t *p = (UInt_t*) rdata;
 
   UInt_t *plast = p+*p;		// Index to last word in the bank
 

--- a/src/THcScalerEvtHandler.h
+++ b/src/THcScalerEvtHandler.h
@@ -47,7 +47,6 @@ private:
    std::vector<Decoder::GenScaler*> scalers;
    std::vector<HCScalerLoc*> scalerloc;
    Double_t evcount;
-   UInt_t *rdata;
    std::vector<Int_t> index;
    Int_t Nvars, ifound, fNormIdx, nscalers;
    Double_t *dvars;

--- a/src/THcScalerEvtHandler.h
+++ b/src/THcScalerEvtHandler.h
@@ -34,7 +34,6 @@ public:
    virtual ~THcScalerEvtHandler();
 
    Int_t Analyze(THaEvData *evdata);
-   virtual void AddEventType(Int_t evtype);
    virtual EStatus Init( const TDatime& run_time);
    virtual Int_t End( THaRunBase* r=0 );
    virtual void SetUseFirstEvent(Bool_t b = kFALSE) {fUseFirstEvent = b;}


### PR DESCRIPTION
Remove ThcScalerEvtHandler::AddEventType method as the base class already has AddEvtType (and SetEvtType) method that does the same thing.

Update podd to get the THaEvData::GetRawDataBuffer() method.

Use GetRawDataBuffer method in scaler event handler to avoid having to copy the whole event and remove the 5000 word event size limit.