### PR TITLE
Cleanup some warnings, fix examples hodtest script

### DIFF
--- a/examples/MAPS/raster_jun04.map
+++ b/examples/MAPS/raster_jun04.map
@@ -42,7 +42,7 @@
 ! SAER_ID= 16             ADC
 ! SLUC_ID=17		 ADC
 !BEAM:
-! RASTER_ID= 18          ADC
+! BRASTER_ID= 18          ADC
 ! BPM_ID= 19             ADC
 !
 !   consider subadd equiv. to channel

--- a/examples/PARAM/hcana.param
+++ b/examples/PARAM/hcana.param
@@ -167,3 +167,14 @@ hcer_region =    30,  -30,   0,
                  30,   30,  30,
                  .1,   .1,  .1,
                  .1,   .1,  .1
+;
+; New raster code assumes two rasters
+;
+gfrxa_adcpercm = gfrx_adcpercm
+gfrxb_adcpercm = gfrx_adcpercm
+gfrya_adcpercm = gfry_adcpercm
+gfryb_adcpercm = gfry_adcpercm
+gfrxa_adc_zero_offset = 0.0
+gfrxb_adc_zero_offset = 0.0
+gfrya_adc_zero_offset = 0.0
+gfryb_adc_zero_offset = 0.0

--- a/examples/hodtest.C
+++ b/examples/hodtest.C
@@ -58,7 +58,7 @@
   SOS->AddDetector( new THcShower("cal", "Shower" ));
   SOS->AddDetector( new THcDC("dc", "Drift Chambers" ));
 
-  THaApparatus* BEAM = new THcRasteredBeam("RB","Rastered Beamline");
+  THaApparatus* BEAM = new THcRasteredBeam("B","Rastered Beamline");
   gHaApps->Add( BEAM );
 
   // setup physics

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -144,6 +144,8 @@ void THcDC::Setup(const char* name, const char* description)
     if( !newplane or newplane->IsZombie() ) {
       Error( Here(here), "Error creating Drift Chamber plane %s. Call expert.", name);
       MakeZombie();
+      delete [] desc;
+      delete [] desc1;
       return;
     }
     fPlanes.push_back(newplane);

--- a/src/THcHallCSpectrometer.cxx
+++ b/src/THcHallCSpectrometer.cxx
@@ -503,7 +503,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingScin()
       Double_t chi2PerDeg;
 
       THaTrack* aTrack = static_cast<THaTrack*>( fTracks->At(itrack) );
-      if (!aTrack) return -1;
+      if (!aTrack) {delete[] x2Hits; delete[] y2Hits; return -1;}
 
       if ( aTrack->GetNDoF() > fSelNDegreesMin ){
 	chi2PerDeg =  aTrack->GetChi2() / aTrack->GetNDoF();
@@ -640,7 +640,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
       keep[ptrack] = kTRUE;
       reject[ptrack] = 0;
       testTracks[ptrack] = static_cast<THaTrack*>( fTracks->At(ptrack) );
-      if (!testTracks[ptrack]) return -1;
+      if (!testTracks[ptrack]) {delete[] keep; delete[] reject; return -1;}
     }
 
     // ! Prune on xptar

--- a/src/THcPrimaryKine.cxx
+++ b/src/THcPrimaryKine.cxx
@@ -185,8 +185,6 @@ Int_t THcPrimaryKine::Process( const THaEvData& )
 Int_t THcPrimaryKine::ReadDatabase( const TDatime& date )
 {
 
-  static const char* const here = "THcPrimaryKine::ReadDatabase";
-
 #ifdef WITH_DEBUG
   cout << "In THcPrimaryKine::ReadDatabase()" << endl;
 #endif

--- a/src/THcRunParameters.h
+++ b/src/THcRunParameters.h
@@ -11,6 +11,7 @@
 
 class THcRunParameters : public THaRunParameters {
 public:
+  using THaRunParameters::operator=;
   THcRunParameters();
   virtual ~THcRunParameters();
 

--- a/src/THcSecondaryKine.cxx
+++ b/src/THcSecondaryKine.cxx
@@ -300,6 +300,7 @@ Int_t THcSecondaryKine::ReadDatabase( const TDatime& date )
   return 0;
   */
   //fMX = 0.938;
+  return kOK;
 }
   
 //_____________________________________________________________________________

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -748,7 +748,7 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
 
     UInt_t i = 0;
     for (THcShowerClusterListIt ppcl = (*fClusterList).begin();
-	 ppcl != (*fClusterList).end(); ppcl++) {
+	 ppcl != (*fClusterList).end(); ++ppcl) {
 
       cout << "  Cluster #" << i++
 	   <<":  E=" << clE(*ppcl)
@@ -760,7 +760,7 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
 
       Int_t j=0;
       for (THcShowerClusterIt pph=(**ppcl).begin(); pph!=(**ppcl).end();
-	   pph++) {
+	   ++pph) {
 	cout << "  hit " << j++ << ": ";
 	(**pph).show();
       }
@@ -815,7 +815,7 @@ void THcShower::ClusterHits(THcShowerHitSet& HitSet,
       for (THcShowerHitIt i=HitSet.begin(); i!=HitSet.end(); ++i) {
 
 	for (THcShowerClusterIt k=(*cluster).begin(); k!=(*cluster).end();
-	     k++) {
+	     ++k) {
 
 	  if ((**i).isNeighbour(*k)) {
 	    (*cluster).insert(*i);      //If the hit #i is neighbouring a hit

--- a/src/THcShowerArray.cxx
+++ b/src/THcShowerArray.cxx
@@ -531,9 +531,9 @@ Int_t THcShowerArray::CoarseProcess( TClonesArray& tracks )
   Int_t ncl=0;
   Int_t block;
     for (THcShowerClusterListIt ppcl = (*fClusterList).begin();
-	 ppcl != (*fClusterList).end(); ppcl++) {
+	 ppcl != (*fClusterList).end(); ++ppcl) {
       for (THcShowerClusterIt pph=(**ppcl).begin(); pph!=(**ppcl).end();
-	   pph++) {
+	   ++pph) {
        block = ((**pph).hitColumn())*fNRows + (**pph).hitRow()+1;
        fBlock_ClusterID[block-1] = ncl;
       }
@@ -548,7 +548,7 @@ Int_t THcShowerArray::CoarseProcess( TClonesArray& tracks )
 
     UInt_t i = 0;
     for (THcShowerClusterListIt ppcl = (*fClusterList).begin();
-	 ppcl != (*fClusterList).end(); ppcl++) {
+	 ppcl != (*fClusterList).end(); ++ppcl) {
 
       cout << "  Cluster #" << i++
 	   <<":  E=" << clE(*ppcl)
@@ -561,7 +561,7 @@ Int_t THcShowerArray::CoarseProcess( TClonesArray& tracks )
 
       Int_t j=0;
       for (THcShowerClusterIt pph=(**ppcl).begin(); pph!=(**ppcl).end();
-	   pph++) {
+	   ++pph) {
 	cout << "  hit " << j++ << ": ";
 	(**pph).show();
       }
@@ -969,7 +969,7 @@ Int_t THcShowerArray::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
 	  cout << "-";
 	}
 	cout << "+";
-0      }
+      }
       cout << endl;
       for(Int_t row=0;row<fNRows;row++) {
 	hitpic[row][(piccolumn+1)*(fNColumns+1)+1] = '\0';


### PR DESCRIPTION
Address compiler warnings in issue #245 and also a few warnings from cppcheck.  (Many cppcheck warnings remain.)

Restore hodtest.C functionality after the changes to the raster code.