### PR TITLE
Change behaviour for multiple ROCs with scalers.

### DIFF
--- a/src/THcScalerEvtHandler.h
+++ b/src/THcScalerEvtHandler.h
@@ -35,13 +35,14 @@ public:
    virtual ~THcScalerEvtHandler();
 
    Int_t Analyze(THaEvData *evdata);
-   Int_t AnalyzeBuffer(UInt_t *rdata);
+   Int_t AnalyzeBuffer(UInt_t *rdata, Bool_t onlysync);
    virtual EStatus Init( const TDatime& run_time);
    virtual Int_t   ReadDatabase(const TDatime& date );
    virtual Int_t End( THaRunBase* r=0 );
    virtual void SetUseFirstEvent(Bool_t b = kFALSE) {fUseFirstEvent = b;}
    virtual void SetDelayedType(int evtype);
    virtual void SetOnlyBanks(Bool_t b = kFALSE) {fOnlyBanks = b;fRocSet.clear();}
+   virtual void SetOnlyUseSyncEvents(Bool_t b=kFALSE) {fOnlySyncEvents = b;}
 
 private:
 
@@ -73,8 +74,9 @@ private:
    Double_t *dvarsFirst;
    TTree *fScalerTree;
    Bool_t fUseFirstEvent;
-   Int_t fDelayedType;
+   Bool_t fOnlySyncEvents;
    Bool_t fOnlyBanks;
+   Int_t fDelayedType;
    std::vector<UInt_t*> fDelayedEvents;
    std::set<UInt_t> fRocSet;
    std::set<UInt_t> fModuleSet;


### PR DESCRIPTION
  1.  If there are multiple ROCs with scalers (hardware, TI, FADC), then
there will be multiple event 129s.  In the case where analysis of these
events is defered to the end of the analysis, all the event 129s will
be analyzed as if a single event, resulting in one entry in the tree.
  2.  Scalers are read either when a given time interval has passed since
the last scaler read (usually 2 seconds), or every time an event is tagged
as a sync event.  In the case of the "timed" reading of events, different ROCs
with scalers are not guaranteed to read their scalers at the same event.  But
or sync event scaler reads, all ROCs read their scalers.  This commit adds an
option SetOnlyUseSyncEvents(Bool_t).  If set, only scaler events triggered
by the sync event will be analyzed.