### PR TITLE
Primary and Secondary Kinematics

### DIFF
--- a/src/THcExtTarCor.cxx
+++ b/src/THcExtTarCor.cxx
@@ -131,24 +131,24 @@ Int_t THcExtTarCor::Process( const THaEvData& )
   Double_t xtar_new=vertex[1];
   TClonesArray* tracks = spectro->GetTracks();
   if( !tracks ){
-  return -2;
+    return -2;
   }
   for( Int_t i = 0; i<ntracks; i++ ) {
-   THaTrack* theTrack = static_cast<THaTrack*>( tracks->At(i) );
+    THaTrack* theTrack = static_cast<THaTrack*>( tracks->At(i) );
     if( theTrack == spectro->GetGoldenTrack() ) {
 
-  // Calculate corrections & recalculate track parameters
-  Double_t x_tg = vertex[1];
-  spectro->CalculateTargetQuantities(theTrack,x_tg,xptar,ytar,yptar,delta);
-  p  = spectro->GetPcentral() * ( 1.0+delta );
-  spectro->TransportToLab( p, xptar, yptar, pvect );
-  Double_t theta=spectro->GetThetaSph();
-  xtar_new = x_tg - xptar*ztarg*cos(theta);
-  // Get a second-iteration value for x_tg based on the 
-  spectro->CalculateTargetQuantities(theTrack,xtar_new,xptar,ytar,yptar,delta);
-  fDeltaDp = delta*100 -theTrack->GetDp();
-  fDeltaP = p - theTrack->GetP();
-  fDeltaTh = xptar -  theTrack->GetTTheta();
+      // Calculate corrections & recalculate track parameters
+      Double_t x_tg = vertex[1];
+      spectro->CalculateTargetQuantities(theTrack,x_tg,xptar,ytar,yptar,delta);
+      p  = spectro->GetPcentral() * ( 1.0+delta );
+      spectro->TransportToLab( p, xptar, yptar, pvect );
+      Double_t theta=spectro->GetThetaSph();
+      xtar_new = x_tg - xptar*ztarg*cos(theta);
+      // Get a second-iteration value for x_tg based on the 
+      spectro->CalculateTargetQuantities(theTrack,xtar_new,xptar,ytar,yptar,delta);
+      fDeltaDp = delta*100 -theTrack->GetDp();
+      fDeltaP = p - theTrack->GetP();
+      fDeltaTh = xptar -  theTrack->GetTTheta();
     }
   }
  // Save results in our TrackInfo

--- a/src/THcPrimaryKine.h
+++ b/src/THcPrimaryKine.h
@@ -11,7 +11,7 @@
 #include "TLorentzVector.h"
 #include "TString.h"
 
-class THaTrackingModule;
+class THcHallCSpectrometer;
 class THaBeamModule;
 typedef TLorentzVector FourVect;
 
@@ -80,12 +80,13 @@ protected:
   Double_t          fM;            // Mass of incident particle (GeV/c^2)
   Double_t          fMA;           // Target mass (GeV/c^2)
   Double_t          fMA_amu;           // Target mass (amu)
+  Double_t          fOopCentralOffset; // Out plane offset of spectrometer
 
   virtual Int_t DefineVariables( EMode mode = kDefine );
 
   TString                 fSpectroName;  // Name of spectrometer to consider
   TString                 fBeamName;     // Name of beam position apparatus
-  THaTrackingModule*      fSpectro;      // Pointer to spectrometer object
+  THcHallCSpectrometer*   fSpectro;      // Pointer to spectrometer object
   THaBeamModule*          fBeam;         // Pointer to beam position apparatus
 
   ClassDef(THcPrimaryKine,0)   //Single arm kinematics module

--- a/src/THcSecondaryKine.cxx
+++ b/src/THcSecondaryKine.cxx
@@ -6,7 +6,7 @@
 
 #include "THcPrimaryKine.h"
 #include "THcSecondaryKine.h"
-#include "THaTrackingModule.h"
+#include "THcHallCSpectrometer.h"
 #include "THcGlobals.h"
 #include "THcParmList.h"
 #include "VarDef.h"
@@ -82,8 +82,10 @@ Int_t THcSecondaryKine::DefineVariables( EMode mode )
     { "pmiss_x",  "x-component of p_miss wrt q (GeV)", "fPmiss_x" },
     { "pmiss_y",  "y-component of p_miss wrt q (GeV)", "fPmiss_y" },
     { "pmiss_z",  "z-component of p_miss, along q (GeV)", "fPmiss_z" },
-    { "emiss",    "Missing energy (GeV), nuclear physics definition "
-                  "omega-Tx-Tb", "fEmiss" },
+    { "emiss_nuc",    "Missing energy (GeV), nuclear physics definition "
+                  "omega-Tx-Tb", "fEmiss_nuc" },
+    { "emiss",    "Missing energy (GeV), ENGINE definition "
+                  "omega-Mt-Ex", "fEmiss" },
     { "Mrecoil",  "Invariant mass of recoil system (GeV)", "fMrecoil" },
     { "Erecoil",  "Total energy of recoil system (GeV)", "fErecoil" },
     { "Prec_x",   "x-component of recoil system in lab (GeV/c)", "fB.X()" },
@@ -118,22 +120,34 @@ THaAnalysisObject::EStatus THcSecondaryKine::Init( const TDatime& run_time )
   // Standard initialization. Calls this object's DefineVariables().
   
   //  cout << "*************&&&&&&&&&&&&&&************" << endl;
-  //cout << "In THcSecondaryKine::Init() " << endl;
+  //  cout << "In THcSecondaryKine::Init() " << endl;
 
-  if( THaPhysicsModule::Init( run_time ) != kOK )
+  fStatus = kOK;
+
+  fSpectro = dynamic_cast<THcHallCSpectrometer*>
+    ( FindModule( fSpectroName.Data(), "THcHallCSpectrometer"));
+  if( !fSpectro ) {
+    fStatus = kInitError;
     return fStatus;
-
-
-  fSpectro = dynamic_cast<THaTrackingModule*>
-    ( FindModule( fSpectroName.Data(), "THaTrackingModule"));
-  if( fStatus ) return fStatus;
+  }
 
   fPrimary = dynamic_cast<THcPrimaryKine*>
     ( FindModule( fPrimaryName.Data(), "THcPrimaryKine"));
+  if(!fPrimary) {
+    fStatus = kInitError;
+    return fStatus;
+  }
+
+  //Get secondary particle mass
+  fMX = dynamic_cast <THcHallCSpectrometer*> (fSpectro)->GetParticleMass();
+  cout << "particleMASS: " << fMX << endl; 
+
+
+  if( (fStatus=THaPhysicsModule::Init( run_time )) != kOK ) {
+    return fStatus;
+  }
+
   return fStatus;
-
-
-
 }
 
 //_____________________________________________________________________________
@@ -145,7 +159,7 @@ Int_t THcSecondaryKine::Process( const THaEvData& )
   if( !IsOK() ) return -1;
 
   //Get secondary particle mass
-  fMX = dynamic_cast <THcHallCSpectrometer*> (fSpectro)->GetParticleMass();
+  //fMX = dynamic_cast <THcHallCSpectrometer*> (fSpectro)->GetParticleMass();
 
   // Tracking information from the secondary spectrometer
   THaTrackInfo* trkifo = fSpectro->GetTrackInfo();
@@ -155,9 +169,12 @@ Int_t THcSecondaryKine::Process( const THaEvData& )
   if( !fPrimary->DataValid() ) return 2;
 
   // Measured momentum of secondary particle X in lab
-  const TVector3& pX3 = trkifo->GetPvect();
+  Double_t xptar = trkifo->GetTheta() + fOopCentralOffset;
+  TVector3 pvect;
+  fSpectro->TransportToLab(trkifo->GetP(), xptar, trkifo->GetPhi(), pvect);
+
   // 4-momentum of X
-  fX.SetVectM( pX3, fMX );
+  fX.SetVectM( pvect, fMX );
 
   // 4-momenta of the the primary interaction
   const TLorentzVector* pA  = fPrimary->GetA();  // Initial target
@@ -213,7 +230,9 @@ Int_t THcSecondaryKine::Process( const THaEvData& )
   // NB: If X is knocked out of a lower shell, the recoil system carries
   // a significant excitation energy. This excitation is included in Emiss
   // here, as it should, since it results from the binding of X.
-  fEmiss = omega - fTX - fTB;
+  fEmiss_nuc = omega - fTX - fTB;
+  // Target Mass + Beam Energy - scatt ele energy - hadron total energy
+  fEmiss = omega + pA->M() - fX.E();
 
   // In production reactions, the "missing energy" is defined 
   // as the total energy of the undetected recoil system.
@@ -274,31 +293,19 @@ Int_t THcSecondaryKine::Process( const THaEvData& )
 Int_t THcSecondaryKine::ReadDatabase( const TDatime& date )
 {
   // cout << "In THcSecondaryKine::ReadDatabase() " << endl;
-  // cout << "particleMASS: " << fMX << endl; 
-// Query the run database for any parameters of the module that were not
-  // set by the constructor. This module has only one parameter,
-  // the mass of the detected secondary particle X.
-  //
-  // First searches for "<prefix>.MX", then, if not found, for "MX".
-  // If still not found, use proton mass.
-  /*
-  Int_t err = THaPhysicsModule::ReadRunDatabase( date );
-  if( err ) return err;
 
-  FILE* f = OpenRunDBFile( date );
-  if( !f ) return kFileError;
+  char prefix[2];
 
-  if ( fMX <= 0.0 ) { 
-    TString name(fPrefix), tag("MX"); name += tag;
-    Int_t st = LoadDBvalue( f, date, name.Data(), fMX );
-    if( st )
-      LoadDBvalue( f, date, tag.Data(), fMX );
-    if( fMX <= 0.0 ) fMX = 0.938;
-  }
-  fclose(f);
-  return 0;
-  */
-  //fMX = 0.938;
+  prefix[0] = tolower(GetName()[0]);
+  prefix[1] = '\0';
+
+  fOopCentralOffset = 0.0;
+  DBRequest list[]={
+    {"_oopcentral_offset",&fOopCentralOffset,kDouble, 0, 1},
+    {0}
+  };
+  gHcParms->LoadParmValues((DBRequest*)&list,prefix);
+  
   return kOK;
 }
   

--- a/src/THcSecondaryKine.h
+++ b/src/THcSecondaryKine.h
@@ -12,7 +12,7 @@
 #include "TLorentzVector.h"
 #include "TString.h"
 
-class THaTrackingModule;
+class THcHallCSpectrometer;
 typedef TLorentzVector FourVect;
 
 class THcSecondaryKine : public THaPhysicsModule {
@@ -81,7 +81,8 @@ public:
   Double_t fPmiss_x;    // x-component of p_miss wrt q (GeV)
   Double_t fPmiss_y;    // y-component of p_miss wrt q (GeV)
   Double_t fPmiss_z;    // z-component of p_miss, along q (GeV)
-  Double_t fEmiss;      // Missing energy (GeV), nuclear physics definition omega-Tx-Tb
+  Double_t fEmiss_nuc;      // Missing energy (GeV), nuclear physics definition omega-Tx-Tb
+  Double_t fEmiss; // Missing energy (GeV), correct definition omega+Mt-Ex
   Double_t fMrecoil;    // Invariant mass of recoil system (GeV)
   Double_t fErecoil;    // Total energy of recoil system (GeV)
   Double_t fTX;         // Kinetic energy of detected particle (GeV)
@@ -103,9 +104,10 @@ public:
 
   // Parameters
   Double_t fMX;         // Mass of secondary particle (GeV)
+  Double_t fOopCentralOffset; //Offset of central out-of-plane angle (rad)
 
   TString            fSpectroName;  // Name of spectrometer for secondary particle
-  THaTrackingModule* fSpectro;      // Pointer to spectrometer object
+  THcHallCSpectrometer* fSpectro;   // Pointer to spectrometer object
   TString            fPrimaryName;  // Name of module for primary interaction kinematics
   THcPrimaryKine*    fPrimary;      // Pointer to primary kinematics module
 


### PR DESCRIPTION
Mofified THcPrimaryKine and THcSecondaryKine to apply the p_oopcentral_offset and h_oopcentral_offset values to xptar before computing kinematics quantities.

Replace the emiss calculation with the calculation used in ENGINE (beam energy + target mass - energy of detected particles). The previous emiss definition is renamed to emiss_nuc.