### PR TITLE
Updated   THcScalerEvtHandler

### DIFF
--- a/src/THcScalerEvtHandler.cxx
+++ b/src/THcScalerEvtHandler.cxx
@@ -139,6 +139,7 @@ Int_t THcScalerEvtHandler::ReadDatabase(const TDatime& date )
     for(Int_t i=0;i<fNumBCMs;i++) {
       fBCM_Name[i] = new char[bcm_names[i].length()+1];
       strcpy(fBCM_Name[i], bcm_names[i].c_str());
+      strcat(fBCM_Name[i],".scal");
       //    cout << fBCM_Gain[i] << " " << fBCM_Offset[i] << " " << fBCM_Name[i] << endl;
     }
     for(Int_t i=0;i<fNumBCMs;i++) {
@@ -347,7 +348,7 @@ Int_t THcScalerEvtHandler::AnalyzeBuffer(UInt_t* rdata)
 	    //printf("%s %f\n",scalerloc[ivar]->name.Data(),scalers[isca]->GetRate(ichan)); //checks
 	  }
 	  if(scalerloc[ivar]->ikind == ICURRENT || scalerloc[ivar]->ikind == ICHARGE){
-	    Int_t bcm_ind=0;
+	    Int_t bcm_ind=-1;
 	    for(Int_t itemp =0; itemp<fNumBCMs;itemp++)
 	      {		
 		size_t match = string(scalerloc[ivar]->name.Data()).find(string(fBCM_Name[itemp]));
@@ -357,12 +358,13 @@ Int_t THcScalerEvtHandler::AnalyzeBuffer(UInt_t* rdata)
 		  }
 	      }
 	    if (scalerloc[ivar]->ikind == ICURRENT) {
-	      dvars[ivar]=((scalers[isca]->GetData(ichan))/fDeltaTime-fBCM_Offset[bcm_ind])/fBCM_Gain[bcm_ind];
+              dvars[ivar]=0.;
+		if (bcm_ind != -1) dvars[ivar]=((scalers[isca]->GetData(ichan))/fDeltaTime-fBCM_Offset[bcm_ind])/fBCM_Gain[bcm_ind];
          	if (bcm_ind == fbcm_Current_Threshold_Index) scal_current= dvars[ivar];
 	    }
 	    if (scalerloc[ivar]->ikind == ICHARGE) {
-	       fBCM_delta_charge[bcm_ind]=fDeltaTime*((scalers[isca]->GetData(ichan))/fDeltaTime-fBCM_Offset[bcm_ind])/fBCM_Gain[bcm_ind];
-	      dvars[ivar]+=fBCM_delta_charge[bcm_ind];
+	      if (bcm_ind != -1) fBCM_delta_charge[bcm_ind]=fDeltaTime*((scalers[isca]->GetData(ichan))/fDeltaTime-fBCM_Offset[bcm_ind])/fBCM_Gain[bcm_ind];
+	      if (bcm_ind != -1) dvars[ivar]+=fBCM_delta_charge[bcm_ind];
 	    }
 	    //	    printf("1st event %i index %i fBCMname %s scalerloc %s offset %f gain %f computed %f\n",evcount, bcm_ind, fBCM_Name[bcm_ind],scalerloc[ivar]->name.Data(),fBCM_Offset[bcm_ind],fBCM_Gain[bcm_ind],dvars[ivar]);
 	  }
@@ -384,7 +386,7 @@ Int_t THcScalerEvtHandler::AnalyzeBuffer(UInt_t* rdata)
 	  }
 	  if(scalerloc[ivar]->ikind == ICURRENT || scalerloc[ivar]->ikind == ICHARGE)
 	    {
-	      Int_t bcm_ind=0;
+	      Int_t bcm_ind=-1;
 	      for(Int_t itemp =0; itemp<fNumBCMs;itemp++)
 		{		
 		  size_t match = string(scalerloc[ivar]->name.Data()).find(string(fBCM_Name[itemp]));
@@ -394,14 +396,14 @@ Int_t THcScalerEvtHandler::AnalyzeBuffer(UInt_t* rdata)
 		    }
 		}
 	    if (scalerloc[ivar]->ikind == ICURRENT) {
-                dvarsFirst[ivar]=((scalers[isca]->GetData(ichan))/fDeltaTime-fBCM_Offset[bcm_ind])/fBCM_Gain[bcm_ind];
-         	if (bcm_ind == fbcm_Current_Threshold_Index) scal_current= dvars[ivar];
+	        dvarsFirst[ivar]=0.0;
+                if (bcm_ind != -1) dvarsFirst[ivar]=((scalers[isca]->GetData(ichan))/fDeltaTime-fBCM_Offset[bcm_ind])/fBCM_Gain[bcm_ind];
+         	if (bcm_ind == fbcm_Current_Threshold_Index) scal_current= dvarsFirst[ivar];
 	    }
 	    if (scalerloc[ivar]->ikind == ICHARGE) {
-	       fBCM_delta_charge[bcm_ind]=fDeltaTime*((scalers[isca]->GetData(ichan))/fDeltaTime-fBCM_Offset[bcm_ind])/fBCM_Gain[bcm_ind];
-               dvarsFirst[ivar]+=fBCM_delta_charge[bcm_ind];
+	       if (bcm_ind != -1) fBCM_delta_charge[bcm_ind]=fDeltaTime*((scalers[isca]->GetData(ichan))/fDeltaTime-fBCM_Offset[bcm_ind])/fBCM_Gain[bcm_ind];
+               if (bcm_ind != -1) dvarsFirst[ivar]+=fBCM_delta_charge[bcm_ind];
 	    }
-	      printf("1st event %i index %i fBCM name %s scalerloc %s offset %f gain %f getrate%f\n", evcount, bcm_ind, fBCM_Name[bcm_ind],scalerloc[ivar]->name.Data(),fBCM_Offset[bcm_ind],fBCM_Gain[bcm_ind],dvarsFirst[ivar]);
 	    }
 	  if (fDebugFile) *fDebugFile << "   dvarsFirst  "<<scalerloc[ivar]->ikind<<"  "<<dvarsFirst[ivar]<<endl;
 	}
@@ -428,7 +430,7 @@ Int_t THcScalerEvtHandler::AnalyzeBuffer(UInt_t* rdata)
 	}
 	if(scalerloc[ivar]->ikind == ICURRENT || scalerloc[ivar]->ikind == ICHARGE)
 	  {
-	    Int_t bcm_ind=0;
+	    Int_t bcm_ind=-1;
 	    for(Int_t itemp =0; itemp<fNumBCMs;itemp++)
 	      {		
 		size_t match = string(scalerloc[ivar]->name.Data()).find(string(fBCM_Name[itemp]));
@@ -438,12 +440,13 @@ Int_t THcScalerEvtHandler::AnalyzeBuffer(UInt_t* rdata)
 		  }
 	      }
 	    if (scalerloc[ivar]->ikind == ICURRENT) {
-                dvars[ivar]=((scalers[isca]->GetData(ichan)-scal_prev_read[nscal-1])/fDeltaTime-fBCM_Offset[bcm_ind])/fBCM_Gain[bcm_ind];
+              dvars[ivar]=0;
+	      if (bcm_ind != -1) dvars[ivar]=((scalers[isca]->GetData(ichan)-scal_prev_read[nscal-1])/fDeltaTime-fBCM_Offset[bcm_ind])/fBCM_Gain[bcm_ind];
          	if (bcm_ind == fbcm_Current_Threshold_Index) scal_current= dvars[ivar];
 	    }
 	    if (scalerloc[ivar]->ikind == ICHARGE) {
-	       fBCM_delta_charge[bcm_ind]=fDeltaTime*((scalers[isca]->GetData(ichan)-scal_prev_read[nscal-1])/fDeltaTime-fBCM_Offset[bcm_ind])/fBCM_Gain[bcm_ind];
-               dvars[ivar]+=fBCM_delta_charge[bcm_ind];
+	       if (bcm_ind != -1) fBCM_delta_charge[bcm_ind]=fDeltaTime*((scalers[isca]->GetData(ichan)-scal_prev_read[nscal-1])/fDeltaTime-fBCM_Offset[bcm_ind])/fBCM_Gain[bcm_ind];
+               if (bcm_ind != -1) dvars[ivar]+=fBCM_delta_charge[bcm_ind];
 	    }
 	    //	    printf("event %i index %i fBCMname %s scalerloc %s offset %f gain %f computed %f\n",evcount, bcm_ind, fBCM_Name[bcm_ind],scalerloc[ivar]->name.Data(),fBCM_Offset[bcm_ind],fBCM_Gain[bcm_ind],dvars[ivar]);
 	  }
@@ -466,7 +469,7 @@ Int_t THcScalerEvtHandler::AnalyzeBuffer(UInt_t* rdata)
       dvars_prev_read[ivar] = scalers[isca]->GetData(ichan);
     }
     if (scalerloc[ivar]->ikind == ICUT+ICHARGE){
-	    Int_t bcm_ind=0;
+	    Int_t bcm_ind=-1;
 	    for(Int_t itemp =0; itemp<fNumBCMs;itemp++)
 	      {		
 		size_t match = string(scalerloc[ivar]->name.Data()).find(string(fBCM_Name[itemp]));
@@ -475,9 +478,9 @@ Int_t THcScalerEvtHandler::AnalyzeBuffer(UInt_t* rdata)
 		    bcm_ind=itemp;
 		  }
 	      }
-      if ( scal_current > fbcm_Current_Threshold) {
+      if ( scal_current > fbcm_Current_Threshold && bcm_ind != -1) {
 	dvars[ivar] += fBCM_delta_charge[bcm_ind];
-      } 
+     } 
     }
     if (scalerloc[ivar]->ikind == ICUT+ITIME){
       if ( scal_current > fbcm_Current_Threshold) {


### PR DESCRIPTION
Fix bug if more BCMs defined in db_PScalevt.dat than in gscalers.param

Fix bug that confused names "BCM1" and "BCM17" by adding ".scal" to the BCM name