### PR TITLE
Remove explicit setting of "c++-11" compiler flag in SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -224,12 +224,6 @@ if pbaseenv['CXX'] == 'g++':
 	if (gxxVersion[0] < 4) or (gxxVersion[0] == 4 and gxxVersion[1] < 4):
 		print('Error: g++ version too old! Need at least g++ 4.4!')
 		Exit(1)
-	elif gxxVersion[0] == 4 and 4 <= gxxVersion[1] < 7:
-		if '-std=c++0x' not in pbaseenv['CXXFLAGS']:
-			pbaseenv.Append(CXXFLAGS='-std=c++0x')
-	else:
-		if '-std=c++11' not in pbaseenv['CXXFLAGS']:
-			pbaseenv.Append(CXXFLAGS='-std=c++11')
 
 ##directorylist = ['./','src','podd','podd/src','podd/hana_decode']
 ##SConscript('podd/SConstruct')


### PR DESCRIPTION
this is handled already (and properly) using $ROOTCONFIG --cflags ... this way of doing things make sure that the g++ compiler flags better match the version of ROOT being compiled against.