### PR TITLE
Primary and Secondary Kinematics

### DIFF
--- a/src/THcExtTarCor.cxx
+++ b/src/THcExtTarCor.cxx
@@ -131,24 +131,24 @@ Int_t THcExtTarCor::Process( const THaEvData& )
   Double_t xtar_new=vertex[1];
   TClonesArray* tracks = spectro->GetTracks();
   if( !tracks ){
-  return -2;
+    return -2;
   }
   for( Int_t i = 0; i<ntracks; i++ ) {
-   THaTrack* theTrack = static_cast<THaTrack*>( tracks->At(i) );
+    THaTrack* theTrack = static_cast<THaTrack*>( tracks->At(i) );
     if( theTrack == spectro->GetGoldenTrack() ) {
 
-  // Calculate corrections & recalculate track parameters
-  Double_t x_tg = vertex[1];
-  spectro->CalculateTargetQuantities(theTrack,x_tg,xptar,ytar,yptar,delta);
-  p  = spectro->GetPcentral() * ( 1.0+delta );
-  spectro->TransportToLab( p, xptar, yptar, pvect );
-  Double_t theta=spectro->GetThetaSph();
-  xtar_new = x_tg - xptar*ztarg*cos(theta);
-  // Get a second-iteration value for x_tg based on the 
-  spectro->CalculateTargetQuantities(theTrack,xtar_new,xptar,ytar,yptar,delta);
-  fDeltaDp = delta*100 -theTrack->GetDp();
-  fDeltaP = p - theTrack->GetP();
-  fDeltaTh = xptar -  theTrack->GetTTheta();
+      // Calculate corrections & recalculate track parameters
+      Double_t x_tg = vertex[1];
+      spectro->CalculateTargetQuantities(theTrack,x_tg,xptar,ytar,yptar,delta);
+      p  = spectro->GetPcentral() * ( 1.0+delta );
+      spectro->TransportToLab( p, xptar, yptar, pvect );
+      Double_t theta=spectro->GetThetaSph();
+      xtar_new = x_tg - xptar*ztarg*cos(theta);
+      // Get a second-iteration value for x_tg based on the 
+      spectro->CalculateTargetQuantities(theTrack,xtar_new,xptar,ytar,yptar,delta);
+      fDeltaDp = delta*100 -theTrack->GetDp();
+      fDeltaP = p - theTrack->GetP();
+      fDeltaTh = xptar -  theTrack->GetTTheta();
     }
   }
  // Save results in our TrackInfo

--- a/src/THcPrimaryKine.h
+++ b/src/THcPrimaryKine.h
@@ -11,7 +11,7 @@
 #include "TLorentzVector.h"
 #include "TString.h"
 
-class THaTrackingModule;
+class THcHallCSpectrometer;
 class THaBeamModule;
 typedef TLorentzVector FourVect;
 
@@ -80,12 +80,13 @@ protected:
   Double_t          fM;            // Mass of incident particle (GeV/c^2)
   Double_t          fMA;           // Target mass (GeV/c^2)
   Double_t          fMA_amu;           // Target mass (amu)
+  Double_t          fOopCentralOffset; // Out plane offset of spectrometer
 
   virtual Int_t DefineVariables( EMode mode = kDefine );
 
   TString                 fSpectroName;  // Name of spectrometer to consider
   TString                 fBeamName;     // Name of beam position apparatus
-  THaTrackingModule*      fSpectro;      // Pointer to spectrometer object
+  THcHallCSpectrometer*   fSpectro;      // Pointer to spectrometer object
   THaBeamModule*          fBeam;         // Pointer to beam position apparatus
 
   ClassDef(THcPrimaryKine,0)   //Single arm kinematics module

--- a/src/THcSecondaryKine.h
+++ b/src/THcSecondaryKine.h
@@ -12,7 +12,7 @@
 #include "TLorentzVector.h"
 #include "TString.h"
 
-class THaTrackingModule;
+class THcHallCSpectrometer;
 typedef TLorentzVector FourVect;
 
 class THcSecondaryKine : public THaPhysicsModule {
@@ -81,7 +81,8 @@ public:
   Double_t fPmiss_x;    // x-component of p_miss wrt q (GeV)
   Double_t fPmiss_y;    // y-component of p_miss wrt q (GeV)
   Double_t fPmiss_z;    // z-component of p_miss, along q (GeV)
-  Double_t fEmiss;      // Missing energy (GeV), nuclear physics definition omega-Tx-Tb
+  Double_t fEmiss_nuc;      // Missing energy (GeV), nuclear physics definition omega-Tx-Tb
+  Double_t fEmiss; // Missing energy (GeV), correct definition omega+Mt-Ex
   Double_t fMrecoil;    // Invariant mass of recoil system (GeV)
   Double_t fErecoil;    // Total energy of recoil system (GeV)
   Double_t fTX;         // Kinetic energy of detected particle (GeV)
@@ -103,9 +104,10 @@ public:
 
   // Parameters
   Double_t fMX;         // Mass of secondary particle (GeV)
+  Double_t fOopCentralOffset; //Offset of central out-of-plane angle (rad)
 
   TString            fSpectroName;  // Name of spectrometer for secondary particle
-  THaTrackingModule* fSpectro;      // Pointer to spectrometer object
+  THcHallCSpectrometer* fSpectro;   // Pointer to spectrometer object
   TString            fPrimaryName;  // Name of module for primary interaction kinematics
   THcPrimaryKine*    fPrimary;      // Pointer to primary kinematics module
 


### PR DESCRIPTION
Mofified THcPrimaryKine and THcSecondaryKine to apply the p_oopcentral_offset and h_oopcentral_offset values to xptar before computing kinematics quantities.

Replace the emiss calculation with the calculation used in ENGINE (beam energy + target mass - energy of detected particles). The previous emiss definition is renamed to emiss_nuc.