### PR TITLE
Modify THcRawAdcHit.cxx and THcRawAdcHit.h

### DIFF
--- a/src/THcRawAdcHit.cxx
+++ b/src/THcRawAdcHit.cxx
@@ -181,6 +181,11 @@ Returns 0 if no signal pedestal is set.
 #include "THcRawAdcHit.h"
 #include <stdexcept>
 #include "TString.h"
+    const Double_t THcRawAdcHit::fNAdcChan      = 4096.0; // Number of FADC channels in units of ADC channels
+    const Double_t THcRawAdcHit::fAdcRange      = 1.0;    // Dynamic range of FADCs in units of V, // TO-DO: Get fAdcRange from pre-start event
+    const Double_t THcRawAdcHit::fAdcImpedence  = 50.0;   // FADC input impedence in units of Ohms
+    const Double_t THcRawAdcHit::fAdcTimeSample = 4000.0;    // Length of FADC time sample in units of ps
+    const Double_t THcRawAdcHit::fAdcTimeRes    = 0.0625; // FADC time resolution in units of ns
 
 THcRawAdcHit::THcRawAdcHit() :
   TObject(),

--- a/src/THcRawAdcHit.h
+++ b/src/THcRawAdcHit.h
@@ -57,11 +57,11 @@ class THcRawAdcHit : public TObject {
     static const UInt_t fMaxNSamples = 511;
     
     // FADC conversion factors
-    const Double_t fNAdcChan      = 4096.0; // Number of FADC channels in units of ADC channels
-    const Double_t fAdcRange      = 1.0;    // Dynamic range of FADCs in units of V, // TO-DO: Get fAdcRange from pre-start event
-    const Double_t fAdcImpedence  = 50.0;   // FADC input impedence in units of Ohms
-    const Double_t fAdcTimeSample = 4000.0;    // Length of FADC time sample in units of ps
-    const Double_t fAdcTimeRes    = 0.0625; // FADC time resolution in units of ns
+    static const Double_t fNAdcChan; // Number of FADC channels in units of ADC channels
+    static const Double_t fAdcRange;    // Dynamic range of FADCs in units of V, // TO-DO: Get fAdcRange from pre-start event
+    static const Double_t fAdcImpedence;   // FADC input impedence in units of Ohms
+    static const Double_t fAdcTimeSample;    // Length of FADC time sample in units of ps
+    static const Double_t fAdcTimeRes; // FADC time resolution in units of ns
 
     Int_t fNPedestalSamples;  // TODO: Get this from prestart event...
     Int_t fNPeakSamples;


### PR DESCRIPTION
Modify the way that the constants for conversion to mV and pC are defined
so that it will compile with and without C11.