### PR TITLE
Modify detector classes

### DIFF
--- a/src/THcAerogel.h
+++ b/src/THcAerogel.h
@@ -11,6 +11,7 @@
 #include "THaNonTrackingDetector.h"
 #include "THcHitList.h"
 #include "THcAerogelHit.h"
+class THcHodoscope;
 
 class THcAerogel : public THaNonTrackingDetector, public THcHitList {
 
@@ -113,11 +114,13 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   vector<Double_t> fGoodPosAdcPulseIntRaw;
   vector<Double_t> fGoodPosAdcPulseAmp;
   vector<Double_t> fGoodPosAdcPulseTime;
+  vector<Double_t> fGoodPosAdcTdcDiffTime;
   vector<Double_t> fGoodNegAdcPed;
   vector<Double_t> fGoodNegAdcPulseInt;
   vector<Double_t> fGoodNegAdcPulseIntRaw;
   vector<Double_t> fGoodNegAdcPulseAmp;
   vector<Double_t> fGoodNegAdcPulseTime;
+ vector<Double_t> fGoodNegAdcTdcDiffTime;
 
   // 6 GeV era variables
   Int_t     fAnalyzePedestals;
@@ -166,6 +169,7 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
 
   void Setup(const char* name, const char* description);
   virtual void  InitializePedestals( );
+ THcHodoscope* fglHod;		// Hodoscope to get start time
 
   ClassDef(THcAerogel,0)   // Generic aerogel class
 }

--- a/src/THcCherenkov.h
+++ b/src/THcCherenkov.h
@@ -11,6 +11,7 @@
 #include "THaNonTrackingDetector.h"
 #include "THcHitList.h"
 #include "THcCherenkovHit.h"
+class THcHodoscope;
 
 class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
 
@@ -65,6 +66,7 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   vector<Double_t> fGoodAdcPulseIntRaw;
   vector<Double_t> fGoodAdcPulseAmp;
   vector<Double_t> fGoodAdcPulseTime;
+  vector<Double_t> fGoodAdcTdcDiffTime;
   vector<Double_t> fNpe;
 
   Int_t     fNRegions;
@@ -110,6 +112,7 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
 
   void Setup(const char* name, const char* description);
   virtual void  InitializePedestals( );
+ THcHodoscope* fglHod;		// Hodoscope to get start time
 
   ClassDef(THcCherenkov,0)        // Generic cherenkov class
 };

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -741,13 +741,11 @@ void THcHodoscope::EstimateFocalPlaneTime( void )
 	  - (fPlanes[ip]->GetZpos()+(index%2)*fPlanes[ip]->GetDzpos())
 	  / (29.979 * fBetaNominal);
 	}
-	if(TMath::Abs(fptime-fStartTimeCenter)<=fStartTimeSlop) {
           Ngood_hits_plane++;
 	  Plane_fptime_sum+=fptime;
 	  fpTimeSum += fptime;
 	  fNfptimes++;
 	  goodplanetime[ip] = kTRUE;
-	}
       } else {
 	hit->SetTwoGoodTimes(kFALSE);
       }

--- a/src/THcScintillatorPlane.h
+++ b/src/THcScintillatorPlane.h
@@ -145,6 +145,9 @@ class THcScintillatorPlane : public THaSubDetector {
 
   vector<Double_t>  fGoodPosAdcPulseTime;
   vector<Double_t>  fGoodNegAdcPulseTime;
+ 
+  vector<Double_t>  fGoodPosAdcTdcDiffTime;
+  vector<Double_t>  fGoodNegAdcTdcDiffTime;
 
   //Hodoscopoe "GOOD" TDC Variables
   vector<Double_t>  fGoodPosTdcTimeUnCorr;

--- a/src/THcShowerArray.h
+++ b/src/THcShowerArray.h
@@ -27,6 +27,7 @@
 
 class THaEvData;
 class THaSignalHit;
+class THcHodoscope;
 
 class THcShowerArray : public THaSubDetector {
 
@@ -113,6 +114,7 @@ protected:
   vector<Double_t>      fGoodAdcPulseInt;       // [fNelem] good pedestal subtracted pulse integrals
   vector<Double_t>      fGoodAdcPulseAmp;
   vector<Double_t>      fGoodAdcPulseTime;
+  vector<Double_t>      fGoodAdcTdcDiffTime;
 
   vector<Double_t>      fE;                    //[fNelem] energy deposition in shower blocks
 
@@ -208,6 +210,7 @@ protected:
 
   virtual Int_t  ReadDatabase( const TDatime& date );
   virtual Int_t  DefineVariables( EMode mode = kDefine );
+ THcHodoscope* fglHod;		// Hodoscope to get start time
   ClassDef(THcShowerArray,0); // Fly;s Eye calorimeter array
 };
 

--- a/src/THcShowerPlane.h
+++ b/src/THcShowerPlane.h
@@ -24,6 +24,7 @@ using namespace std;
 
 class THaEvData;
 class THaSignalHit;
+class THcHodoscope;
 
 class THcShowerPlane : public THaSubDetector {
 
@@ -153,11 +154,13 @@ protected:
   vector<Double_t>      fGoodPosAdcPulseInt;
   vector<Double_t>      fGoodPosAdcPulseAmp;
   vector<Double_t>      fGoodPosAdcPulseTime;
+  vector<Double_t>      fGoodPosAdcTdcDiffTime;
 
   vector<Double_t>      fGoodNegAdcPed;
   vector<Double_t>      fGoodNegAdcPulseInt;
   vector<Double_t>      fGoodNegAdcPulseAmp;
   vector<Double_t>      fGoodNegAdcPulseTime;
+ vector<Double_t>       fGoodNegAdcTdcDiffTime;
 
   vector<Double_t>      fGoodPosAdcPulseIntRaw;
   vector<Double_t>      fGoodNegAdcPulseIntRaw;
@@ -237,6 +240,8 @@ protected:
   vector<Int_t> fStatNumHit;
   Int_t fTotStatNumTrk;
   Int_t fTotStatNumHit;
+
+ THcHodoscope* fglHod;		// Hodoscope to get start time
   
   ClassDef(THcShowerPlane,0); // Calorimeter bars in a plane
 };


### PR DESCRIPTION
Modify THcHodoscope::EstimateFocalPlaneTime
Eliminate cut on fStartTimeCenter in selecting good
  focal plane times.

Modify THcScintillatorPlane
Have variables fGoodPosAdcTdcDiffTime and fGoodNegAdcTdcDiffTime
which are the difference
between TDC time and ADC pulse time

Replace ADC pulse time cut with cut on difference
between TDC time and ADC pulse time to select
good ADC pulse.

Modify Aerogel, Cherenkov, ShowerArray and ShowerPlane
Add variable for the difference between the Hodoscope start time
and the ADC pulse time.

Select good adc hit based on window on this difference