### PR TITLE
Improve suppression of missing reference time messages in THcTrigDet

### DIFF
--- a/src/THcTrigDet.cxx
+++ b/src/THcTrigDet.cxx
@@ -218,8 +218,12 @@ void THcTrigDet::Clear(Option_t* opt) {
 
 Int_t THcTrigDet::Decode(const THaEvData& evData) {
   // Decode raw data for this event.
-  Bool_t present = kTRUE;	// Suppress reference time warnings
-  if(fPresentP) {		// if this spectrometer not part of trigger
+  Bool_t present = kTRUE;	// Don't suppress reference time warnings
+  if(HaveIgnoreList()) {
+    if(IsIgnoreType(evData.GetEvType())) {
+      present = kFALSE;
+    }
+  } else if(fPresentP) {		// if this spectrometer not part of trigger
     present = *fPresentP;
   }
   Int_t numHits = DecodeToHitList(evData, !present);
@@ -445,6 +449,26 @@ void THcTrigDet::SetSpectName( const char* name)
   fSpectName = name;
 }
 
+void THcTrigDet::AddEvtType(int evtype) {
+  eventtypes.push_back(evtype);
+}
+  
+void THcTrigDet::SetEvtType(int evtype) {
+  eventtypes.clear();
+  AddEvtType(evtype);
+}
 
+Bool_t THcTrigDet::IsIgnoreType(Int_t evtype) const
+{
+  for (UInt_t i=0; i < eventtypes.size(); i++) {
+    if (evtype == eventtypes[i]) return kTRUE;
+  }
+  return kFALSE; 
+}
+
+Bool_t THcTrigDet::HaveIgnoreList() const
+{
+  return( (eventtypes.size()>0) ? kTRUE : kFALSE);
+}
 
 ClassImp(THcTrigDet)

--- a/src/THcTrigDet.h
+++ b/src/THcTrigDet.h
@@ -27,6 +27,10 @@ class THcTrigDet : public THaDetector, public THcHitList {
     Int_t Decode(const THaEvData& evData);
 
     virtual void SetSpectName( const char* name);
+    virtual void AddEvtType(int evtype);
+    virtual void SetEvtType(int evtype);
+    virtual Bool_t IsIgnoreType(Int_t evtype) const;
+    virtual Bool_t HaveIgnoreList() const;
 
   protected:
     void Setup(const char* name, const char* description);
@@ -65,6 +69,7 @@ class THcTrigDet : public THaDetector, public THcHitList {
     Int_t fAdcMultiplicity[fMaxAdcChannels];
 
     TString fSpectName;
+    std::vector<Int_t> eventtypes;
     Bool_t* fPresentP;
 
   private:


### PR DESCRIPTION
   For a TrigDet associated with one spectrometer, call SetSpectName
   so that H.present or P.present can be found.
   For coin TrigDet, supply a list of event types for which warnings
   should be suppressed.