### PR TITLE
Scaler analysis features and improvements

### DIFF
--- a/SConscript.py
+++ b/SConscript.py
@@ -20,7 +20,11 @@ for hcheaderfile in hcheadersbase:
     filename = '%s' % hcheaderfile
     basefilename = filename.rsplit('.',1)
     newbasefilename = basefilename[0].rsplit('/',1)
-    cmd1 = "echo '#pragma link C++ class %s+;' >> src/HallC_LinkDef.h" % newbasefilename[1]
+    # Assume filenames beginning with Scaler are decoder classes
+    if newbasefilename[1][:6] == 'Scaler':
+        cmd1 = "echo '#pragma link C++ class Decoder::%s+;' >> src/HallC_LinkDef.h" % newbasefilename[1]
+    else:
+        cmd1 = "echo '#pragma link C++ class %s+;' >> src/HallC_LinkDef.h" % newbasefilename[1]
     os.system(cmd1)
 
 cmd = "cat src/HallC_LinkDef.h_postamble >> src/HallC_LinkDef.h"

--- a/src/Scaler9001.cxx
+++ b/src/Scaler9001.cxx
@@ -1,0 +1,32 @@
+////////////////////////////////////////////////////////////////////
+//
+//   TI scalers
+//     Identified by a 9001 bank
+//
+/////////////////////////////////////////////////////////////////////
+
+#include "Scaler9001.h"
+
+using namespace std;
+
+namespace Decoder {
+
+Module::TypeIter_t Scaler9001::fgThisType =
+  DoRegister( ModuleType( "Decoder::Scaler9001" , 9001 ));
+
+Scaler9001::Scaler9001(Int_t crate, Int_t slot) : GenScaler(crate, slot) {
+  Init();
+}
+
+Scaler9001::~Scaler9001() {
+}
+
+void Scaler9001::Init() {
+  fNumChan = 12;
+  fWordsExpect = 12;
+  GenScaler::GenInit();
+}
+
+}
+
+ClassImp(Decoder::Scaler9001)

--- a/src/Scaler9001.h
+++ b/src/Scaler9001.h
@@ -1,0 +1,35 @@
+#ifndef Scaler9001_
+#define Scaler9001_
+
+/////////////////////////////////////////////////////////////////////
+//
+//   Scaler9001
+//   TI scalers
+//
+/////////////////////////////////////////////////////////////////////
+
+#include "GenScaler.h"
+
+namespace Decoder {
+
+class Scaler9001 : public GenScaler {
+
+public:
+
+   Scaler9001() {};
+   Scaler9001(Int_t crate, Int_t slot);
+   virtual ~Scaler9001();
+
+   virtual void Init();
+
+private:
+
+   static TypeIter_t fgThisType;
+
+   ClassDef(Scaler9001,0)  // TI scalers
+
+};
+
+}
+
+#endif

--- a/src/Scaler9250.cxx
+++ b/src/Scaler9250.cxx
@@ -1,0 +1,31 @@
+////////////////////////////////////////////////////////////////////
+//
+//   FADC250 scalers
+//
+/////////////////////////////////////////////////////////////////////
+
+#include "Scaler9250.h"
+
+using namespace std;
+
+namespace Decoder {
+
+Module::TypeIter_t Scaler9250::fgThisType =
+  DoRegister( ModuleType( "Decoder::Scaler9250" , 9250 ));
+
+Scaler9250::Scaler9250(Int_t crate, Int_t slot) : GenScaler(crate, slot) {
+  Init();
+}
+
+Scaler9250::~Scaler9250() {
+}
+
+void Scaler9250::Init() {
+  fNumChan = 16;
+  fWordsExpect = 16;
+  GenScaler::GenInit();
+}
+
+}
+
+ClassImp(Decoder::Scaler9250)

--- a/src/Scaler9250.h
+++ b/src/Scaler9250.h
@@ -1,0 +1,35 @@
+#ifndef Scaler9250_
+#define Scaler9250_
+
+/////////////////////////////////////////////////////////////////////
+//
+//   Scaler9250
+//   FADC250 scalers
+//
+/////////////////////////////////////////////////////////////////////
+
+#include "GenScaler.h"
+
+namespace Decoder {
+
+class Scaler9250 : public GenScaler {
+
+public:
+
+   Scaler9250() {};
+   Scaler9250(Int_t crate, Int_t slot);
+   virtual ~Scaler9250();
+
+   virtual void Init();
+
+private:
+
+   static TypeIter_t fgThisType;
+
+   ClassDef(Scaler9250,0)  // FADC250 scalers
+
+};
+
+}
+
+#endif

--- a/src/THcScalerEvtHandler.cxx
+++ b/src/THcScalerEvtHandler.cxx
@@ -353,7 +353,8 @@ THaAnalysisObject::EStatus THcScalerEvtHandler::Init(const TDatime& date)
   vector<string> dbline;
 
   while( fgets(cbuf, LEN, fi) != NULL) {
-    std::string sinput(cbuf);
+    std::string sin(cbuf);
+    std::string sinput(sin.substr(0,sin.find_first_of("#")));
     if (fDebugFile) *fDebugFile << "string input "<<sinput<<endl;
     dbline = vsplit(sinput);
     if (dbline.size() > 0) {

--- a/src/THcScalerEvtHandler.cxx
+++ b/src/THcScalerEvtHandler.cxx
@@ -40,6 +40,8 @@ To enable debugging you may try this in the setup script
 #include "Scaler3801.h"
 #include "Scaler1151.h"
 #include "Scaler560.h"
+#include "Scaler9001.h"
+#include "Scaler9250.h"
 #include "THaCodaData.h"
 #include "THaEvData.h"
 #include "TNamed.h"
@@ -386,6 +388,12 @@ THaAnalysisObject::EStatus THcScalerEvtHandler::Init(const TDatime& date)
 	  break;
 	case 3801:
 	  scalers.push_back(new Scaler3801(icrate, islot));
+	  break;
+	case 9001:		// TI Scalers
+	  scalers.push_back(new Scaler9001(icrate, islot));
+	  break;
+	case 9250:		// FADC250 Scalers
+	  scalers.push_back(new Scaler9250(icrate, islot));
 	  break;
 	}
 	if (scalers.size() > 0) {

--- a/src/THcScalerEvtHandler.h
+++ b/src/THcScalerEvtHandler.h
@@ -34,9 +34,11 @@ public:
    virtual ~THcScalerEvtHandler();
 
    Int_t Analyze(THaEvData *evdata);
+   Int_t AnalyzeBuffer(UInt_t *rdata);
    virtual EStatus Init( const TDatime& run_time);
    virtual Int_t End( THaRunBase* r=0 );
    virtual void SetUseFirstEvent(Bool_t b = kFALSE) {fUseFirstEvent = b;}
+   virtual void SetDelayedType(int evtype);
 
 private:
 
@@ -47,12 +49,13 @@ private:
    std::vector<Decoder::GenScaler*> scalers;
    std::vector<HCScalerLoc*> scalerloc;
    Double_t evcount;
-   std::vector<Int_t> index;
    Int_t Nvars, ifound, fNormIdx, nscalers;
    Double_t *dvars;
    Double_t *dvarsFirst;
    TTree *fScalerTree;
    Bool_t fUseFirstEvent;
+   Int_t fDelayedType;
+   std::vector<UInt_t*> fDelayedEvents;
 
    THcScalerEvtHandler(const THcScalerEvtHandler& fh);
    THcScalerEvtHandler& operator=(const THcScalerEvtHandler& fh);

--- a/src/THcScalerEvtHandler.h
+++ b/src/THcScalerEvtHandler.h
@@ -39,6 +39,7 @@ public:
    virtual Int_t End( THaRunBase* r=0 );
    virtual void SetUseFirstEvent(Bool_t b = kFALSE) {fUseFirstEvent = b;}
    virtual void SetDelayedType(int evtype);
+   virtual void SetOnlyBanks(Bool_t b = kFALSE) {fOnlyBanks = b;fRocSet.clear();}
 
 private:
 
@@ -55,7 +56,10 @@ private:
    TTree *fScalerTree;
    Bool_t fUseFirstEvent;
    Int_t fDelayedType;
+   Bool_t fOnlyBanks;
    std::vector<UInt_t*> fDelayedEvents;
+   std::set<UInt_t> fRocSet;
+   std::set<UInt_t> fModuleSet;
 
    THcScalerEvtHandler(const THcScalerEvtHandler& fh);
    THcScalerEvtHandler& operator=(const THcScalerEvtHandler& fh);


### PR DESCRIPTION
Decoder classes for FADC250 and TI scalers are added and can be used in THcScalerEvtHandler

Set an event type with THcScalerEvtHandler::SetDelayedType(evtype) to delay analysis of events with that type until the end of the run.  (For end of run user events that may get misplaced by the event builder in the coda file.)

Allow comments (with #) on lines in the scaler config DB file.

Only try to analyze banks that might contain scalers.