### PR TITLE
Best reference time selection

### DIFF
--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -185,14 +185,15 @@ THaAnalysisObject::EStatus THcAerogel::Init( const TDatime& date )
     return kInitError;
   }
 
-  // Should probably put this in ReadDatabase as we will know the
-  // maximum number of hits after setting up the detector map
-  InitHitList(fDetMap, "THcAerogelHit", fDetMap->GetTotNumChan()+1);
-
   EStatus status;
   if( (status = THaNonTrackingDetector::Init( date )) )
     return fStatus=status;
- 
+
+  // Should probably put this in ReadDatabase as we will know the
+  // maximum number of hits after setting up the detector map
+  InitHitList(fDetMap, "THcAerogelHit", fDetMap->GetTotNumChan()+1,
+	      0, fADC_RefTimeCut);
+
  THcHallCSpectrometer *app=dynamic_cast<THcHallCSpectrometer*>(GetApparatus());
    if(  !app ||
       !(fglHod = dynamic_cast<THcHodoscope*>(app->GetDetector("hod"))) ) {
@@ -333,13 +334,14 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
     {"aero_tdc_offset",       &fTdcOffset,        kInt,    0,               optional},
     {"aero_min_peds",         &fMinPeds,          kInt,    0,               optional},
     {"aero_region",           &fRegionValue[0],   kDouble, (UInt_t) fRegionsValueMax},
-
+    {"aero_adcrefcut",        &fADC_RefTimeCut,   kInt,    0, 1},
     {0}
   };
 
   fSixGevData = 0; // Set 6 GeV data parameter to false unless set in parameter file
   fDebugAdc   = 0; // Set ADC debug parameter to false unless set in parameter file
   fAdcTdcOffset = 0.0;
+  fADC_RefTimeCut = 0;
 
   gHcParms->LoadParmValues((DBRequest*)&list, prefix);
 

--- a/src/THcAerogel.h
+++ b/src/THcAerogel.h
@@ -43,6 +43,8 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   Int_t fNhits;
   Bool_t* fPresentP;
 
+  Int_t fADC_RefTimeCut;
+
   // 12 GeV variables
   // Vector/TClonesArray length parameters
   static const Int_t MaxNumAdcPulse   = 4;

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -148,13 +148,14 @@ THaAnalysisObject::EStatus THcCherenkov::Init( const TDatime& date )
     return kInitError;
   }
 
-  // Should probably put this in ReadDatabase as we will know the
-  // maximum number of hits after setting up the detector map
-  InitHitList(fDetMap, "THcCherenkovHit", fDetMap->GetTotNumChan()+1);
-
   EStatus status;
   if((status = THaNonTrackingDetector::Init( date )))
     return fStatus=status;
+
+  // Should probably put this in ReadDatabase as we will know the
+  // maximum number of hits after setting up the detector map
+  InitHitList(fDetMap, "THcCherenkovHit", fDetMap->GetTotNumChan()+1,
+	      0, fADC_RefTimeCut);
 
   THcHallCSpectrometer *app=dynamic_cast<THcHallCSpectrometer*>(GetApparatus());
    if(  !app ||
@@ -224,11 +225,13 @@ Int_t THcCherenkov::ReadDatabase( const TDatime& date )
     {"_adcTimeWindowMax", &fAdcTimeWindowMax, kDouble},
     {"_adc_tdc_offset",   &fAdcTdcOffset,     kDouble, 0, 1},
     {"_region",           &fRegionValue[0],   kDouble,  (UInt_t) fRegionsValueMax},
+    {"_adcrefcut",        &fADC_RefTimeCut,   kInt,    0, 1},
     {0}
   };
 
   fDebugAdc = 0; // Set ADC debug parameter to false unless set in parameter file
   fAdcTdcOffset = 0.0;
+  fADC_RefTimeCut = 0;
 
   gHcParms->LoadParmValues((DBRequest*)&list, prefix.c_str());
 

--- a/src/THcCherenkov.h
+++ b/src/THcCherenkov.h
@@ -49,6 +49,8 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   Int_t     fDebugAdc;
   Double_t* fWidth;
 
+  Int_t     fADC_RefTimeCut;
+
   Int_t     fNhits;
   Int_t     fTotNumAdcHits;
   Int_t     fTotNumGoodAdcHits;

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -117,10 +117,12 @@ void THcDC::Setup(const char* name, const char* description)
     {"dc_tdc_time_per_channel",&fNSperChan, kDouble},
     {"dc_wire_velocity",&fWireVelocity,kDouble},
     {"dc_plane_names",&planenamelist, kString},
-	{"dc_version", &fVersion, kInt, 0, optional},
+    {"dc_version", &fVersion, kInt, 0, optional},
+    {"dc_tdcrefcut", &fTDC_RefTimeCut, kInt, 0, 1},
     {0}
   };
 
+  fTDC_RefTimeCut = 0;		// Minimum allowed reference times
   gHcParms->LoadParmValues((DBRequest*)&list,fPrefix);
 
   if(fVersion==0) {
@@ -207,7 +209,8 @@ THaAnalysisObject::EStatus THcDC::Init( const TDatime& date )
 
   // Should probably put this in ReadDatabase as we will know the
   // maximum number of hits after setting up the detector map
-  InitHitList(fDetMap, "THcRawDCHit", fDetMap->GetTotNumChan()+1);
+  InitHitList(fDetMap, "THcRawDCHit", fDetMap->GetTotNumChan()+1,
+	      fTDC_RefTimeCut, 0);
 
   EStatus status;
   // This triggers call of ReadDatabase and DefineVariables

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -92,6 +92,8 @@ protected:
   Int_t fdebugprintdecodeddc;
   Int_t fHMSStyleChambers;
 
+  Int_t fTDC_RefTimeCut;
+
   UInt_t fNDCTracks;
   TClonesArray* fDCTracks;     // Tracks found from stubs (THcDCTrack obj)
   // Calibration

--- a/src/THcHitList.h
+++ b/src/THcHitList.h
@@ -39,6 +39,8 @@ public:
   Int_t         fNMaxRawHits;
   Int_t         fTDC_RefTimeCut;
   Int_t         fADC_RefTimeCut;
+  Bool_t        fTDC_RefTimeBest;
+  Bool_t        fADC_RefTimeBest;
   TClonesArray* fRawHitList; // List of raw hits
   TClass* fRawHitClass;		  // Class of raw hit object to use
 

--- a/src/THcHitList.h
+++ b/src/THcHitList.h
@@ -30,12 +30,15 @@ public:
 
   virtual Int_t DecodeToHitList( const THaEvData&, Bool_t suppress=kFALSE );
   void          InitHitList(THaDetMap* detmap,
-			    const char *hitclass, Int_t maxhits);
+			    const char *hitclass, Int_t maxhits,
+			    Int_t tdcref_cut=0, Int_t adcref_cut=0);
 
   TClonesArray* GetHitList() const {return fRawHitList; }
 
   UInt_t         fNRawHits;
   Int_t         fNMaxRawHits;
+  Int_t         fTDC_RefTimeCut;
+  Int_t         fADC_RefTimeCut;
   TClonesArray* fRawHitList; // List of raw hits
   TClass* fRawHitClass;		  // Class of raw hit object to use
 

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -95,9 +95,13 @@ void THcHodoscope::Setup(const char* name, const char* description)
   DBRequest listextra[]={
     {"hodo_num_planes", &fNPlanes, kInt},
     {"hodo_plane_names",&planenamelist, kString},
+    {"hodo_tdcrefcut", &fTDC_RefTimeCut, kInt, 0, 1},
+    {"hodo_adcrefcut", &fADC_RefTimeCut, kInt, 0, 1},
     {0}
   };
   //fNPlanes = 4; 		// Default if not defined
+  fTDC_RefTimeCut = 0;		// Minimum allowed reference times
+  fADC_RefTimeCut = 0;
   gHcParms->LoadParmValues((DBRequest*)&listextra,prefix);
 
   cout << "Plane Name List : " << planenamelist << endl;
@@ -160,7 +164,8 @@ THaAnalysisObject::EStatus THcHodoscope::Init( const TDatime& date )
   // But it needs to happen before the sub detectors are initialized
   // so that they can get the pointer to the hitlist.
 
-  InitHitList(fDetMap, "THcRawHodoHit", fDetMap->GetTotNumChan()+1);
+  InitHitList(fDetMap, "THcRawHodoHit", fDetMap->GetTotNumChan()+1,
+	      fTDC_RefTimeCut, fADC_RefTimeCut);
 
   EStatus status;
   // This triggers call of ReadDatabase and DefineVariables

--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -121,6 +121,9 @@ protected:
 
   THcCherenkov* fCherenkov;
 
+  Int_t fTDC_RefTimeCut;
+  Int_t fADC_RefTimeCut;
+
   Int_t fAnalyzePedestals;
 
   Int_t fNHits;

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -63,9 +63,11 @@ void THcShower::Setup(const char* name, const char* description)
     {"cal_num_layers", &fNLayers, kInt},
     {"cal_layer_names", &layernamelist, kString},
     {"cal_array",&fHasArray, kInt,0, 1},
+    {"cal_adcrefcut", &fADC_RefTimeCut, kInt, 0, 1},
     {0}
   };
 
+  fADC_RefTimeCut = 0;
   gHcParms->LoadParmValues((DBRequest*)&list,prefix);
   fNTotLayers = (fNLayers+(fHasArray!=0?1:0));
   vector<string> layer_names = vsplit(layernamelist);
@@ -141,7 +143,8 @@ THaAnalysisObject::EStatus THcShower::Init( const TDatime& date )
   // Should probably put this in ReadDatabase as we will know the
   // maximum number of hits after setting up the detector map
 
-  InitHitList(fDetMap, "THcRawShowerHit", fDetMap->GetTotNumChan()+1);
+  InitHitList(fDetMap, "THcRawShowerHit", fDetMap->GetTotNumChan()+1,
+	      0, fADC_RefTimeCut);
 
   EStatus status;
   if( (status = THaNonTrackingDetector::Init( date )) )

--- a/src/TIBlobModule.cxx
+++ b/src/TIBlobModule.cxx
@@ -81,7 +81,7 @@ namespace Decoder {
     Int_t evlen = evbuffer.size();
     if(evlen>0) {
       // The first word might be a filler word
-      Int_t ifill = ((evbuffer[0]>>27)&0x1F == 0x1F) ? 1 : 0;
+      Int_t ifill = (((evbuffer[0]>>27)&0x1F) == 0x1F) ? 1 : 0;
       if (evlen>=5+ifill) {// Need at least two headers and the trailer and 2 data words
 	UInt_t header1=evbuffer[ifill];
 	Int_t slot_blk_hdr=(header1 >> 22) & 0x1F;  // Slot number (set by VME64x backplane), mask 5 bits


### PR DESCRIPTION
The reference times can have multiple hits.  These patches implement two schemes of selecting the best of the reference time hits.  They are activated by setting the parameters xxxx_tdcrefcut and xxxx_adccrefcut for each detector.  (xxxx= e.g. hhodo, pdc, haero, ...)  The absolute value of these parameters are minimum reference times.

If the parameter is positive, then the first reference time hit above the cut is taken to be the reference time.  If no hit is above the cut, then no reference time is registered.

If the parameter is negative, then the first reference time hit above the absolute value of the cut is taken to be the reference time.  If no hit exceeds the cut, then the last (largest) hit is taken as the reference time.

This pull request also contains an unrelated commit with a small fix to TIBlobModule.