### PR TITLE
Add method THcHallCSpectrometer::CalculateTargetQuantities

### DIFF
--- a/src/THcHallCSpectrometer.h
+++ b/src/THcHallCSpectrometer.h
@@ -41,6 +41,7 @@ public:
 
   virtual Int_t   ReadDatabase( const TDatime& date );
   virtual void    EnforcePruneLimits();
+  virtual void    CalculateTargetQuantities(THaTrack* track,Double_t gbeam_y,Double_t  xptar,Double_t ytar,Double_t yptar,Double_t delta);
   virtual Int_t   FindVertices( TClonesArray& tracks );
   virtual Int_t   TrackCalc();
   virtual Int_t   BestTrackSimple();


### PR DESCRIPTION
This method calculates the target quantities using the focal
plane quantities and the optics matrix. Previously
this was done in THcHallCSpectrometer::FindVertices.
Now in THcHallCSpectrometer::FindVertices there is
a call to CalculateTargetQuantities


This method will be called by THcExtTarCor
to do the xtar correction.