### PR TITLE
Add _ti_ps_factors[] array with prescale factors computed from exponents

### DIFF
--- a/src/THcConfigEvtHandler.cxx
+++ b/src/THcConfigEvtHandler.cxx
@@ -233,11 +233,20 @@ void THcConfigEvtHandler::MakeParms(Int_t roc)
 	Int_t sync_count = cinfo->TI.sync_count;
 	gHcParms->Define(Form("g%s_ti_sync_count",fName.Data()),"Number of Pedestal events",sync_count);
 
-	Int_t *prescales = new Int_t[cinfo->TI.num_prescales];
+	Int_t *ps_exps = new Int_t[cinfo->TI.num_prescales];
+	Int_t *ps_factors = new Int_t[cinfo->TI.num_prescales];
 	for(Int_t i=0;i<cinfo->TI.num_prescales;i++) {
-	  prescales[i] = cinfo->TI.prescales[i];
+	  ps_exps[i] = cinfo->TI.prescales[i];
+	  if(ps_exps[i] > 0) {
+	    ps_factors[i] = 1<<(ps_exps[i]-1) + 1;
+	  } else if (ps_exps[i] == 0) {
+	    ps_factors[i] = 1;
+	  } else {
+	    ps_factors[i] = -1;
+	  }
 	}
-	gHcParms->Define(Form("g%s_ti_ps[%d]",fName.Data(),cinfo->TI.num_prescales),"TI Event Prescaler settings",*prescales);
+	gHcParms->Define(Form("g%s_ti_ps[%d]",fName.Data(),cinfo->TI.num_prescales),"TI Event Prescaler settings",*ps_exps);
+	gHcParms->Define(Form("g%s_ti_ps_factors[%d]",fName.Data(),cinfo->TI.num_prescales),"TI Event Prescaler settings",*ps_exps);
       }
     }
     it++;

--- a/src/THcConfigEvtHandler.cxx
+++ b/src/THcConfigEvtHandler.cxx
@@ -238,15 +238,15 @@ void THcConfigEvtHandler::MakeParms(Int_t roc)
 	for(Int_t i=0;i<cinfo->TI.num_prescales;i++) {
 	  ps_exps[i] = cinfo->TI.prescales[i];
 	  if(ps_exps[i] > 0) {
-	    ps_factors[i] = 1<<(ps_exps[i]-1) + 1;
+	    ps_factors[i] = (1<<(ps_exps[i]-1)) + 1;
 	  } else if (ps_exps[i] == 0) {
 	    ps_factors[i] = 1;
 	  } else {
 	    ps_factors[i] = -1;
 	  }
 	}
-	gHcParms->Define(Form("g%s_ti_ps[%d]",fName.Data(),cinfo->TI.num_prescales),"TI Event Prescaler settings",*ps_exps);
-	gHcParms->Define(Form("g%s_ti_ps_factors[%d]",fName.Data(),cinfo->TI.num_prescales),"TI Event Prescaler settings",*ps_exps);
+	gHcParms->Define(Form("g%s_ti_ps[%d]",fName.Data(),cinfo->TI.num_prescales),"TI Event Prescale Internal Value",*ps_exps);
+	gHcParms->Define(Form("g%s_ti_ps_factors[%d]",fName.Data(),cinfo->TI.num_prescales),"TI Event Prescale Factor",*ps_factors);
       }
     }
     it++;


### PR DESCRIPTION
Compute a array of prescale factors that can be used to scale up rates of prescaled things.  Should be tested before merging.