### PR TITLE
Print summary of missing reference times for each detector

### DIFF
--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -1023,6 +1023,11 @@ void THcAerogel::Print(const Option_t* opt) const
   cout << " fMinPeds = " << fMinPeds << endl;
   cout << endl;
 }
-
+//_____________________________________________________________________________
+Int_t THcAerogel::End(THaRunBase* run)
+{
+  MissReport(Form("%s.%s", GetApparatus()->GetName(), GetName()));
+  return 0;
+}
 ClassImp(THcAerogel)
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/THcAerogel.h
+++ b/src/THcAerogel.h
@@ -30,6 +30,7 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   virtual Int_t   FineProcess(TClonesArray& tracks);
   virtual Int_t   ApplyCorrections(void);
   virtual EStatus Init(const TDatime& run_time);
+  Int_t           End(THaRunBase* run=0);
 
   void  InitArrays();
   void  DeleteArrays();

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -620,6 +620,11 @@ Double_t THcCherenkov::GetCerNPE()
 {
   return fNpeSum;
 }
-
+//_____________________________________________________________________________
+Int_t THcCherenkov::End(THaRunBase* run)
+{
+  MissReport(Form("%s.%s", GetApparatus()->GetName(), GetName()));
+  return 0;
+}
 ClassImp(THcCherenkov)
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/THcCherenkov.h
+++ b/src/THcCherenkov.h
@@ -30,6 +30,8 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   virtual Int_t   FineProcess(TClonesArray& tracks);
   virtual Int_t   ApplyCorrections( void );
   virtual EStatus Init(const TDatime& run_time);
+  Int_t           End(THaRunBase* run);
+
 
   void  InitArrays();
   void  DeleteArrays();

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -1173,6 +1173,7 @@ Double_t THcDC::DpsiFun(Double_t ray[4], Int_t plane)
 Int_t THcDC::End(THaRunBase* run)
 {
   //  EffCalc();
+  MissReport(Form("%s.%s", GetApparatus()->GetName(), GetName()));
   return 0;
 }
 

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -29,6 +29,7 @@ public:
 
   virtual Int_t      Decode( const THaEvData& );
   virtual EStatus    Init( const TDatime& run_time );
+  virtual Int_t      End(THaRunBase* run=0);
   virtual Int_t      CoarseTrack( TClonesArray& tracks );
   virtual Int_t      FineTrack( TClonesArray& tracks );
 
@@ -197,7 +198,6 @@ protected:
   void           LinkStubs();
   void           TrackFit();
   Double_t       DpsiFun(Double_t ray[4], Int_t plane);
-  Int_t          End(THaRunBase* run);
   void           EffInit();
   void           Eff();
 

--- a/src/THcHitList.cxx
+++ b/src/THcHitList.cxx
@@ -133,6 +133,9 @@ void THcHitList::InitHitList(THaDetMap* detmap,
     fPSE125 = 0;
   }
   fHaveFADCInfo = kFALSE;
+
+  fNTDCRef_miss = 0;
+  fNADCRef_miss = 0;
 }
 
 /**
@@ -151,6 +154,8 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
   // cout << " Clearing TClonesArray " << endl;
   fRawHitList->Clear( );
   fNRawHits = 0;
+  Bool_t tdcref_miss = kFALSE;
+  Bool_t adcref_miss = kFALSE;
 
   // Get the indexed reference times for this event
   for(Int_t i=0;i<fNRefIndex;i++) {
@@ -250,6 +255,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
 	      cout << "HitList(event=" << evdata.GetEvNum() << "): refchan " << d->refchan <<
 		" missing for (" << d->crate << ", " << d->slot <<
 		", " << chan << ")" << endl;
+	      tdcref_miss = kTRUE;
 	    }
 	  }
 	} else {
@@ -264,6 +270,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
 		  ", " << fRefIndexMaps[d->refindex].channel << ")" <<
 		  " missing for (" << d->crate << ", " << d->slot <<
 		  ", " << chan << ")" << endl;
+		tdcref_miss = kTRUE;
 	      }
 	    }
 	  }
@@ -310,6 +317,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
 	      cout << "HitList(event=" << evdata.GetEvNum() << "): refchan " << d->refchan <<
 		" missing for (" << d->crate << ", " << d->slot <<
 		", " << chan << ")" << endl;
+	      adcref_miss = kTRUE;
 	    }
 	  }
 	} else {
@@ -324,6 +332,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
 		  ", " << fRefIndexMaps[d->refindex].channel << ")" <<
 		  " missing for (" << d->crate << ", " << d->slot <<
 		  ", " << chan << ")" << endl;
+		adcref_miss = kTRUE;
 	      }
 	    }
 	  }
@@ -333,7 +342,14 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
   }
   fRawHitList->Sort(fNRawHits);
 
+  fNTDCRef_miss += (tdcref_miss ? 1 : 0);
+  fNADCRef_miss += (adcref_miss ? 1 : 0);
+
   return fNRawHits;		// Does anything care what is returned
+}
+void THcHitList::MissReport(const char *name)
+{
+  cout << "Missing Ref times:" << setw(20) << name << setw(10) << fNTDCRef_miss << setw(10) << fNADCRef_miss << endl;
 }
 
 ClassImp(THcHitList)

--- a/src/THcHitList.h
+++ b/src/THcHitList.h
@@ -8,6 +8,7 @@
 #include "TObject.h"
 #include "Decoder.h"
 
+#include <iomanip>
 
 using namespace std;
 
@@ -33,6 +34,7 @@ public:
 			    const char *hitclass, Int_t maxhits);
 
   TClonesArray* GetHitList() const {return fRawHitList; }
+  void          MissReport(const char *name);
 
   UInt_t         fNRawHits;
   Int_t         fNMaxRawHits;
@@ -64,6 +66,9 @@ protected:
   Int_t fNSA;
   Int_t fNSB;
   Int_t fNPED;
+
+  Int_t fNTDCRef_miss;
+  Int_t fNADCRef_miss;
 
   ClassDef(THcHitList,0);  // List of raw hits sorted by plane, counter
 };

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -1586,5 +1586,11 @@ Int_t THcHodoscope::GetScinIndex( Int_t nSide, Int_t nPlane, Int_t nPaddle ) {
 Double_t THcHodoscope::GetPathLengthCentral() {
   return fPathLengthCentral;
 }
+//_____________________________________________________________________________
+Int_t THcHodoscope::End(THaRunBase* run)
+{
+  MissReport(Form("%s.%s", GetApparatus()->GetName(), GetName()));
+  return 0;
+}
 ClassImp(THcHodoscope)
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -46,6 +46,7 @@ public:
 
   virtual Int_t      CoarseProcess( TClonesArray& tracks );
   virtual Int_t      FineProcess( TClonesArray& tracks );
+  virtual Int_t      End(THaRunBase* run=0);
 
   void EstimateFocalPlaneTime(void);
   virtual Int_t      ApplyCorrections( void );

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -1230,6 +1230,12 @@ Int_t THcShower::FineProcess( TClonesArray& tracks )
 Double_t THcShower::GetNormETot( ){
   return fEtotNorm;
 }
+//_____________________________________________________________________________
+Int_t THcShower::End(THaRunBase* run)
+{
+  MissReport(Form("%s.%s", GetApparatus()->GetName(), GetName()));
+  return 0;
+}
 
 ClassImp(THcShower)
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -252,6 +252,8 @@ protected:
 
   void ClusterHits(THcShowerHitSet& HitSet, THcShowerClusterList* ClusterList);
 
+  virtual Int_t      End(THaRunBase *r = 0);
+
   friend class THcShowerPlane;   //to access debug flags.
   friend class THcShowerArray;   //to access debug flags.
 

--- a/src/THcTrigDet.cxx
+++ b/src/THcTrigDet.cxx
@@ -470,5 +470,11 @@ Bool_t THcTrigDet::HaveIgnoreList() const
 {
   return( (eventtypes.size()>0) ? kTRUE : kFALSE);
 }
+//_____________________________________________________________________________
+Int_t THcTrigDet::End(THaRunBase* run)
+{
+  MissReport(Form("%s.%s", GetApparatus()->GetName(), GetName()));
+  return 0;
+}
 
 ClassImp(THcTrigDet)

--- a/src/THcTrigDet.h
+++ b/src/THcTrigDet.h
@@ -31,6 +31,7 @@ class THcTrigDet : public THaDetector, public THcHitList {
     virtual void SetEvtType(int evtype);
     virtual Bool_t IsIgnoreType(Int_t evtype) const;
     virtual Bool_t HaveIgnoreList() const;
+    Int_t          End(THaRunBase* run);
 
   protected:
     void Setup(const char* name, const char* description);


### PR DESCRIPTION
  Add End method to each detector that calls MissReport which
  prints the number of events with missing TDC and ADC reference times.