### PR TITLE
Add raw time without reference time subtraction to THcDCHit

### DIFF
--- a/src/THcDCHit.h
+++ b/src/THcDCHit.h
@@ -16,9 +16,9 @@
 class THcDCHit : public TObject {
 
 public:
-  THcDCHit( THcDCWire* wire=NULL, Int_t rawtime=0, Double_t time=0.0,
+  THcDCHit( THcDCWire* wire=NULL, Int_t rawnorefcorrtime=0, Int_t rawtime=0, Double_t time=0.0,
     THcDriftChamberPlane* wp=0) :
-    fWire(wire), fRawTime(rawtime), fTime(time), fWirePlane(wp),
+    fWire(wire), fRawNoRefCorrTime(rawnorefcorrtime), fRawTime(rawtime), fTime(time), fWirePlane(wp),
     fDist(0.0), ftrDist(kBig) {
       if (wire) ConvertTimeToDist();
       fCorrected = 0;
@@ -34,6 +34,7 @@ public:
   THcDCWire* GetWire() const { return fWire; }
   Int_t    GetWireNum() const { return fWire->GetNum(); }
   Int_t    GetRawTime() const { return fRawTime; }
+  Int_t    GetRawNoRefCorrTime() const { return fRawNoRefCorrTime; }
   Double_t GetTime()    const { return fTime; }
   Double_t GetDist()    const { return fDist; }
   Double_t GetPos()     const { return fWire->GetPos(); } //Position of hit wire
@@ -168,7 +169,8 @@ protected:
   static const Double_t kBig;  //!
 
   THcDCWire*  fWire;     // Wire on which the hit occurred
-  Int_t       fRawTime;  // TDC value (channels)
+  Int_t       fRawNoRefCorrTime;  // raw TDC value (channels) 
+  Int_t       fRawTime;  // TDC value (channels) reference time subtracted
   Double_t    fTime;     // Time corrected for time offset of wire (s)
   THcDriftChamberPlane* fWirePlane; //! Pointer to parent wire plane
   Double_t    fDist;     // (Perpendicular) Drift Distance

--- a/src/THcDriftChamberPlane.cxx
+++ b/src/THcDriftChamberPlane.cxx
@@ -268,7 +268,9 @@ Int_t THcDriftChamberPlane::DefineVariables( EMode mode )
   RVarDef vars[] = {
     {"wirenum", "List of TDC wire number",
      "fHits.THcDCHit.GetWireNum()"},
-    {"rawtdc", "Raw TDC Values",
+    {"rawnorefcorrtdc", "Raw TDC Values",
+     "fHits.THcDCHit.GetRawNoRefCorrTime()"},
+    {"rawtdc", "Raw TDC with reference time subtracted Values",
      "fHits.THcDCHit.GetRawTime()"},
     {"time","Drift times",
      "fHits.THcDCHit.GetTime()"},
@@ -348,7 +350,8 @@ Int_t THcDriftChamberPlane::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
     for(UInt_t mhit=0; mhit<hit->GetRawTdcHit().GetNHits(); mhit++) {
       fNRawhits++;
       /* Sort into early, late and ontime */
-      Int_t rawtdc = hit->GetRawTdcHit().GetTime(mhit); // Get the ref time subtracted time
+      Int_t rawnorefcorrtdc = hit->GetRawTdcHit().GetTimeRaw(mhit); // Get the ref time subtracted time
+       Int_t rawtdc = hit->GetRawTdcHit().GetTime(mhit); // Get the ref time subtracted time
       if(rawtdc < fTdcWinMin) {
 	// Increment early counter  (Actually late because TDC is backward)
       } else if (rawtdc > fTdcWinMax) {
@@ -361,7 +364,7 @@ Int_t THcDriftChamberPlane::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
 	//	  - (rawtdc-reftime)*fNSperChan + fPlaneTimeZero;
 	// How do we get this start time from the hodoscope to here
 	// (or at least have it ready by coarse process)
-	new( (*fHits)[nextHit++] ) THcDCHit(wire, rawtdc, time, this);
+	new( (*fHits)[nextHit++] ) THcDCHit(wire, rawnorefcorrtdc,rawtdc, time, this);
 	break;			// Take just the first hit in the time window
       }
     }


### PR DESCRIPTION
Add rawnorefcorrtime to THcDCHit which is the TDC raw without
the reference time subtraction.

Add variable rawnorefcorrtdc in THcDriftChamberPlane::DefineVariables

Modify THcDriftChamberPlane::ProcessHits to call GetRawTdcHit().GetTimeRaw
  and call THcDCHit with new extra argument for raw time without reference time
  subtraction.