### PR TITLE
Put a minimum cut on reference times.

### DIFF
--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -185,14 +185,15 @@ THaAnalysisObject::EStatus THcAerogel::Init( const TDatime& date )
     return kInitError;
   }
 
-  // Should probably put this in ReadDatabase as we will know the
-  // maximum number of hits after setting up the detector map
-  InitHitList(fDetMap, "THcAerogelHit", fDetMap->GetTotNumChan()+1);
-
   EStatus status;
   if( (status = THaNonTrackingDetector::Init( date )) )
     return fStatus=status;
- 
+
+  // Should probably put this in ReadDatabase as we will know the
+  // maximum number of hits after setting up the detector map
+  InitHitList(fDetMap, "THcAerogelHit", fDetMap->GetTotNumChan()+1,
+	      0, fADC_RefTimeCut);
+
  THcHallCSpectrometer *app=dynamic_cast<THcHallCSpectrometer*>(GetApparatus());
    if(  !app ||
       !(fglHod = dynamic_cast<THcHodoscope*>(app->GetDetector("hod"))) ) {
@@ -333,13 +334,14 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
     {"aero_tdc_offset",       &fTdcOffset,        kInt,    0,               optional},
     {"aero_min_peds",         &fMinPeds,          kInt,    0,               optional},
     {"aero_region",           &fRegionValue[0],   kDouble, (UInt_t) fRegionsValueMax},
-
+    {"aero_adcrefcut",        &fADC_RefTimeCut,   kInt,    0, 1},
     {0}
   };
 
   fSixGevData = 0; // Set 6 GeV data parameter to false unless set in parameter file
   fDebugAdc   = 0; // Set ADC debug parameter to false unless set in parameter file
   fAdcTdcOffset = 0.0;
+  fADC_RefTimeCut = 0;
 
   gHcParms->LoadParmValues((DBRequest*)&list, prefix);
 

--- a/src/THcAerogel.h
+++ b/src/THcAerogel.h
@@ -44,6 +44,8 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   Int_t fNhits;
   Bool_t* fPresentP;
 
+  Int_t fADC_RefTimeCut;
+
   // 12 GeV variables
   // Vector/TClonesArray length parameters
   static const Int_t MaxNumAdcPulse   = 4;

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -148,13 +148,14 @@ THaAnalysisObject::EStatus THcCherenkov::Init( const TDatime& date )
     return kInitError;
   }
 
-  // Should probably put this in ReadDatabase as we will know the
-  // maximum number of hits after setting up the detector map
-  InitHitList(fDetMap, "THcCherenkovHit", fDetMap->GetTotNumChan()+1);
-
   EStatus status;
   if((status = THaNonTrackingDetector::Init( date )))
     return fStatus=status;
+
+  // Should probably put this in ReadDatabase as we will know the
+  // maximum number of hits after setting up the detector map
+  InitHitList(fDetMap, "THcCherenkovHit", fDetMap->GetTotNumChan()+1,
+	      0, fADC_RefTimeCut);
 
   THcHallCSpectrometer *app=dynamic_cast<THcHallCSpectrometer*>(GetApparatus());
    if(  !app ||
@@ -224,11 +225,13 @@ Int_t THcCherenkov::ReadDatabase( const TDatime& date )
     {"_adcTimeWindowMax", &fAdcTimeWindowMax, kDouble},
     {"_adc_tdc_offset",   &fAdcTdcOffset,     kDouble, 0, 1},
     {"_region",           &fRegionValue[0],   kDouble,  (UInt_t) fRegionsValueMax},
+    {"_adcrefcut",        &fADC_RefTimeCut,   kInt,    0, 1},
     {0}
   };
 
   fDebugAdc = 0; // Set ADC debug parameter to false unless set in parameter file
   fAdcTdcOffset = 0.0;
+  fADC_RefTimeCut = 0;
 
   gHcParms->LoadParmValues((DBRequest*)&list, prefix.c_str());
 

--- a/src/THcCherenkov.h
+++ b/src/THcCherenkov.h
@@ -51,6 +51,8 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   Int_t     fDebugAdc;
   Double_t* fWidth;
 
+  Int_t     fADC_RefTimeCut;
+
   Int_t     fNhits;
   Int_t     fTotNumAdcHits;
   Int_t     fTotNumGoodAdcHits;

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -117,10 +117,12 @@ void THcDC::Setup(const char* name, const char* description)
     {"dc_tdc_time_per_channel",&fNSperChan, kDouble},
     {"dc_wire_velocity",&fWireVelocity,kDouble},
     {"dc_plane_names",&planenamelist, kString},
-	{"dc_version", &fVersion, kInt, 0, optional},
+    {"dc_version", &fVersion, kInt, 0, optional},
+    {"dc_tdcrefcut", &fTDC_RefTimeCut, kInt, 0, 1},
     {0}
   };
 
+  fTDC_RefTimeCut = 0;		// Minimum allowed reference times
   gHcParms->LoadParmValues((DBRequest*)&list,fPrefix);
 
   if(fVersion==0) {
@@ -207,7 +209,8 @@ THaAnalysisObject::EStatus THcDC::Init( const TDatime& date )
 
   // Should probably put this in ReadDatabase as we will know the
   // maximum number of hits after setting up the detector map
-  InitHitList(fDetMap, "THcRawDCHit", fDetMap->GetTotNumChan()+1);
+  InitHitList(fDetMap, "THcRawDCHit", fDetMap->GetTotNumChan()+1,
+	      fTDC_RefTimeCut, 0);
 
   EStatus status;
   // This triggers call of ReadDatabase and DefineVariables

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -93,6 +93,8 @@ protected:
   Int_t fdebugprintdecodeddc;
   Int_t fHMSStyleChambers;
 
+  Int_t fTDC_RefTimeCut;
+
   UInt_t fNDCTracks;
   TClonesArray* fDCTracks;     // Tracks found from stubs (THcDCTrack obj)
   // Calibration

--- a/src/THcHitList.h
+++ b/src/THcHitList.h
@@ -31,13 +31,18 @@ public:
 
   virtual Int_t DecodeToHitList( const THaEvData&, Bool_t suppress=kFALSE );
   void          InitHitList(THaDetMap* detmap,
-			    const char *hitclass, Int_t maxhits);
+			    const char *hitclass, Int_t maxhits,
+			    Int_t tdcref_cut=0, Int_t adcref_cut=0);
 
   TClonesArray* GetHitList() const {return fRawHitList; }
   void          MissReport(const char *name);
 
   UInt_t         fNRawHits;
   Int_t         fNMaxRawHits;
+  Int_t         fTDC_RefTimeCut;
+  Int_t         fADC_RefTimeCut;
+  Bool_t        fTDC_RefTimeBest;
+  Bool_t        fADC_RefTimeBest;
   TClonesArray* fRawHitList; // List of raw hits
   TClass* fRawHitClass;		  // Class of raw hit object to use
 

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -95,9 +95,13 @@ void THcHodoscope::Setup(const char* name, const char* description)
   DBRequest listextra[]={
     {"hodo_num_planes", &fNPlanes, kInt},
     {"hodo_plane_names",&planenamelist, kString},
+    {"hodo_tdcrefcut", &fTDC_RefTimeCut, kInt, 0, 1},
+    {"hodo_adcrefcut", &fADC_RefTimeCut, kInt, 0, 1},
     {0}
   };
   //fNPlanes = 4; 		// Default if not defined
+  fTDC_RefTimeCut = 0;		// Minimum allowed reference times
+  fADC_RefTimeCut = 0;
   gHcParms->LoadParmValues((DBRequest*)&listextra,prefix);
 
   cout << "Plane Name List : " << planenamelist << endl;
@@ -160,7 +164,8 @@ THaAnalysisObject::EStatus THcHodoscope::Init( const TDatime& date )
   // But it needs to happen before the sub detectors are initialized
   // so that they can get the pointer to the hitlist.
 
-  InitHitList(fDetMap, "THcRawHodoHit", fDetMap->GetTotNumChan()+1);
+  InitHitList(fDetMap, "THcRawHodoHit", fDetMap->GetTotNumChan()+1,
+	      fTDC_RefTimeCut, fADC_RefTimeCut);
 
   EStatus status;
   // This triggers call of ReadDatabase and DefineVariables

--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -122,6 +122,9 @@ protected:
 
   THcCherenkov* fCherenkov;
 
+  Int_t fTDC_RefTimeCut;
+  Int_t fADC_RefTimeCut;
+
   Int_t fAnalyzePedestals;
 
   Int_t fNHits;

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -63,9 +63,11 @@ void THcShower::Setup(const char* name, const char* description)
     {"cal_num_layers", &fNLayers, kInt},
     {"cal_layer_names", &layernamelist, kString},
     {"cal_array",&fHasArray, kInt,0, 1},
+    {"cal_adcrefcut", &fADC_RefTimeCut, kInt, 0, 1},
     {0}
   };
 
+  fADC_RefTimeCut = 0;
   gHcParms->LoadParmValues((DBRequest*)&list,prefix);
   fNTotLayers = (fNLayers+(fHasArray!=0?1:0));
   vector<string> layer_names = vsplit(layernamelist);
@@ -141,7 +143,8 @@ THaAnalysisObject::EStatus THcShower::Init( const TDatime& date )
   // Should probably put this in ReadDatabase as we will know the
   // maximum number of hits after setting up the detector map
 
-  InitHitList(fDetMap, "THcRawShowerHit", fDetMap->GetTotNumChan()+1);
+  InitHitList(fDetMap, "THcRawShowerHit", fDetMap->GetTotNumChan()+1,
+	      0, fADC_RefTimeCut);
 
   EStatus status;
   if( (status = THaNonTrackingDetector::Init( date )) )


### PR DESCRIPTION
   First hit above this cut is taken as the reference time.
   Cuts are per detector and read as an optional parameter in
   each detector class.  TDCs and Flash ADC times have separate cuts.

Implement a second method of selecting best reference time.
  If InitHitList is passed a possitive reference time cut,
    use the first reference time above that cut.  If none of the
    hits pass the cut, then no reference time is set
  If InitHitList is passed a negative cut, the cut is taken to be
    the absolute value of the cut, but a reference time is garuanteed
    to be set as long as there is at least one reference time hit.
    If none of the reference time hits pass the cut, then the last
    hit is taken to be the reference time.  (Should be the largest.)

Allow reference time cuts for all the spectrometer detector classes
  Hodoscopes, drift chambers, Aerogels, Gas Cherenkovs, Calorimeters