### PR TITLE
Modify THcRaster and THcExtTarCor

### DIFF
--- a/src/THcExtTarCor.cxx
+++ b/src/THcExtTarCor.cxx
@@ -136,8 +136,8 @@ Int_t THcExtTarCor::Process( const THaEvData& )
   for( Int_t i = 0; i<ntracks; i++ ) {
     THaTrack* theTrack = static_cast<THaTrack*>( tracks->At(i) );
     if( theTrack == spectro->GetGoldenTrack() ) {
-
-      // Calculate corrections & recalculate track parameters
+      // Calculate corrections & recalculate ,,,track parameters
+      //cout << " orig" << spectro->GetName() << " " <<theTrack->GetTTheta()<< " " << theTrack->GetDp() << endl;
       Double_t x_tg = vertex[1];
       spectro->CalculateTargetQuantities(theTrack,x_tg,xptar,ytar,yptar,delta);
       p  = spectro->GetPcentral() * ( 1.0+delta );
@@ -149,11 +149,19 @@ Int_t THcExtTarCor::Process( const THaEvData& )
       fDeltaDp = delta*100 -theTrack->GetDp();
       fDeltaP = p - theTrack->GetP();
       fDeltaTh = xptar -  theTrack->GetTTheta();
+     theTrack->SetTarget(0.0, ytar*100.0, xptar, yptar);
+    theTrack->SetDp(delta*100.0);	// Percent.  
+    Double_t ptemp =spectro->GetPcentral()*(1+theTrack->GetDp()/100.0);
+      theTrack->SetMomentum(ptemp);
+    TVector3 pvect_temp;
+    spectro->TransportToLab(theTrack->GetP(),theTrack->GetTTheta(),theTrack->GetTPhi(),pvect_temp);
+    theTrack->SetPvect(pvect_temp);
     }
   }
  // Save results in our TrackInfo
+ // cout << spectro->GetName() << " exttarcor = " << xptar << " " << delta*100 << endl;
+  trkifo->Set( p, delta*100, xtar_new,100*ytar, xptar, yptar, pvect );
   fTrkIfo.Set( p, delta*100, xtar_new,100*ytar, xptar, yptar, pvect );
-
   fDataValid = true;
   return 0;
 }

--- a/src/THcRaster.cxx
+++ b/src/THcRaster.cxx
@@ -394,7 +394,6 @@ gHcParms->LoadParmValues(list);
   fXB_ADC =  FRXB_rawadc-fFrXB_ADC_zero_offset;
   fYB_ADC =  FRYB_rawadc-fFrYB_ADC_zero_offset;
   
-  //std::cout<<" Raw X ADC = "<<fXADC<<" Raw Y ADC = "<<fYADC<<std::endl;
 
   /*
     calculate the raster positions
@@ -404,9 +403,9 @@ gHcParms->LoadParmValues(list);
   */
 
   fXA_pos = (fXA_ADC/fFrXA_ADCperCM)*(fFrCalMom/fgpBeam);
-  fYA_pos = (-1)*(fYA_ADC/fFrYA_ADCperCM)*(fFrCalMom/fgpBeam);
+  fYA_pos = (-1.)*(fYA_ADC/fFrYA_ADCperCM)*(fFrCalMom/fgpBeam);
   fXB_pos = (fXB_ADC/fFrXB_ADCperCM)*(fFrCalMom/fgpBeam);
-  fYB_pos = (-1)*(fYB_ADC/fFrYB_ADCperCM)*(fFrCalMom/fgpBeam);
+  fYB_pos = (-1.)*(fYB_ADC/fFrYB_ADCperCM)*(fFrCalMom/fgpBeam);
 
   // std::cout<<" X = "<<fXpos<<" Y = "<<fYpos<<std::endl;
 
@@ -414,12 +413,12 @@ gHcParms->LoadParmValues(list);
   Double_t tt;
   Double_t tp;
   if(fgusefr != 0) {
-    fPosition[1].SetXYZ(fXA_pos+fgbeam_xoff, fYA_pos+fgbeam_yoff, 0.0);
+    fPosition[1].SetXYZ((-1.)*(fXA_pos+fgbeam_xoff), fYA_pos+fgbeam_yoff, 0.0);
     tt = (-1)*(fXA_pos/fgfrx_dist+fgbeam_xpoff);
     tp = fYA_pos/fgfry_dist+fgbeam_ypoff;
 
   } else {			// Just use fixed beam position and angle
-    fPosition[0].SetXYZ(fgbeam_xoff, fgbeam_yoff, 0.0);
+    fPosition[0].SetXYZ((-1.)*fgbeam_xoff, fgbeam_yoff, 0.0);
     tt = (-1)*fgbeam_xpoff;
     tp = fgbeam_ypoff;
   }


### PR DESCRIPTION
Update THcRaster.cxx

When filling beam position that is used in determining the reaction
  point multiply the raster X by -1 to put in the right handed coordinate system

The raster coordinate system is left-handed to match the EPICS beam
  coordinate system.

Modify THcExtTarCor.cxx

Added call trkifo->Set since it is used in THcPrimaryKine and THcSecondaryKine

Fill golden track with target quantities after correction for
  vertical target position.