### PR TITLE
wire velocity corrections and plane shifts

### DIFF
--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -293,6 +293,8 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
     {"aero_beta_max",         &fBetaMax,          kDouble},
     {"aero_enorm_min",        &fENormMin,         kDouble},
     {"aero_enorm_max",        &fENormMax,         kDouble},
+    {"aero_dp_min",           &fDpMin,            kDouble},
+    {"aero_dp_max",           &fDpMax,            kDouble},
     {"aero_diff_box_zpos",    &fDiffBoxZPos,      kDouble},
     {"aero_npe_thresh",       &fNpeThresh,        kDouble},
     {"aero_adcTimeWindowMin", &fAdcTimeWindowMin, kDouble},
@@ -799,6 +801,7 @@ Int_t THcAerogel::FineProcess( TClonesArray& tracks )
     Double_t trackEnergy  = track->GetEnergy();
     Double_t trackMom     = track->GetP();
     Double_t trackENorm   = trackEnergy/trackMom;
+    Double_t trackDp      = track->GetDp();
     Double_t trackXfp     = track->GetX();
     Double_t trackYfp     = track->GetY();
     Double_t trackTheta   = track->GetTheta();
@@ -807,8 +810,9 @@ Int_t THcAerogel::FineProcess( TClonesArray& tracks )
     Bool_t trackRedChi2Cut = trackRedChi2 > fRedChi2Min && trackRedChi2 < fRedChi2Max;
     Bool_t trackBetaCut    = trackBeta    > fBetaMin    && trackBeta    < fBetaMax;
     Bool_t trackENormCut   = trackENorm   > fENormMin   && trackENorm   < fENormMax;
+    Bool_t trackDpCut      = trackDp      > fDpMin      && trackDp      < fDpMax;
 
-    if (trackRedChi2Cut && trackBetaCut && trackENormCut) {
+    if (trackRedChi2Cut && trackBetaCut && trackENormCut && trackDpCut) {
 
       // Project the track to the Aerogel diffuser box plane
       Double_t xAtAero = trackXfp + trackTheta * fDiffBoxZPos;

--- a/src/THcAerogel.h
+++ b/src/THcAerogel.h
@@ -54,6 +54,8 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   Double_t  fBetaMax;
   Double_t  fENormMin;
   Double_t  fENormMax;
+  Double_t  fDpMin;
+  Double_t  fDpMax;
   Double_t  fDiffBoxZPos;
   Double_t  fNpeThresh;
   Double_t  fAdcTimeWindowMin;

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -317,6 +317,7 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
     {"debugtrackprint", &fdebugtrackprint , kInt},
     {0}
   };
+
   gHcParms->LoadParmValues((DBRequest*)&list,fPrefix);
   if(fNTracksMaxFP <= 0) fNTracksMaxFP = 10;
   // if(fNTracksMaxFP > HNRACKS_MAX) fNTracksMaxFP = NHTRACKS_MAX;

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -59,6 +59,8 @@ THcDC::THcDC(
   fNChamber = NULL;
   fWireOrder = NULL;
   fDriftTimeSign = NULL;
+  fReadoutTB = NULL;
+  fReadoutLR = NULL;
 
   fXPos = NULL;
   fYPos = NULL;
@@ -106,7 +108,7 @@ void THcDC::Setup(const char* name, const char* description)
   } else {
     fHMSStyleChambers = 0;
   }
-
+  cout<<"HMS Style??\t"<<fHMSStyleChambers<<endl;
   string planenamelist;
   DBRequest list[]={
     {"dc_num_planes",&fNPlanes, kInt},
@@ -260,6 +262,8 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
   delete [] fNChamber;  fNChamber = new Int_t [fNPlanes]; // Which chamber is this plane
   delete [] fWireOrder;  fWireOrder = new Int_t [fNPlanes]; // Wire readout order
   delete [] fDriftTimeSign;  fDriftTimeSign = new Int_t [fNPlanes];
+  delete [] fReadoutLR;  fReadoutLR = new Int_t [fNPlanes];
+  delete [] fReadoutTB;  fReadoutTB = new Int_t [fNPlanes];
 
   delete [] fXPos;  fXPos = new Double_t [fNPlanes];
   delete [] fYPos;  fYPos = new Double_t [fNPlanes];
@@ -271,6 +275,10 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
   delete [] fCentralWire;  fCentralWire = new Double_t [fNPlanes];
   delete [] fPlaneTimeZero;  fPlaneTimeZero = new Double_t [fNPlanes];
   delete [] fSigma;  fSigma = new Double_t [fNPlanes];
+
+  Bool_t optional = true;
+  fReadoutLR = new Int_t[fNPlanes];
+  fReadoutTB = new Int_t[fNPlanes];
 
   DBRequest list[]={
     {"dc_tdc_time_per_channel",&fNSperChan, kDouble},
@@ -290,6 +298,8 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
     {"dc_chamber_planes", fNChamber, kInt, (UInt_t)fNPlanes},
     {"dc_wire_counting", fWireOrder, kInt, (UInt_t)fNPlanes},
     {"dc_drifttime_sign", fDriftTimeSign, kInt, (UInt_t)fNPlanes},
+    {"dc_readoutLR", fReadoutLR, kInt, (UInt_t)fNPlanes, optional},
+    {"dc_readoutTB", fReadoutTB, kInt, (UInt_t)fNPlanes, optional},
 
     {"dc_xpos", fXPos, kDouble, (UInt_t)fNPlanes},
     {"dc_ypos", fYPos, kDouble, (UInt_t)fNPlanes},
@@ -405,6 +415,8 @@ void THcDC::DeleteArrays()
   delete [] fNChamber;   fNChamber = NULL;
   delete [] fWireOrder;   fWireOrder = NULL;
   delete [] fDriftTimeSign;   fDriftTimeSign = NULL;
+  delete [] fReadoutLR;   fReadoutLR = NULL;
+  delete [] fReadoutTB;   fReadoutTB = NULL;
 
   delete [] fXPos;   fXPos = NULL;
   delete [] fYPos;   fYPos = NULL;
@@ -862,7 +874,6 @@ void THcDC::TrackFit()
   // }
 
   Double_t dummychi2 = 1.0E4;
-
   for(UInt_t itrack=0;itrack<fNDCTracks;itrack++) {
     //    Double_t chi2 = dummychi2;
     //    Int_t htrack_fit_num = itrack;
@@ -874,20 +885,21 @@ void THcDC::TrackFit()
       THcDCHit* hit=theDCTrack->GetHit(ihit);
       planes[ihit]=hit->GetPlaneNum()-1;
       if(fFixLR) {
-	if(fFixPropagationCorrection) {
-	  coords[ihit] = hit->GetPos()
-	    + theDCTrack->GetHitLR(ihit)*theDCTrack->GetHitDist(ihit);
-	} else {
-	  coords[ihit] = hit->GetPos()
-	    + theDCTrack->GetHitLR(ihit)*hit->GetDist();
-	}
+    	  if(fFixPropagationCorrection) {
+    		  coords[ihit] = hit->GetPos()
+	    		+ theDCTrack->GetHitLR(ihit)*theDCTrack->GetHitDist(ihit);
+    	  } else {
+    		  coords[ihit] = hit->GetPos()
+	    		+ theDCTrack->GetHitLR(ihit)*hit->GetDist();
+    	  }
+
       } else {
-	if(fFixPropagationCorrection) {
-	  coords[ihit] = hit->GetPos()
-	    + hit->GetLR()*theDCTrack->GetHitDist(ihit);
-	} else {
-	  coords[ihit] = hit->GetCoord();
-	}
+    	  if(fFixPropagationCorrection) {
+    		  coords[ihit] = hit->GetPos()
+	    		+ hit->GetLR()*theDCTrack->GetHitDist(ihit);
+    	  } else {
+    		  coords[ihit] = hit->GetCoord();
+    	  }
       }
     }
 
@@ -897,26 +909,26 @@ void THcDC::TrackFit()
       TVectorD TT(NUM_FPRAY);
       TMatrixD AA(NUM_FPRAY,NUM_FPRAY);
       for(Int_t irayp=0;irayp<NUM_FPRAY;irayp++) {
-	TT[irayp] = 0.0;
-	for(Int_t ihit=0;ihit < theDCTrack->GetNHits();ihit++) {
-	  TT[irayp] += (coords[ihit]*
-			fPlaneCoeffs[planes[ihit]][raycoeffmap[irayp]])
-	    /pow(fSigma[planes[ihit]],2);
-	}
+    	  TT[irayp] = 0.0;
+    	  for(Int_t ihit=0;ihit < theDCTrack->GetNHits();ihit++) {
+    		  TT[irayp] += (coords[ihit]*
+    				  fPlaneCoeffs[planes[ihit]][raycoeffmap[irayp]])
+					  /pow(fSigma[planes[ihit]],2);
+    	  }
       }
       for(Int_t irayp=0;irayp<NUM_FPRAY;irayp++) {
-	for(Int_t jrayp=0;jrayp<NUM_FPRAY;jrayp++) {
-	  AA[irayp][jrayp] = 0.0;
-	  if(jrayp<irayp) { // Symmetric
-	    AA[irayp][jrayp] = AA[jrayp][irayp];
-	  } else {
-	    for(Int_t ihit=0;ihit < theDCTrack->GetNHits();ihit++) {
-	      AA[irayp][jrayp] += fPlaneCoeffs[planes[ihit]][raycoeffmap[irayp]]*
-		fPlaneCoeffs[planes[ihit]][raycoeffmap[jrayp]]/
-		pow(fSigma[planes[ihit]],2);
-	    }
-	  }
-	}
+    	  for(Int_t jrayp=0;jrayp<NUM_FPRAY;jrayp++) {
+    		  AA[irayp][jrayp] = 0.0;
+    		  if(jrayp<irayp) { // Symmetric
+    			  AA[irayp][jrayp] = AA[jrayp][irayp];
+    		  } else {
+    			  for(Int_t ihit=0;ihit < theDCTrack->GetNHits();ihit++) {
+    				  AA[irayp][jrayp] += fPlaneCoeffs[planes[ihit]][raycoeffmap[irayp]]*
+    						  fPlaneCoeffs[planes[ihit]][raycoeffmap[jrayp]]/
+							  pow(fSigma[planes[ihit]],2);
+    			  }
+    		  }
+    	  }
       }
 
       // Solve 4x4 equations
@@ -933,25 +945,24 @@ void THcDC::TrackFit()
 
       // Make sure fCoords, fResiduals, and fDoubleResiduals are clear
       for(Int_t iplane=0;iplane < fNPlanes; iplane++) {
-	Double_t coord=0.0;
-	for(Int_t ir=0;ir<NUM_FPRAY;ir++) {
-	  coord += fPlaneCoeffs[iplane][raycoeffmap[ir]]*dray[ir];
-	  // cout << "ir = " << ir << ", dray[ir] = " << dray[ir] << endl;
-	}
-	theDCTrack->SetCoord(iplane,coord);
+    	  Double_t coord=0.0;
+    	  for(Int_t ir=0;ir<NUM_FPRAY;ir++) {
+    		  coord += fPlaneCoeffs[iplane][raycoeffmap[ir]]*dray[ir];
+    		  // cout << "ir = " << ir << ", dray[ir] = " << dray[ir] << endl;
+    	  }
+    	  theDCTrack->SetCoord(iplane,coord);
       }
       // Compute Chi2 and residuals
       chi2 = 0.0;
       for(Int_t ihit=0;ihit < theDCTrack->GetNHits();ihit++) {
-	Double_t residual = coords[ihit] - theDCTrack->GetCoord(planes[ihit]);
-	// cout << "ihit = " << ihit << ", planes[ihit] = " << planes[ihit]
-	//      << ", coords[ihit] = " << coords[ihit]
-	//      << ", theDCTrack->GetCoord(planes[ihit]) = "
-	//      << theDCTrack->GetCoord(planes[ihit]) << endl;
-	theDCTrack->SetResidual(planes[ihit], residual);
-	// cout << "Getting residual = " << theDCTrack->GetResidual(planes[ihit]) << endl;
-	chi2 += pow(residual/fSigma[planes[ihit]],2);
+    	  Double_t residual = coords[ihit] - theDCTrack->GetCoord(planes[ihit]);
+    	  theDCTrack->SetResidual(planes[ihit], residual);
+
+  //  	  double track_coord = theDCTrack->GetCoord(planes[ihit]);
+//cout<<planes[ihit]<<"\t"<<track_coord<<"\t"<<coords[ihit]<<"\t"<<residual<<endl;
+    	  chi2 += pow(residual/fSigma[planes[ihit]],2);
       }
+
       theDCTrack->SetVector(dray[0], dray[1], 0.0, dray[2], dray[3]);
     }
     theDCTrack->SetChisq(chi2);

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -108,7 +108,7 @@ void THcDC::Setup(const char* name, const char* description)
   } else {
     fHMSStyleChambers = 0;
   }
-  cout<<"HMS Style??\t"<<fHMSStyleChambers<<endl;
+  //cout<<"HMS Style??\t"<<fHMSStyleChambers<<endl;
   string planenamelist;
   DBRequest list[]={
     {"dc_num_planes",&fNPlanes, kInt},
@@ -301,8 +301,6 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
     {"dc_readoutLR", fReadoutLR, kInt, (UInt_t)fNPlanes, optional},
     {"dc_readoutTB", fReadoutTB, kInt, (UInt_t)fNPlanes, optional},
 
-    {"dc_xpos", fXPos, kDouble, (UInt_t)fNPlanes},
-    {"dc_ypos", fYPos, kDouble, (UInt_t)fNPlanes},
     {"dc_zpos", fZPos, kDouble, (UInt_t)fNPlanes},
     {"dc_alpha_angle", fAlphaAngle, kDouble, (UInt_t)fNPlanes},
     {"dc_beta_angle", fBetaAngle, kDouble, (UInt_t)fNPlanes},
@@ -329,6 +327,21 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
   };
 
   gHcParms->LoadParmValues((DBRequest*)&list,fPrefix);
+
+  //Set the default plane x,y positions to those of the chamber
+   for(Int_t ip=0; ip<fNPlanes;ip++) {
+    fXPos[ip] = fXCenter;
+    fYPos[ip] = fXCenter;
+   }
+
+   //Load the x,y positions of the planes if they exist (overwrites defaults)
+   DBRequest listOpt[]={
+     {"dc_xpos", fXPos, kDouble, (UInt_t)fNPlanes, optional},
+     {"dc_ypos", fYPos, kDouble, (UInt_t)fNPlanes, optional},
+     {0}
+   };
+   gHcParms->LoadParmValues((DBRequest*)&listOpt,fPrefix);
+
   if(fNTracksMaxFP <= 0) fNTracksMaxFP = 10;
   // if(fNTracksMaxFP > HNRACKS_MAX) fNTracksMaxFP = NHTRACKS_MAX;
   cout << "Plane counts:";

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -329,18 +329,21 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
   gHcParms->LoadParmValues((DBRequest*)&list,fPrefix);
 
   //Set the default plane x,y positions to those of the chamber
+  //This assumes each chamber has 6 tracking planes!
    for(Int_t ip=0; ip<fNPlanes;ip++) {
-    fXPos[ip] = fXCenter;
-    fYPos[ip] = fYCenter;
+	   int ncham = 0;
+	   if (ip>5) {ncham=1;}
+       fXPos[ip] = fXCenter[ncham];
+       fYPos[ip] = fYCenter[ncham];
    }
 
    //Load the x,y positions of the planes if they exist (overwrites defaults)
-   DBRequest listOpt[]={
+  DBRequest listOpt[]={
      {"dc_xpos", fXPos, kDouble, (UInt_t)fNPlanes, optional},
      {"dc_ypos", fYPos, kDouble, (UInt_t)fNPlanes, optional},
      {0}
    };
-   gHcParms->LoadParmValues((DBRequest*)&listOpt,fPrefix);
+  gHcParms->LoadParmValues((DBRequest*)&listOpt,fPrefix);
 
   if(fNTracksMaxFP <= 0) fNTracksMaxFP = 10;
   // if(fNTracksMaxFP > HNRACKS_MAX) fNTracksMaxFP = NHTRACKS_MAX;

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -331,7 +331,7 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
   //Set the default plane x,y positions to those of the chamber
    for(Int_t ip=0; ip<fNPlanes;ip++) {
     fXPos[ip] = fXCenter;
-    fYPos[ip] = fXCenter;
+    fYPos[ip] = fYCenter;
    }
 
    //Load the x,y positions of the planes if they exist (overwrites defaults)

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -60,6 +60,8 @@ THcDC::THcDC(
   fWireOrder = NULL;
   fDriftTimeSign = NULL;
 
+  fXPos = NULL;
+  fYPos = NULL;
   fZPos = NULL;
   fAlphaAngle = NULL;
   fBetaAngle = NULL;
@@ -259,6 +261,8 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
   delete [] fWireOrder;  fWireOrder = new Int_t [fNPlanes]; // Wire readout order
   delete [] fDriftTimeSign;  fDriftTimeSign = new Int_t [fNPlanes];
 
+  delete [] fXPos;  fXPos = new Double_t [fNPlanes];
+  delete [] fYPos;  fYPos = new Double_t [fNPlanes];
   delete [] fZPos;  fZPos = new Double_t [fNPlanes];
   delete [] fAlphaAngle;  fAlphaAngle = new Double_t [fNPlanes];
   delete [] fBetaAngle;  fBetaAngle = new Double_t [fNPlanes];
@@ -287,6 +291,8 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
     {"dc_wire_counting", fWireOrder, kInt, (UInt_t)fNPlanes},
     {"dc_drifttime_sign", fDriftTimeSign, kInt, (UInt_t)fNPlanes},
 
+    {"dc_xpos", fXPos, kDouble, (UInt_t)fNPlanes},
+    {"dc_ypos", fYPos, kDouble, (UInt_t)fNPlanes},
     {"dc_zpos", fZPos, kDouble, (UInt_t)fNPlanes},
     {"dc_alpha_angle", fAlphaAngle, kDouble, (UInt_t)fNPlanes},
     {"dc_beta_angle", fBetaAngle, kDouble, (UInt_t)fNPlanes},
@@ -399,6 +405,8 @@ void THcDC::DeleteArrays()
   delete [] fWireOrder;   fWireOrder = NULL;
   delete [] fDriftTimeSign;   fDriftTimeSign = NULL;
 
+  delete [] fXPos;   fXPos = NULL;
+  delete [] fYPos;   fYPos = NULL;
   delete [] fZPos;   fZPos = NULL;
   delete [] fAlphaAngle;   fAlphaAngle = NULL;
   delete [] fBetaAngle;   fBetaAngle = NULL;

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -61,6 +61,9 @@ public:
   Double_t GetSpacePointCriterion(Int_t chamber) const { return fSpace_Point_Criterion[chamber-1];}
   Double_t GetCentralTime(Int_t plane) const { return fCentralTime[plane-1];}
   Int_t GetDriftTimeSign(Int_t plane) const { return fDriftTimeSign[plane-1];}
+  Int_t GetReadoutLR(Int_t plane) const { return fReadoutLR[plane-1];}
+  Int_t GetReadoutTB(Int_t plane) const { return fReadoutTB[plane-1];}
+
 
   Double_t GetPlaneTimeZero(Int_t plane) const { return fPlaneTimeZero[plane-1];}
   Double_t GetSigma(Int_t plane) const { return fSigma[plane-1];}
@@ -69,7 +72,6 @@ public:
   Double_t GetNSperChan() const { return fNSperChan;}
 
   Double_t GetCenter(Int_t plane) const {
-    Int_t chamber = GetNChamber(plane)-1;
     return
       //fXCenter[chamber]*sin(fAlphaAngle[plane-1]) +
       //fYCenter[chamber]*cos(fAlphaAngle[plane-1]);
@@ -145,6 +147,9 @@ protected:
   Int_t* fNChamber;
   Int_t* fWireOrder;
   Int_t* fDriftTimeSign;
+  Int_t* fReadoutTB;
+  Int_t* fReadoutLR;
+
 
   Double_t* fXPos;
   Double_t* fYPos;

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -71,8 +71,11 @@ public:
   Double_t GetCenter(Int_t plane) const {
     Int_t chamber = GetNChamber(plane)-1;
     return
-      fXCenter[chamber]*sin(fAlphaAngle[plane-1]) +
-      fYCenter[chamber]*cos(fAlphaAngle[plane-1]);
+      //fXCenter[chamber]*sin(fAlphaAngle[plane-1]) +
+      //fYCenter[chamber]*cos(fAlphaAngle[plane-1]);
+
+      fXPos[plane-1]*sin(fAlphaAngle[plane-1]) +
+      fYPos[plane-1]*cos(fAlphaAngle[plane-1]);
   }
   //  friend class THaScCalib;
 

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -48,6 +48,8 @@ public:
   Int_t GetTdcWinMin(Int_t plane) const { return fTdcWinMin[plane-1];}
   Int_t GetTdcWinMax(Int_t plane) const { return fTdcWinMax[plane-1];}
 
+  Double_t GetXPos(Int_t plane) const { return fXPos[plane-1];}
+  Double_t GetYPos(Int_t plane) const { return fYPos[plane-1];}
   Double_t GetZPos(Int_t plane) const { return fZPos[plane-1];}
   Double_t GetAlphaAngle(Int_t plane) const { return fAlphaAngle[plane-1];}
   Double_t GetBetaAngle(Int_t plane) const { return fBetaAngle[plane-1];}
@@ -141,6 +143,8 @@ protected:
   Int_t* fWireOrder;
   Int_t* fDriftTimeSign;
 
+  Double_t* fXPos;
+  Double_t* fYPos;
   Double_t* fZPos;
   Double_t* fAlphaAngle;
   Double_t* fBetaAngle;

--- a/src/THcDCHit.h
+++ b/src/THcDCHit.h
@@ -43,7 +43,6 @@ public:
 
   THcDriftChamberPlane* GetWirePlane() const { return fWirePlane; }
 
-
   void     SetWire(THcDCWire * wire) { fWire = wire; ConvertTimeToDist(); }
   void     SetRawTime(Int_t time)     { fRawTime = time; }
   void     SetTime(Double_t time)     { fTime = time; }
@@ -56,6 +55,66 @@ public:
   Int_t    GetPlaneIndex() const { return fWirePlane->GetPlaneIndex(); }
   Int_t    GetChamberNum() const { return fWirePlane->GetChamberNum(); }
   void     SetCorrectedStatus(Int_t c) { fCorrected = c; }
+
+  //Set this correctly
+  Int_t GetReadoutSide() {
+	  Int_t pln = fWirePlane->GetPlaneNum();
+	  Int_t tb = fWirePlane->GetReadoutTB();
+	  Int_t wn = fWire->GetNum();
+
+	  //check if x board
+	  if ((pln>=3 && pln<=4) || (pln>=9 && pln<=10)){
+		  if (tb>0){
+			  if (wn < 49){
+				  fReadoutSide = 4;
+			  }
+			  else {
+				  fReadoutSide = 2;
+			  }
+		  }
+		  else {
+			  if (wn < 33){
+				  fReadoutSide = 2;
+			  }
+			  else {
+				  fReadoutSide = 4;
+			  }
+		  }
+	  }
+	  //else is u board
+	  else{
+		  if (tb>0){
+		  	if (wn < 41){
+		  		fReadoutSide = 4;
+		  	}
+		  	else if (wn >= 41 && wn <= 63){
+		  		fReadoutSide = 3;
+		  	}
+		  	else if (wn >=64 && wn <=69){
+		  		fReadoutSide = 1;
+		  	}
+		  	else {
+		  		fReadoutSide = 2;
+		  	}
+		  }
+		  else {
+			  if (wn < 39){
+				  fReadoutSide = 2;
+			  }
+			  else if (wn >=39 && wn<=44){
+				  fReadoutSide = 1;
+			  }
+			  else if (wn>=45 && wn<=67){
+				  fReadoutSide = 3;
+			  }
+			  else {
+				  fReadoutSide = 4;
+			  }
+		  }
+	  }
+	  return fReadoutSide;
+  }
+
 
 protected:
   static const Double_t kBig;  //!
@@ -70,6 +129,7 @@ protected:
   Double_t    fdDist;    // uncertainty in fDist (for chi2 calc)
   Double_t    ftrDist;   // (Perpendicular) distance from the track
   Int_t       fCorrected; // Has this hit been corrected?
+  Int_t       fReadoutSide; // Side where wire is read out. 1-4 is T/R/B/L from beam view for new chambers.
 
   THcDriftChamber* fChamber; //! Pointer to parent wire plane
 

--- a/src/THcDCTrack.cxx
+++ b/src/THcDCTrack.cxx
@@ -26,6 +26,7 @@ void THcDCTrack::AddHit(THcDCHit * hit, Double_t dist, Int_t lr)
   fHits.push_back(newhit);
   fNHits++;
 }
+
 void THcDCTrack::AddSpacePoint( THcSpacePoint* sp )
 {
   // Add to list of space points in this track

--- a/src/THcDriftChamber.h
+++ b/src/THcDriftChamber.h
@@ -94,8 +94,8 @@ protected:
   Int_t fhdebugflagpr;
   Int_t fdebugstubchisq;
   Double_t fZPos;
-  Double_t fXCenter;
-  Double_t fYCenter;
+  Double_t fXPos;//fXCenter
+  Double_t fYPos;//fYCenter
   Double_t fSpacePointCriterion;
   Double_t fMaxDist; 		// Max dist used in EasySpacePoint methods
   Double_t* fSinBeta;

--- a/src/THcDriftChamberPlane.cxx
+++ b/src/THcDriftChamberPlane.cxx
@@ -129,6 +129,8 @@ Int_t THcDriftChamberPlane::ReadDatabase( const TDatime& date )
   fCenter = fParent->GetCenter(fPlaneNum);
   fCentralTime = fParent->GetCentralTime(fPlaneNum);
   fDriftTimeSign = fParent->GetDriftTimeSign(fPlaneNum);
+  fReadoutLR = fParent->GetReadoutLR(fPlaneNum);
+  fReadoutTB = fParent->GetReadoutTB(fPlaneNum);
 
   fNSperChan = fParent->GetNSperChan();
 
@@ -177,7 +179,7 @@ Int_t THcDriftChamberPlane::ReadDatabase( const TDatime& date )
   Double_t stubychi = sinalpha;
   Double_t stubypsi = cosalpha;
 
-  if(cosalpha <= 0.707) { // x-like wire, need dist from x=0 line
+  if(abs(cosalpha) <= 0.707) { // x-like wire, need dist from x=0 line
     fReadoutX = 1;
     fReadoutCorr = 1/sinalpha;
   } else {

--- a/src/THcDriftChamberPlane.h
+++ b/src/THcDriftChamberPlane.h
@@ -69,6 +69,9 @@ public:
   Double_t*    GetPlaneCoef() { return fPlaneCoef; }
   THcDriftChamberPlane(); // for ROOT I/O
   Double_t     CalcWireFromPos(Double_t pos);
+  Int_t        GetReadoutLR() const { return fReadoutLR;}
+  Int_t        GetReadoutTB() const { return fReadoutTB;}
+
 protected:
 
   TClonesArray* fParentHitList;
@@ -100,6 +103,8 @@ protected:
   Double_t fReadoutCorr;
   Double_t fCentralTime;
   Int_t fDriftTimeSign;
+  Int_t fReadoutLR;
+  Int_t fReadoutTB;
 
   Double_t fCenter;
 


### PR DESCRIPTION
This contains the wire velocity corrections for the new shms drift chambers. If the geometry parameters that specify the new shms chamber readout are not specified in the param file, then this defaults to the old behavior. No changes are observed really in the width of tracking residuals. Also, the hit positions of the center of each wire can now take in the per plane shifts from alignment. 