### PR TITLE
Update THcHallCSpectrometer and THcExtTarCor

### DIFF
--- a/src/THcHallCSpectrometer.cxx
+++ b/src/THcHallCSpectrometer.cxx
@@ -207,6 +207,8 @@ Int_t THcHallCSpectrometer::ReadDatabase( const TDatime& date )
     {"theta_lab",             &fTheta_lab,             kDouble               },
     {"partmass",              &fPartMass,              kDouble               },
     {"phi_lab",               &fPhi_lab,               kDouble,         0,  1},
+    {"mispointing_x",               &fMispointing_x,               kDouble,         0,  1},
+    {"mispointing_y",               &fMispointing_y,               kDouble,         0,  1},
     {"sel_using_scin",        &fSelUsingScin,          kInt,            0,  1},
     {"sel_using_prune",       &fSelUsingPrune,         kInt,            0,  1},
     {"sel_ndegreesmin",       &fSelNDegreesMin,        kDouble,         0,  1},
@@ -238,6 +240,8 @@ Int_t THcHallCSpectrometer::ReadDatabase( const TDatime& date )
   fSelUsingPrune = 0;
   fPhi_lab = 0.;
   fSatCorr=0.;
+  fMispointing_x=0.;
+  fMispointing_y=0.;
   gHcParms->LoadParmValues((DBRequest*)&list,prefix);
 
   EnforcePruneLimits();
@@ -270,9 +274,8 @@ Int_t THcHallCSpectrometer::ReadDatabase( const TDatime& date )
   // Computes TRotation fToLabRot and fToTraRot
   Bool_t bend_down = kFALSE;
   SetCentralAngles(fTheta_lab, ph, bend_down);
-  Double_t off_x = 0.0, off_y = 0.0, off_z = 0.0;
-  fPointingOffset.SetXYZ( off_x, off_y, off_z );
-
+  Double_t off_z = 0.0;
+  fPointingOffset.SetXYZ( fMispointing_x, fMispointing_y, off_z );
   //
   ifstream ifile;
   ifile.open(reconCoeffFilename.c_str());
@@ -388,7 +391,7 @@ Int_t THcHallCSpectrometer::FindVertices( TClonesArray& tracks )
   return 0;
 }
 //
-void THcHallCSpectrometer::CalculateTargetQuantities(THaTrack* track,Double_t& gbeam_y,Double_t&  xptar,Double_t& ytar,Double_t& yptar,Double_t& delta) 
+void THcHallCSpectrometer::CalculateTargetQuantities(THaTrack* track,Double_t& xtar,Double_t&  xptar,Double_t& ytar,Double_t& yptar,Double_t& delta) 
 {
     Double_t hut[5];
     Double_t hut_rot[5];
@@ -398,7 +401,7 @@ void THcHallCSpectrometer::CalculateTargetQuantities(THaTrack* track,Double_t& g
     hut[2] = track->GetY()/100.0 + fZTrueFocus*track->GetPhi() + fDetOffset_y;//m
     hut[3] = track->GetPhi() + fAngOffset_y;//radians
 
-    hut[4] = -gbeam_y/100.0;
+    hut[4] = xtar/100.0;
 
     // Retrieve the focal plane coordnates
     // Do the transpormation

--- a/src/THcHallCSpectrometer.h
+++ b/src/THcHallCSpectrometer.h
@@ -144,6 +144,8 @@ protected:
   Double_t fPCentralOffset; // Offset Central spectrometer momentum (%)
   Double_t fTheta_lab; // Central spectrometer angle (deg)
   Double_t fPhi_lab; // Central spectrometer angle (deg)
+  Double_t fMispointing_x; // Spectrometer Verticcal Mispointing
+  Double_t fMispointing_y; // Spectrometer Horizontal Mispointing
   // For spectrometer central momentum use fPcentral in THaSpectrometer.h
   //  THaScintillator *sc_ref;  // calculate time track hits this plane
 


### PR DESCRIPTION
THcHallCSpectrometer
  1) Add variables fMispointing_x and fMispointing_y
    which are filled by parameters hmispointing_x, hmispointing_y
      in PARAM/HMS/GEN/hmsflags.param and pmispointing_x, pmispointing_y
      in PARAM/SHMS/GEN/shmsflags.param .
   The offsets are used in THcExtTarCor and THaReactionPoint
  2) Modify argument to method CalculateTargetQuantities to be xtar
     instead of gbeam_y .

THcExtTarCor
   1) add call to get spectrometer pointing offsets
   2) The mispointing_x is added to xtar
   3) Set xtar to start as -beam_y = - vertex(1)+mispointing_x for first call to CalculateTargetQuantities
      After first call the xtar is recalculated using the returned xptar
      and a second call is done to get the target xptar,ytar,yptar and delta.
    4) Fill golden track with final xtar