### PR TITLE
Suppress missing reference time warnings

### DIFF
--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -191,6 +191,11 @@ THaAnalysisObject::EStatus THcAerogel::Init( const TDatime& date )
   if( (status = THaNonTrackingDetector::Init( date )) )
     return fStatus=status;
 
+  fPresentP = 0;
+  THaVar* vpresent = gHaVars->Find(Form("%s.present",GetApparatus()->GetName()));
+  if(vpresent) {
+    fPresentP = (Bool_t *) vpresent->GetValuePointer();
+  }
   return fStatus = kOK;
 }
 
@@ -565,7 +570,11 @@ void THcAerogel::Clear(Option_t* opt)
 Int_t THcAerogel::Decode( const THaEvData& evdata )
 {
   // Get the Hall C style hitlist (fRawHitList) for this event
-  fNhits = DecodeToHitList(evdata);
+  Bool_t present = kTRUE;	// Suppress reference time warnings
+  if(fPresentP) {		// if this spectrometer not part of trigger
+    present = *fPresentP;
+  }
+  fNhits = DecodeToHitList(evdata, !present);
 
   if (fSixGevData) {
     if(gHaCuts->Result("Pedestal_event")) {

--- a/src/THcAerogel.h
+++ b/src/THcAerogel.h
@@ -40,6 +40,7 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
 
   // Event information
   Int_t fNhits;
+  Bool_t* fPresentP;
 
   // 12 GeV variables
   // Vector/TClonesArray length parameters

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -152,6 +152,11 @@ THaAnalysisObject::EStatus THcCherenkov::Init( const TDatime& date )
   if((status = THaNonTrackingDetector::Init( date )))
     return fStatus=status;
 
+ fPresentP = 0;
+  THaVar* vpresent = gHaVars->Find(Form("%s.present",GetApparatus()->GetName()));
+  if(vpresent) {
+    fPresentP = (Bool_t *) vpresent->GetValuePointer();
+  }
   return fStatus = kOK;
 }
 
@@ -340,7 +345,11 @@ void THcCherenkov::Clear(Option_t* opt)
 Int_t THcCherenkov::Decode( const THaEvData& evdata )
 {
   // Get the Hall C style hitlist (fRawHitList) for this event
-  fNhits = DecodeToHitList(evdata);
+  Bool_t present = kTRUE;	// Suppress reference time warnings
+  if(fPresentP) {		// if this spectrometer not part of trigger
+    present = *fPresentP;
+  }
+  fNhits = DecodeToHitList(evdata, !present);
 
   if(gHaCuts->Result("Pedestal_event")) {
     AccumulatePedestals(fRawHitList);

--- a/src/THcCherenkov.h
+++ b/src/THcCherenkov.h
@@ -43,6 +43,7 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
 
   THcCherenkov();  // for ROOT I/O
  protected:
+  Bool_t*   fPresentP;
   Int_t     fAnalyzePedestals;
   Int_t     fDebugAdc;
   Double_t* fWidth;

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -246,7 +246,12 @@ THaAnalysisObject::EStatus THcDC::Init( const TDatime& date )
   //    { &fLTNhit, &fLANhit, fLT, fLT_c, fLA, fLA_p, fLA_c, fLOff, fLPed, fLGain }
   //  };
   //  memcpy( fDataDest, tmp, NDEST*sizeof(DataDest) );
-
+  
+  fPresentP = 0;
+  THaVar* vpresent = gHaVars->Find(Form("%s.present",GetApparatus()->GetName()));
+  if(vpresent) {
+    fPresentP = (Bool_t *) vpresent->GetValuePointer();
+  }
   return fStatus = kOK;
 }
 
@@ -502,7 +507,12 @@ Int_t THcDC::Decode( const THaEvData& evdata )
   Int_t num_event = evdata.GetEvNum();
   if (fdebugprintrawdc ||fdebugprintdecodeddc || fdebuglinkstubs || fdebugtrackprint) cout << " event num = " << num_event << endl;
   // Get the Hall C style hitlist (fRawHitList) for this event
-  fNhits = DecodeToHitList(evdata);
+
+  Bool_t present = kTRUE;	// Suppress reference time warnings
+  if(fPresentP) {		// if this spectrometer not part of trigger
+    present = *fPresentP;
+  }
+  fNhits = DecodeToHitList(evdata, !present);
 
   if(!gHaCuts->Result("Pedestal_event")) {
     // Let each plane get its hits

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -175,6 +175,10 @@ protected:
   Int_t* fNChamHits;
   Int_t* fPlaneEvents;
 
+  // Pointer to global var indicating whether this spectrometer is triggered
+  // for this event.
+  Bool_t* fPresentP;
+
   // Useful derived quantities
   // double tan_angle, sin_angle, cos_angle;
 

--- a/src/THcHallCSpectrometer.cxx
+++ b/src/THcHallCSpectrometer.cxx
@@ -79,7 +79,7 @@ using namespace std;
 
 //_____________________________________________________________________________
 THcHallCSpectrometer::THcHallCSpectrometer( const char* name, const char* description ) :
-  THaSpectrometer( name, description )
+  THaSpectrometer( name, description ), fPresent(kTRUE)
 {
   // Constructor. Defines the standard detectors for the HRS.
   //  AddDetector( new THaTriggerTime("trg","Trigger-based time offset"));
@@ -87,6 +87,7 @@ THcHallCSpectrometer::THcHallCSpectrometer( const char* name, const char* descri
   //sc_ref = static_cast<THaScintillator*>(GetDetector("s1"));
 
   SetTrSorting(kTRUE);
+  eventtypes.clear();
 }
 
 //_____________________________________________________________________________
@@ -107,6 +108,7 @@ Int_t THcHallCSpectrometer::DefineVariables( EMode mode )
   fIsSetup = ( mode == kDefine );
   RVarDef vars[] = {
     { "tr.betachisq", "Chi2 of beta", "fTracks.THaTrack.GetBetaChi2()"},
+    { "present", "Trigger Type includes this spectrometer", "fPresent"},
     { 0 }
   };
 
@@ -864,6 +866,20 @@ Int_t THcHallCSpectrometer::TrackTimes( TClonesArray* Tracks ) {
   return 0;
 }
 
+Int_t THcHallCSpectrometer::Decode( const THaEvData& evdata )
+{
+
+  fPresent=kTRUE;
+  if(eventtypes.size()!=0) {
+    Int_t evtype = evdata.GetEvType();
+    if(!IsMyEvent(evtype)) {
+      fPresent = kFALSE;
+    }
+  }
+
+  return THaSpectrometer::Decode(evdata);
+}
+
 //_____________________________________________________________________________
 Int_t THcHallCSpectrometer::ReadRunDatabase( const TDatime& date )
 {
@@ -871,6 +887,24 @@ Int_t THcHallCSpectrometer::ReadRunDatabase( const TDatime& date )
   // read in ReadDatabase.
 
   return kOK;
+}
+
+void THcHallCSpectrometer::AddEvtType(int evtype) {
+  eventtypes.push_back(evtype);
+}
+  
+void THcHallCSpectrometer::SetEvtType(int evtype) {
+  eventtypes.clear();
+  AddEvtType(evtype);
+}
+
+Bool_t THcHallCSpectrometer::IsMyEvent(Int_t evtype) const
+{
+  for (UInt_t i=0; i < eventtypes.size(); i++) {
+    if (evtype == eventtypes[i]) return kTRUE;
+  }
+
+  return kFALSE;
 }
 
 //_____________________________________________________________________________

--- a/src/THcHallCSpectrometer.h
+++ b/src/THcHallCSpectrometer.h
@@ -49,6 +49,8 @@ public:
   virtual Int_t   BestTrackUsingPrune();
   virtual Int_t   TrackTimes( TClonesArray* tracks );
 
+  virtual Int_t   Decode( const THaEvData& );
+
   virtual Int_t   ReadRunDatabase( const TDatime& date );
   virtual Int_t  DefineVariables( EMode mode = kDefine );
 
@@ -59,6 +61,13 @@ public:
   Double_t GetParticleMass() const {return fPartMass; }
   Double_t GetBetaAtPcentral() const { return
       fPcentral/TMath::Sqrt(fPcentral*fPcentral+fPartMass*fPartMass);}
+
+  virtual void AddEvtType(int evtype);
+  virtual void SetEvtType(int evtype);
+  virtual Bool_t IsMyEvent(Int_t evtype) const;
+  virtual Int_t GetNumTypes() { return eventtypes.size(); };
+  virtual Bool_t IsPresent() {return fPresent;};
+
 
 protected:
   void InitializeReconstruction();
@@ -139,6 +148,9 @@ protected:
 
   // Flag for fProperties indicating that tracks are to be sorted by chi2
   static const UInt_t kSortTracks = BIT(16);
+
+  std::vector<Int_t> eventtypes;
+  Bool_t fPresent;
 
   ClassDef(THcHallCSpectrometer,0) //A Hall C Spectrometer
 };

--- a/src/THcHitList.cxx
+++ b/src/THcHitList.cxx
@@ -135,7 +135,7 @@ multiple signal types (e.g. ADC+, ADC-, TDC+, TDC-), or multiplehits for multihi
 The hit list is sorted (by plane, counter) after filling.
 
 */
-Int_t THcHitList::DecodeToHitList( const THaEvData& evdata ) {
+Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarnings ) {
 
   // cout << " Clearing TClonesArray " << endl;
   fRawHitList->Clear( );
@@ -235,21 +235,25 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata ) {
 	    Int_t reftime = evdata.GetData(d->crate, d->slot, d->refchan, 0);
 	    rawhit->SetReference(signal, reftime);
 	  } else {
-	    cout << "HitList(event=" << evdata.GetEvNum() << "): refchan " << d->refchan <<
-	      " missing for (" << d->crate << ", " << d->slot <<
-	      ", " << chan << ")" << endl;
+	    if(!suppresswarnings) {
+	      cout << "HitList(event=" << evdata.GetEvNum() << "): refchan " << d->refchan <<
+		" missing for (" << d->crate << ", " << d->slot <<
+		", " << chan << ")" << endl;
+	    }
 	  }
 	} else {
 	  if(d->refindex >=0 && d->refindex < fNRefIndex) {
 	    if(fRefIndexMaps[d->refindex].hashit) {
 	      rawhit->SetReference(signal, fRefIndexMaps[d->refindex].reftime);
 	    } else {
-	      cout << "HitList(event=" << evdata.GetEvNum() << "): refindex " << d->refindex <<
-          " (" << fRefIndexMaps[d->refindex].crate <<
-          ", " << fRefIndexMaps[d->refindex].slot <<
-          ", " << fRefIndexMaps[d->refindex].channel << ")" <<
-		" missing for (" << d->crate << ", " << d->slot <<
-		", " << chan << ")" << endl;
+	      if(!suppresswarnings) {
+		cout << "HitList(event=" << evdata.GetEvNum() << "): refindex " << d->refindex <<
+		  " (" << fRefIndexMaps[d->refindex].crate <<
+		  ", " << fRefIndexMaps[d->refindex].slot <<
+		  ", " << fRefIndexMaps[d->refindex].channel << ")" <<
+		  " missing for (" << d->crate << ", " << d->slot <<
+		  ", " << chan << ")" << endl;
+	      }
 	    }
 	  }
 	}

--- a/src/THcHitList.h
+++ b/src/THcHitList.h
@@ -28,7 +28,7 @@ public:
 
   THcHitList();
 
-  virtual Int_t DecodeToHitList( const THaEvData& );
+  virtual Int_t DecodeToHitList( const THaEvData&, Bool_t suppress=kFALSE );
   void          InitHitList(THaDetMap* detmap,
 			    const char *hitclass, Int_t maxhits);
 

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -197,8 +197,11 @@ THaAnalysisObject::EStatus THcHodoscope::Init( const TDatime& date )
     fScinHitPaddle.push_back(std::vector<Int_t>(fNPaddle[ip], 0));
   }
 
-
-
+  fPresentP = 0;
+  THaVar* vpresent = gHaVars->Find(Form("%s.present",GetApparatus()->GetName()));
+  if(vpresent) {
+    fPresentP = (Bool_t *) vpresent->GetValuePointer();
+  }
 
   return fStatus = kOK;
 }
@@ -590,7 +593,11 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
    */
   ClearEvent();
   // Get the Hall C style hitlist (fRawHitList) for this event
-  fNHits = DecodeToHitList(evdata);
+  Bool_t present = kTRUE;	// Suppress reference time warnings
+  if(fPresentP) {		// if this spectrometer not part of trigger
+    present = *fPresentP;
+  }
+  fNHits = DecodeToHitList(evdata, !present);
 
   //
   // GN: print event number so we can cross-check with engine

--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -132,6 +132,7 @@ protected:
   Double_t fStartTime;
   Double_t fFPTimeAll;
   Int_t fNfptimes;
+  Bool_t* fPresentP;
 
   Double_t     fBeta;
 

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -177,6 +177,11 @@ THaAnalysisObject::EStatus THcShower::Init( const TDatime& date )
   //      <<  GetName() << endl;
   // cout << "---------------------------------------------------------------\n";
 
+  fPresentP = 0;
+  THaVar* vpresent = gHaVars->Find(Form("%s.present",GetApparatus()->GetName()));
+  if(vpresent) {
+    fPresentP = (Bool_t *) vpresent->GetValuePointer();
+  }
   return fStatus = kOK;
 }
 
@@ -626,7 +631,11 @@ Int_t THcShower::Decode( const THaEvData& evdata )
   Clear();
 
   // Get the Hall C style hitlist (fRawHitList) for this event
-  Int_t nhits = DecodeToHitList(evdata);
+  Bool_t present = kTRUE;	// Suppress reference time warnings
+  if(fPresentP) {		// if this spectrometer not part of trigger
+    present = *fPresentP;
+  }
+  Int_t nhits = DecodeToHitList(evdata, !present);
   
   fEvent = evdata.GetEvNum();
 

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -145,6 +145,7 @@ public:
 
 protected:
 
+  Bool_t* fPresentP;
   Int_t fEvent;
   Int_t fADCMode;		//   != 0 if using FADC 
    //  1 == Use the pulse int - pulse ped


### PR DESCRIPTION
Coincidence data files may include prescaled singles events.  For a singles event for a given spectrometer, the other spectrometer's modules will still be gated and read out.  However, the reference times for that other spectrometer will typically not be present.  The decoder (DecodeToHitList) will print warning messages for missing reference times.   These can be avoided by telling each spectrometer object which event types should include data from that spectrometer.  When a spectrometer "X" is not expected to have data (as determined by the event type), the global variable X.present will be false.  Each detector class looks at this variable and suppresses the decoder warnings when it is false.

As an example, if "HMS" is the THcHallCSpectrometer object for the high momentum spectrometer and event type 1 is a coincidence event and event type 3 is an HMS singles event, then this warning suppression is setup with:

HMS->AddEvtType(1);
HMS->AddEvtType(3);

If no event types are added for the spectrometer, then all missing reference time warnings are printed.