### PR TITLE
Rewrite the local evio library download handling for scons

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -79,33 +79,40 @@ if evio_libdir is None or evio_incdir is None:
 	evio_local_inc = "%s/evio-%s/%s/include" % (evio_local,evio_version,evio_name)
 	evio_tarfile = "%s/evio-%s.tgz" % (evio_local,evio_version)
 
-	####### Check to see if scons -c has been called #########
-
 	if baseenv.GetOption('clean'):
-    		subprocess.call(['echo', '!!!!!!!!!!!!!! EVIO Cleaning Process !!!!!!!!!!!! '])
-		if not os.path.isdir(evio_local_lib):
-			if not os.path.exists(evio_tarfile):
-				evio_command_scons = "rm libevio*.*; cd %s; wget --no-check-certificate https://coda.jlab.org/drupal/system/files/evio-%s.tgz; tar xvfz evio-%s.tgz; cd evio-%s/ ; scons install -c --prefix=." % (evio_local,evio_version,evio_version,evio_version)
-			else:
-				evio_command_scons = "rm libevio*.*; cd %s; tar xvfz evio-%s.tgz; cd evio-%s/ ; scons install -c --prefix=." % (evio_local,evio_version,evio_version)
+		print "!!!!!!!!!!!!!! EVIO Cleaning Process !!!!!!!!!!!! "
+		evio_files = Glob("libevio*.*")
+		for f in evio_files:
+			os.unlink( f )
+
+	if not os.path.isdir(evio_local_lib):
+		if not os.path.exists(evio_tarfile):
+			evio_command_scons = "\
+			mkdir %s;\
+			cd %s;\
+			wget --no-check-certificate https://coda.jlab.org/drupal/system/files/evio-%s.tgz;\
+			" % (evio_local, evio_local, evio_version)
+			print "evio_command_scons = %s" % evio_command_scons
+			os.system(evio_command_scons)
+
+		if os.path.exists(evio_tarfile):
+			evio_command_scons = "\
+			cd %s;\
+			tar xvfz %s;\
+			cd evio-%s/ ;\
+			scons install --prefix=.\
+			" % (evio_local, evio_tarfile, evio_version)
+			print "evio_command_scons = %s" % evio_command_scons
+			os.system(evio_command_scons)
 		else:
-			evio_command_scons = "rm libevio*.*; cd %s; cd evio-%s/ ; scons install -c --prefix=." % (evio_local,evio_version)
-		print "evio_command_scons = %s" % evio_command_scons
-		os.system(evio_command_scons)
-	else:
-		if not os.path.isdir(evio_local_lib):
-			if not os.path.exists(evio_tarfile):
-				evio_command_scons = "cd %s; wget --no-check-certificate https://coda.jlab.org/drupal/system/files/evio-%s.tgz; tar xvfz evio-%s.tgz; cd evio-%s/ ; scons install --prefix=." % (evio_local,evio_version,evio_version,evio_version)
-			else:
-				evio_command_scons = "cd %s; tar xvfz evio-%s.tgz; cd evio-%s/ ; scons install --prefix=." % (evio_local,evio_version,evio_version)
-		else:
-			evio_command_scons = "cd %s; cd evio-%s/ ; scons install --prefix=." % (evio_local,evio_version)
-		print "evio_command_scons = %s" % evio_command_scons
-		os.system(evio_command_scons)
-		evio_local_lib_files = "%s/*.*" % (evio_local_lib)
-		evio_command_libcopy = "cp %s %s" % (evio_local_lib_files,baseenv.subst('$HA_DIR'))
-		print "evio_command_libcopy = %s" % evio_command_libcopy
-		os.system(evio_command_libcopy)
+			print "Can't find the coda tarball: %s" % evio_tarfile
+			Exit(1)
+
+
+	evio_local_lib_files = "%s/*.*" % (evio_local_lib)
+	evio_command_libcopy = "cp %s %s" % (evio_local_lib_files, baseenv.subst('$HA_DIR'))
+	print "evio_command_libcopy = %s" % evio_command_libcopy
+	os.system(evio_command_libcopy)
 
 	baseenv.Append(EVIO_LIB = evio_local_lib)
 	baseenv.Append(EVIO_INC = evio_local_inc)
@@ -114,8 +121,10 @@ else:
 	# os.system(evio_command_scons)
 	baseenv.Append(EVIO_LIB = os.getenv('EVIO_LIBDIR'))
 	baseenv.Append(EVIO_INC = os.getenv('EVIO_INCDIR'))
+
 print "EVIO lib Directory = %s" % baseenv.subst('$EVIO_LIB')
 print "EVIO include Directory = %s" % baseenv.subst('$EVIO_INC')
+
 baseenv.Append(CPPPATH = ['$EVIO_INC'])
 #
 # end evio environment


### PR DESCRIPTION
- Attempted to remove some copy-paste duplication and simplify the
  code logic.

- Still a little uncomfortable about how this works, and I will admit
  some of the old code's function escaped me... hopefully I didn't break
  anything.
  - Fixme: 'scons -c' should probably delete the local evio stuff + tarball,
    not leave a copy in place...
    - Keeping the old behavior for now though.
  - Not sure why we 'rm libevio*.*' in the top level build dir.  I don't
    think those files would ever be there...  Perhaps copy-paste
    artifact copied from podd's SConstruct?
    - Keeping the old behavior for now.
  - The 'wget --no-check-certificate' is unfortunate.  (JLab should fix
    their bloody certs!  Argh.)
  - Future TODO: Pulling evio as a tarball is kind of weak sauce.
    Perhaps this is in a git repo somewhere and can be added as a
    submodule in podd?

-- Brad