### PR TITLE
Ev125 update and spurious invalid signal message elimination

### DIFF
--- a/src/THcConfigEvtHandler.h
+++ b/src/THcConfigEvtHandler.h
@@ -63,6 +63,14 @@ private:
       Int_t timewindow_offset;
       Int_t timewindow_width;
    } CAEN1190;
+    struct TI {
+      Int_t present;
+      Int_t nped;
+      Int_t scaler_period;
+      Int_t sync_count;
+      Int_t num_prescales;
+      Int_t prescales[6];
+    } TI;
    //CrateInfo : FADC250.nmodules(0),CAEN1190.present(0) {}
   } CrateInfo_t;
 

--- a/src/THcHitList.cxx
+++ b/src/THcHitList.cxx
@@ -102,17 +102,19 @@ void THcHitList::InitHitList(THaDetMap* detmap,
   for (Int_t i=0; i < fdMap->GetSize(); i++) {
     THaDetMap::Module* d = fdMap->GetModule(i);
     Int_t refindex = d->refindex;
-    if(d->plane < 1000 && refindex >= 0) {
-      if(!fRefIndexMaps[refindex].defined) {
-	cout << "Refindex " << refindex << " not defined for " <<
+    if(d->plane < 1000) {
+      if(d->signal >= fNSignals) {
+	cout << "Invalid signal " << d->signal << " for " <<
 	  " (" << d->crate << ", " << d->slot <<
 	  ", " << d->lo << ")" << endl;
       }
-    }
-    if(d->signal >= fNSignals) {
-      cout << "Invalid signal " << d->signal << " for " <<
+      if(refindex >= 0) {
+	if(!fRefIndexMaps[refindex].defined) {
+	  cout << "Refindex " << refindex << " not defined for " <<
 	    " (" << d->crate << ", " << d->slot <<
 	    ", " << d->lo << ")" << endl;
+	}
+      }
     }
   }
 


### PR DESCRIPTION
Eliminates spurious "Invalid signal" messages in hit list initialization.

Partially address issue #271.  Still need to come up with a scheme to make information collected by event 125 available in gHcParms or gHaVars.