### PR TITLE
Fix/clarify setup.csh behavior when called from script

### DIFF
--- a/setup.csh
+++ b/setup.csh
@@ -1,14 +1,21 @@
-#!/bin/csh
+#!/bin/tcsh
 
-set called=($_)
-if ("$called" != "") then
-  set scriptdir=$called[2]
-  set MYDIR=`dirname $scriptdir`
-  set MYDIR=`c\d $MYDIR && pwd`    # ensure absolute path
+if ( $?loginsh ) then
+  set MYDIR=`pwd`
+  echo "--> Setting HCANALYZER to $MYDIR"
 else
-  set scriptdir=$1
-  set MYDIR=$scriptdir
+  if ( "$1" == "" ) then
+    echo "ERROR:  'setup.csh' must have a path to the hcana location as its argument"
+    echo "   Often this is also the location of the setup.csh script itself:"
+    echo "     source /my/path/to/setup.csh /my/path/to/setup.csh"
+    echo "   Or, if you have already cd'd into the hcana directory, then you can call:"
+    echo '     source setup.csh `pwd`'
+    exit 1
+  else
+    set MYDIR=$1
+  endif
 endif
+
 setenv ANALYZER $MYDIR/podd
 setenv HCANALYZER $MYDIR
 # Check if LD_LIBRARY_PATH is defined

--- a/setup.csh
+++ b/setup.csh
@@ -1,11 +1,13 @@
-#!/bin/tcsh
+#!/bin/csh
 
-if ( $?loginsh ) then
+if ( -r "./setup.csh" ) then
   set MYDIR=`pwd`
-  echo "--> Setting HCANALYZER to $MYDIR"
+  if ($?prompt) then
+    echo "--> Setting HCANALYZER to '$MYDIR'"
+  endif
 else
   if ( "$1" == "" ) then
-    echo "ERROR:  'setup.csh' must have a path to the hcana location as its argument"
+    echo "ERROR:  'setup.csh' should have a path to the hcana location as its argument."
     echo "   Often this is also the location of the setup.csh script itself:"
     echo "     source /my/path/to/setup.csh /my/path/to/setup.csh"
     echo "   Or, if you have already cd'd into the hcana directory, then you can call:"


### PR DESCRIPTION
See also discussion #248 "MYDIR remains undefined if called from a shell script"

- The underlying problem here is that $_ is assumed to contain the path
  to the sourced file, but that isn't true for any version of tcsh I've
  tried... (I guess it must have worked for some version of tcsh?)
  Anyway, that fails and $1 is also empty in the else clause so the
  script fails.

- Reliably finding the path to a sourced file is next to impossible in
  tcsh, so just encourage/force people to pass a path to the script
  directory as an argument.

-- Brad