### PR TITLE
Added optional parameter to define the chamber style

### DIFF
--- a/THcConfigEvtHandler.cxx
+++ b/THcConfigEvtHandler.cxx
@@ -1,0 +1,306 @@
+/** \class THcConfigEvtHandler
+    \ingroup base
+
+  Event handler for Hall C prestart config event.  Type 125
+
+  Example of an Event Type Handler for event type 125,
+  the hall C prestart event.
+
+  It was tested on some hms data.  However, note that I don't know what
+  these data mean yet and I presume the data structure is under development;
+  someone will need to modify this class (and the comments).
+
+  To use as a plugin with your own modifications, you can do this in
+  your analysis script
+
+  gHaEvtHandlers->Add (new THcConfigEvtHandler("hallcpre","for evtype 125"));
+
+  Global variables are defined in Init.  You can see them in Podd, as
+    analyzer [2] gHaVars->Print()
+
+     OBJ: THaVar	HCvar1	Hall C event type 125 variable 1
+     OBJ: THaVar	HCvar2	Hall C event type 125 variable 2
+     OBJ: THaVar	HCvar3	Hall C event type 125 variable 3
+     OBJ: THaVar	HCvar4	Hall C event type 125 variable 4
+
+  The data can be added to the ROOT Tree "T" using the output
+  definition file.  Then you can see them, for example as follows
+
+     T->Scan("HCvar1:HCvar2:HCvar3:HCvar4")
+
+\author Robert Michaels (rom@jlab.org), updated by Stephen Wood (saw@jlab.org)
+*/
+
+#include "THcConfigEvtHandler.h"
+#include "THaEvData.h"
+#include "THaVarList.h"
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <iomanip>
+
+using namespace std;
+
+THcConfigEvtHandler::THcConfigEvtHandler(const char *name, const char* description)
+  : THaEvtTypeHandler(name,description)
+{
+}
+
+THcConfigEvtHandler::~THcConfigEvtHandler()
+{
+}
+
+//Float_t THcConfigEvtHandler::GetData(const std::string& tag)
+//{
+//  // A public method which other classes may use
+//  if (theDataMap.find(tag) == theDataMap.end())
+//    return 0;
+// return theDataMap[tag];
+//}
+
+
+Int_t THcConfigEvtHandler::Analyze(THaEvData *evdata)
+{
+
+  Bool_t ldebug = true;  // FIXME: use fDebug
+
+  if ( !IsMyEvent(evdata->GetEvType()) ) return -1;
+
+  if (ldebug) cout << "------------------\n  Event type 125"<<endl;
+
+  Int_t evlen = evdata->GetEvLength();
+  Int_t ip = 0;
+  ip++;
+  UInt_t thisword = evdata->GetRawData(ip);
+  Int_t roc = thisword & 0xff;
+  cout << "THcConfigEvtHandler: " << roc << endl;
+  // Should check if this roc has already been seen
+  CrateInfo_t *cinfo = new CrateInfo_t;
+  cinfo->FADC250.nmodules=0;
+  cinfo->FADC250.present=0;
+  cinfo->CAEN1190.present=0;
+  cinfo->TI.present=0;  
+  CrateInfoMap.insert(std::make_pair(roc, cinfo));
+  ip++;
+  // Three possible blocks of config data
+  // 0xdafadc01 - FADC information for the crate
+  // 0xdafadcff - Set of threshold by slot/channel
+  // 0xdedc1190 - 1190 TDC information for the crate
+  while(ip<evlen) {
+    thisword = evdata->GetRawData(ip);
+    if (thisword == 0xdafadcff) {
+      ip++;
+      thisword = evdata->GetRawData(ip);
+      cout << "ADC thresholds for slots ";
+      while((thisword & 0xfffff000)==0xfadcf000) {
+        Int_t slot = thisword&0x1f;
+        // Should check if this slot has already been SDC_WIRE_CENTER
+        cinfo->FADC250.nmodules++;
+        cout << " " << slot;
+        Int_t *thresholds = new Int_t [16];
+        cinfo->FADC250.thresholds.insert(std::make_pair(slot, thresholds));
+        for(Int_t i=0;i<16;i++) {
+          thresholds[i] = evdata->GetRawData(ip+1+i);
+        }
+        ip +=18;
+        if(ip>=evlen) {
+          if(ip>evlen) {
+            cout << endl << "Info event truncated" << endl;
+          }
+          break;
+        }
+        thisword = evdata->GetRawData(ip);
+      }
+      cout << endl;
+    } else if((thisword&0xffffff00) == 0xdafadc00) { // FADC250 information
+      cout << "ADC information: Block level " << (thisword&0xff) << endl;
+      cinfo->FADC250.present = 1;
+      cinfo->FADC250.blocklevel = thisword&0xff;
+      cinfo->FADC250.daq_level = evdata->GetRawData(ip+2);
+      cinfo->FADC250.threshold = evdata->GetRawData(ip+3);
+      cinfo->FADC250.mode = evdata->GetRawData(ip+4);
+      cinfo->FADC250.window_lat = evdata->GetRawData(ip+5);
+      cinfo->FADC250.window_width = evdata->GetRawData(ip+6);
+      cinfo->FADC250.nsb = evdata->GetRawData(ip+7);
+      cinfo->FADC250.nsa = evdata->GetRawData(ip+8);
+      cinfo->FADC250.np = evdata->GetRawData(ip+9);
+      cinfo->FADC250.nped = evdata->GetRawData(ip+10);
+      cinfo->FADC250.maxped = evdata->GetRawData(ip+11);
+      cinfo->FADC250.nsat = evdata->GetRawData(ip+12);
+      ip += 13;
+    } else if (thisword == 0xdedc1190) { // CAEN 1190 information
+      cout << "TDC information" << endl;
+      cinfo->CAEN1190.present = 1;
+      cinfo->CAEN1190.resolution = evdata->GetRawData(ip+2);
+      cinfo->CAEN1190.timewindow_offset = evdata->GetRawData(ip+3);
+      cinfo->CAEN1190.timewindow_width = evdata->GetRawData(ip+4);
+      ip += 6;
+    } else if (thisword == 0xd0000000) { // TI setup data
+      cinfo->TI.present = 1;
+      ip += 1;
+      UInt_t versionword = evdata->GetRawData(ip++);
+      if((versionword & 0xffff0000) != 0xabcd0000) {
+	cout << "Unexpected TI info word " << hex << thisword << dec << endl;
+	cout << "  Expected 0xabcdNNNN" << endl;
+	ip += 1;
+      } else {
+	Int_t version = versionword & 0xffff;
+	cinfo->TI.num_prescales = 6;
+	cinfo->TI.nped = evdata->GetRawData(ip++);
+	if(version >= 2) {
+	  cinfo->TI.scaler_period = evdata->GetRawData(ip++);
+	  cinfo->TI.sync_count = evdata->GetRawData(ip++);
+	} else {
+	  cinfo->TI.scaler_period = 2;
+	  cinfo->TI.sync_count = -1;
+	}
+	for(Int_t i = 0; i<cinfo->TI.num_prescales; i++) {
+	  cinfo->TI.prescales[i] = evdata->GetRawData(ip++);
+	}
+	UInt_t lastword = evdata->GetRawData(ip++);
+	if(lastword != 0xd000000f) {
+	  cout << "Unexpected last word of TI information block "
+	       << hex << lastword << dec << endl;
+	}
+      }
+    } else {
+      cout << "Expected header missing" << endl;
+      cout << ip << " " << hex << thisword << dec << endl;
+      ip = evlen;
+    }
+  }
+
+  return 1;
+}
+
+void THcConfigEvtHandler::PrintConfig()
+{
+/**
+  Stub of method to pretty print the config data
+*/
+  std::map<Int_t, CrateInfo_t *>::iterator it = CrateInfoMap.begin();
+  while(it != CrateInfoMap.end()) {
+    Int_t roc = it->first;
+    cout << "================= Configuration Data ROC " << roc << "==================" << endl;
+    CrateInfo_t *cinfo = it->second;
+    if(cinfo->CAEN1190.present) {
+      cout << "    CAEN 1190 Configuration" << endl;
+      cout << "        Resolution: " << cinfo->CAEN1190.resolution << " ps" << endl;
+      cout << "        T Offset:   " << cinfo->CAEN1190.timewindow_offset << endl;
+      cout << "        T Width:    " << cinfo->CAEN1190.timewindow_width << endl;
+    }
+    if (cinfo->FADC250.present) {
+      cout << "    FADC250 Configuration" << endl;
+      cout << "       Mode:   " << cinfo->FADC250.mode << endl;
+      cout << "       Latency: " << cinfo->FADC250.window_lat << "  Width: "<< cinfo->FADC250.window_width << endl;
+      cout << "       DAQ Level: " << cinfo->FADC250.daq_level << "  Threshold: " << cinfo->FADC250.threshold << endl;
+      cout << "       NPED: " << cinfo->FADC250.nped << "  NSA: " << cinfo->FADC250.nsa << "  NSB: " << cinfo->FADC250.nsb << endl;
+      cout << "       MAXPED: " << cinfo->FADC250.maxped << "  NP: " << cinfo->FADC250.np << "  NSAT: " << cinfo->FADC250.nsat << endl;
+
+      // Loop over FADC slots
+      cout << "       Thresholds";
+      std::map<Int_t, Int_t *>::iterator itt = cinfo->FADC250.thresholds.begin();
+      while(itt != cinfo->FADC250.thresholds.end()) {
+        Int_t slot = itt->first;
+        cout << " " << setw(5) << slot;
+        itt++;
+      }
+      cout << endl;
+      for(Int_t ichan=0;ichan<16;ichan++) {
+        cout << "           " << setw(2) << ichan << "    ";
+        std::map<Int_t, Int_t *>::iterator itt = cinfo->FADC250.thresholds.begin();
+        while(itt != cinfo->FADC250.thresholds.end()) {
+          Int_t *thresholds = itt->second;
+          cout << " " << setw(5) << thresholds[ichan];
+          itt++;
+        }
+        cout << endl;
+      }
+    }
+    if(cinfo->TI.present) {
+      cout << "    TI Configuration" << endl;
+      cout << "        N Pedestals:   " << cinfo->TI.nped << " events" << endl;
+      cout << "        Scaler Period: " << cinfo->TI.scaler_period << " seconds" << endl;
+      cout << "        Sync interval: " << cinfo->TI.sync_count << " events" << endl;
+      cout << "        Prescales:    ";
+      for(Int_t i=0;i<cinfo->TI.num_prescales;i++) {
+	cout << " " << cinfo->TI.prescales[i];
+      }
+      cout << endl;
+    }
+    it++;
+  }
+}
+
+Int_t THcConfigEvtHandler::IsPresent(Int_t crate) {
+  if(CrateInfoMap.find(crate)!=CrateInfoMap.end()) {
+    CrateInfo_t *cinfo = CrateInfoMap[crate];
+    return cinfo->FADC250.present;
+  }
+  return(0);
+}
+Int_t THcConfigEvtHandler::GetNSA(Int_t crate) {
+  if(CrateInfoMap.find(crate)!=CrateInfoMap.end()) {
+    CrateInfo_t *cinfo = CrateInfoMap[crate];
+    if(cinfo->FADC250.present > 0) return(cinfo->FADC250.nsa);
+  }
+  return(-1);
+}
+Int_t THcConfigEvtHandler::GetNSB(Int_t crate) {
+  if(CrateInfoMap.find(crate)!=CrateInfoMap.end()) {
+    CrateInfo_t *cinfo = CrateInfoMap[crate];
+    if(cinfo->FADC250.present > 0) return(cinfo->FADC250.nsb);
+  }
+  return(-1);
+}
+Int_t THcConfigEvtHandler::GetNPED(Int_t crate) {
+  if(CrateInfoMap.find(crate)!=CrateInfoMap.end()) {
+    CrateInfo_t *cinfo = CrateInfoMap[crate];
+    if(cinfo->FADC250.present > 0) return(cinfo->FADC250.nped);
+  }
+  return(-1);
+}
+void THcConfigEvtHandler::AddEventType(Int_t evtype)
+{
+  eventtypes.push_back(evtype);
+}
+
+THaAnalysisObject::EStatus THcConfigEvtHandler::Init(const TDatime& date)
+{
+
+  cout << "Howdy !  We are initializing THcConfigEvtHandler !!   name =   "<<fName<<endl;
+
+  if(eventtypes.size()==0) {
+    eventtypes.push_back(125);  // what events to look for
+  }
+
+// dvars is a member of this class.
+// The index of the dvars array track the array of global variables created.
+// This is just a fake example with 4 variables.
+// Please change these comments when you modify this class.
+
+  NVars = 4;
+  dvars = new Double_t[NVars];
+  memset(dvars, 0, NVars*sizeof(Double_t));
+  if (gHaVars) {
+      cout << "EvtHandler:: Have gHaVars.  Good thing. "<<gHaVars<<endl;
+  } else {
+      cout << "EvtHandler:: No gHaVars ?!  Well, that is a problem !!"<<endl;
+      return kInitError;
+  }
+  const Int_t* count = 0;
+  char cname[80];
+  char cdescription[80];
+  for (UInt_t i = 0; i < NVars; i++) {
+    sprintf(cname,"HCvar%d",i+1);
+    sprintf(cdescription,"Hall C event type 125 variable %d",i+1);
+    gHaVars->DefineByType(cname, cdescription, &dvars[i], kDouble, count);
+  }
+
+
+  fStatus = kOK;
+  return kOK;
+}
+
+ClassImp(THcConfigEvtHandler)

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -84,6 +84,7 @@ THcDC::THcDC(
   fNChamHits = 0;
   fPlaneEvents = 0;
 
+  //The version defaults to 0 (old HMS style). 1 is new HMS style and 2 is SHMS style.
   fVersion = 0;
 }
 

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -83,11 +83,16 @@ THcDC::THcDC(
 
   fNChamHits = 0;
   fPlaneEvents = 0;
+
+  fVersion = 0;
 }
 
 //_____________________________________________________________________________
 void THcDC::Setup(const char* name, const char* description)
 {
+
+	Bool_t optional = true;
+
   // Create the chamber and plane objects using parameters.
   static const char* const here = "Setup";
 
@@ -116,6 +121,7 @@ void THcDC::Setup(const char* name, const char* description)
     {"dc_tdc_time_per_channel",&fNSperChan, kDouble},
     {"dc_wire_velocity",&fWireVelocity,kDouble},
     {"dc_plane_names",&planenamelist, kString},
+	{"dc_version", &fVersion, kInt, 0, optional},
     {0}
   };
 

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -63,6 +63,7 @@ public:
   Int_t GetDriftTimeSign(Int_t plane) const { return fDriftTimeSign[plane-1];}
   Int_t GetReadoutLR(Int_t plane) const { return fReadoutLR[plane-1];}
   Int_t GetReadoutTB(Int_t plane) const { return fReadoutTB[plane-1];}
+  Int_t GetVersion() const {return fVersion;}
 
 
   Double_t GetPlaneTimeZero(Int_t plane) const { return fPlaneTimeZero[plane-1];}
@@ -128,6 +129,7 @@ protected:
   Double_t fYtTrCriterion;
   Double_t fXptTrCriterion;
   Double_t fYptTrCriterion;
+  Int_t fVersion;
 
   // Each of these will be dimensioned with the number of chambers
   Double_t* fXCenter;

--- a/src/THcDCHit.h
+++ b/src/THcDCHit.h
@@ -56,59 +56,107 @@ public:
   Int_t    GetChamberNum() const { return fWirePlane->GetChamberNum(); }
   void     SetCorrectedStatus(Int_t c) { fCorrected = c; }
 
-  //Set this correctly
   Int_t GetReadoutSide() {
 	  Int_t pln = fWirePlane->GetPlaneNum();
 	  Int_t tb = fWirePlane->GetReadoutTB();
 	  Int_t wn = fWire->GetNum();
+	  Int_t version = fWirePlane->GetVersion();
 
-	  //check if x board
-	  if ((pln>=3 && pln<=4) || (pln>=9 && pln<=10)){
-		  if (tb>0){
-			  if (wn < 49){
-				  fReadoutSide = 4;
+	  //if new HMS
+	  if (version == 1){
+		  if ((pln>=3 && pln<=4) || (pln>=9 && pln<=10)){
+			  if (tb>0){
+				  if (wn < 60){
+					  fReadoutSide = 2;
+				  }
+				  else {
+					  fReadoutSide = 4;
+				  }
 			  }
 			  else {
-				  fReadoutSide = 2;
+				  if (wn < 44){
+					  fReadoutSide = 4;
+				  }
+				  else {
+					  fReadoutSide = 2;
+				  }
 			  }
 		  }
-		  else {
-			  if (wn < 33){
-				  fReadoutSide = 2;
+		  else{
+			  if (tb>0){
+				  if (wn < 51){
+					  fReadoutSide = 2;
+				  }
+				  else if (wn >= 51 && wn <= 64){
+					  fReadoutSide = 1;
+				  }
+				  else {
+					  fReadoutSide =4;
+				  }
 			  }
 			  else {
-				  fReadoutSide = 4;
+				  if (wn < 33){
+					  fReadoutSide = 4;
+				  }
+				  else if (wn >=33 && wn<=46){
+					  fReadoutSide = 1;
+				  }
+				  else {
+					  fReadoutSide = 2;
+				  }
 			  }
 		  }
 	  }
-	  //else is u board
-	  else{
-		  if (tb>0){
-		  	if (wn < 41){
-		  		fReadoutSide = 4;
-		  	}
-		  	else if (wn >= 41 && wn <= 63){
-		  		fReadoutSide = 3;
-		  	}
-		  	else if (wn >=64 && wn <=69){
-		  		fReadoutSide = 1;
-		  	}
-		  	else {
-		  		fReadoutSide = 2;
-		  	}
-		  }
-		  else {
-			  if (wn < 39){
-				  fReadoutSide = 2;
-			  }
-			  else if (wn >=39 && wn<=44){
-				  fReadoutSide = 1;
-			  }
-			  else if (wn>=45 && wn<=67){
-				  fReadoutSide = 3;
+
+	  else{//appplies SHMS DC configuration
+		  //check if x board
+		  if ((pln>=3 && pln<=4) || (pln>=9 && pln<=10)){
+			  if (tb>0){
+				  if (wn < 49){
+					  fReadoutSide = 4;
+				  }
+				  else {
+					  fReadoutSide = 2;
+				  }
 			  }
 			  else {
-				  fReadoutSide = 4;
+				  if (wn < 33){
+					  fReadoutSide = 2;
+				  }
+				  else {
+					  fReadoutSide = 4;
+				  }
+			  }
+		  }
+		  //else is u board
+		  else{
+			  if (tb>0){
+				  if (wn < 41){
+					  fReadoutSide = 4;
+				  }
+				  else if (wn >= 41 && wn <= 63){
+					  fReadoutSide = 3;
+				  }
+				  else if (wn >=64 && wn <=69){
+					  fReadoutSide = 1;
+				  }
+				  else {
+					  fReadoutSide = 2;
+				  }
+			  }
+			  else {
+				  if (wn < 39){
+					  fReadoutSide = 2;
+				  }
+				  else if (wn >=39 && wn<=44){
+					  fReadoutSide = 1;
+				  }
+				  else if (wn>=45 && wn<=67){
+					  fReadoutSide = 3;
+				  }
+				  else {
+					  fReadoutSide = 4;
+				  }
 			  }
 		  }
 	  }

--- a/src/THcDriftChamber.cxx
+++ b/src/THcDriftChamber.cxx
@@ -144,6 +144,7 @@ Int_t THcDriftChamber::ReadDatabase( const TDatime& date )
     {Form("dc_%d_zpos",fChamberNum), &fZPos, kDouble},
     {0}
   };
+
   fRemove_Sppt_If_One_YPlane = 0; // Default
   fStubMaxXPDiff = 0.05;	  // The HMS default.  Not used for SOS.
   gHcParms->LoadParmValues((DBRequest*)&list,prefix);
@@ -912,12 +913,13 @@ void THcDriftChamber::CorrectHitTimes()
 				 x*plane->GetReadoutCorr()/fWireVelocity;
 
 		  // This applies the wire velocity correction for new SHMS chambers --hszumila, SEP17
-		  if (abs(plane->GetReadoutLR())==1){
+		  THcDC* fParent;
+		  fParent = (THcDC*) GetParent();
+		  Int_t version = fParent->GetVersion();
+		  if (version!= 0){
 			  Int_t pln = hit->GetPlaneNum();
 			  Int_t readoutSide = hit->GetReadoutSide();
 
-			  THcDC* fParent;
-			  fParent = (THcDC*) GetParent();
 			  Double_t posn = hit->GetPos();
 			  //The following values are determined from param file as permutations on planes 5 and 10
 			  Int_t readhoriz = plane->GetReadoutLR();

--- a/src/THcDriftChamberPlane.cxx
+++ b/src/THcDriftChamberPlane.cxx
@@ -102,6 +102,9 @@ Int_t THcDriftChamberPlane::ReadDatabase( const TDatime& date )
     {"_using_tzero_per_wire", &fUsingTzeroPerWire, kInt,0,1},
     {0}
   };
+
+
+
   gHcParms->LoadParmValues((DBRequest*)&list,prefix);
 
   Double_t *DriftMap = new Double_t[NumDriftMapBins];
@@ -131,6 +134,7 @@ Int_t THcDriftChamberPlane::ReadDatabase( const TDatime& date )
   fDriftTimeSign = fParent->GetDriftTimeSign(fPlaneNum);
   fReadoutLR = fParent->GetReadoutLR(fPlaneNum);
   fReadoutTB = fParent->GetReadoutTB(fPlaneNum);
+  fVersion = fParent->GetVersion();
 
   fNSperChan = fParent->GetNSperChan();
 

--- a/src/THcDriftChamberPlane.h
+++ b/src/THcDriftChamberPlane.h
@@ -71,6 +71,7 @@ public:
   Double_t     CalcWireFromPos(Double_t pos);
   Int_t        GetReadoutLR() const { return fReadoutLR;}
   Int_t        GetReadoutTB() const { return fReadoutTB;}
+  Int_t        GetVersion() const {return fVersion;}
 
 protected:
 
@@ -79,6 +80,7 @@ protected:
   TClonesArray* fHits;
   TClonesArray* fWires;
 
+  Int_t fVersion;
   Int_t fWireOrder;
   Int_t fPlaneNum;
   Int_t fPlaneIndex;		/* Index of this plane within it's chamber */

--- a/src/THcScalerEvtHandler.cxx
+++ b/src/THcScalerEvtHandler.cxx
@@ -110,41 +110,44 @@ Int_t THcScalerEvtHandler::ReadDatabase(const TDatime& date )
   char prefix[2];
   prefix[0]='g';
   prefix[1]='\0';
+  fNumBCMs = 0;
   DBRequest list[]={
-    {"NumBCMs",&fNumBCMs, kInt},
+    {"NumBCMs",&fNumBCMs, kInt, 0, 1},
     {0}
   };
   gHcParms->LoadParmValues((DBRequest*)&list, prefix);
   //cout << " NUmber of BCMs = " << fNumBCMs << endl;
   //
-  fBCM_Gain = new Double_t[fNumBCMs];
-  fBCM_Offset = new Double_t[fNumBCMs];
- fBCM_delta_charge= new Double_t[fNumBCMs];
- string bcm_namelist;
-  DBRequest list2[]={
-    {"BCM_Gain",      fBCM_Gain,         kDouble, (UInt_t) fNumBCMs},
-    {"BCM_Offset",     fBCM_Offset,       kDouble,(UInt_t) fNumBCMs},
-    {"BCM_Names",     &bcm_namelist,       kString},
-    {"BCM_Current_threshold",     &fbcm_Current_Threshold,       kDouble,0, 1},
-    {"BCM_Current_threshold_index",     &fbcm_Current_Threshold_Index,       kInt,0,1},
-    {0}
-  };
-  fbcm_Current_Threshold = 0.0;
-  fbcm_Current_Threshold_Index = 0;
-  gHcParms->LoadParmValues((DBRequest*)&list2, prefix);
-  vector<string> bcm_names = vsplit(bcm_namelist);
-  fBCM_Name = new char* [fNumBCMs];
-  for(Int_t i=0;i<fNumBCMs;i++) {
-    fBCM_Name[i] = new char[bcm_names[i].length()+1];
-    strcpy(fBCM_Name[i], bcm_names[i].c_str());
-    //    cout << fBCM_Gain[i] << " " << fBCM_Offset[i] << " " << fBCM_Name[i] << endl;
+  if(fNumBCMs > 0) {
+    fBCM_Gain = new Double_t[fNumBCMs];
+    fBCM_Offset = new Double_t[fNumBCMs];
+    fBCM_delta_charge= new Double_t[fNumBCMs];
+    string bcm_namelist;
+    DBRequest list2[]={
+      {"BCM_Gain",      fBCM_Gain,         kDouble, (UInt_t) fNumBCMs},
+      {"BCM_Offset",     fBCM_Offset,       kDouble,(UInt_t) fNumBCMs},
+      {"BCM_Names",     &bcm_namelist,       kString},
+      {"BCM_Current_threshold",     &fbcm_Current_Threshold,       kDouble,0, 1},
+      {"BCM_Current_threshold_index",     &fbcm_Current_Threshold_Index,       kInt,0,1},
+      {0}
+    };
+    fbcm_Current_Threshold = 0.0;
+    fbcm_Current_Threshold_Index = 0;
+    gHcParms->LoadParmValues((DBRequest*)&list2, prefix);
+    vector<string> bcm_names = vsplit(bcm_namelist);
+    fBCM_Name = new char* [fNumBCMs];
+    for(Int_t i=0;i<fNumBCMs;i++) {
+      fBCM_Name[i] = new char[bcm_names[i].length()+1];
+      strcpy(fBCM_Name[i], bcm_names[i].c_str());
+      //    cout << fBCM_Gain[i] << " " << fBCM_Offset[i] << " " << fBCM_Name[i] << endl;
+    }
+    for(Int_t i=0;i<fNumBCMs;i++) {
+      fBCM_delta_charge[i]=0.;
+    }
   }
   fTotalTime=0.;
   fPrevTotalTime=0.;
   fDeltaTime=-1.;
-  for(Int_t i=0;i<fNumBCMs;i++) {
-    fBCM_delta_charge[i]=0.;
-  }
   //
   //
   return kOK;


### PR DESCRIPTION
The new parameter from the database: dc_version fills the fVersion variable for a chamber. By default this is 0 if no parameter is read in from the database. The default, 0, corresponds to a 6 GeV era HMS style chamber. 1 corresponds to a new HMS chamber and 2 corresponds to a new SHMS chamber. This is read in from the database in THcDC.cxx and set for the entire chamber. This variable is then copied down to the plane and can be accessed by fWirePlane->GetVersion(). This variable is the same for all planes. The variable is also only used when correcting the hit times for time propagation along the wire. 