### PR TITLE
THcHitlist finds THcConfigEvtHandler (Event 125) by type instead of name

### DIFF
--- a/src/THcConfigEvtHandler.cxx
+++ b/src/THcConfigEvtHandler.cxx
@@ -354,6 +354,8 @@ THaAnalysisObject::EStatus THcConfigEvtHandler::Init(const TDatime& date)
     eventtypes.push_back(125);  // what events to look for
   }
 
+  CrateInfoMap.clear();
+
   fStatus = kOK;
   return kOK;
 }

--- a/src/THcHitList.h
+++ b/src/THcHitList.h
@@ -60,6 +60,10 @@ protected:
   THcRawHit::ESignalType *fSignalTypes;
 
   THcConfigEvtHandler* fPSE125;
+  Bool_t fHaveFADCInfo;
+  Int_t fNSA;
+  Int_t fNSB;
+  Int_t fNPED;
 
   ClassDef(THcHitList,0);  // List of raw hits sorted by plane, counter
 };


### PR DESCRIPTION
  The Event handler can now be given any name.
    (Only one THcConfigEvtHandler should be instatiated.)
  Also:
     THcConfigEventHandler clears CrateInfoMap on Init.
     THcHitList caches FADC config on first event