### PR TITLE
Create parameters to hold missing reference time counts

### DIFF
--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -221,6 +221,8 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
   prefix[0]=tolower(GetApparatus()->GetName()[0]);
   prefix[1]='\0';
 
+  CreateMissReportParms(Form("%saero",prefix));
+
   fNRegions = 1;   // Default if not set in parameter file
 
   DBRequest listextra[]={

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -183,6 +183,8 @@ Int_t THcCherenkov::ReadDatabase( const TDatime& date )
   string prefix = string(GetApparatus()->GetName()).substr(0, 1) + GetName();
   std::transform(prefix.begin(), prefix.end(), prefix.begin(), ::tolower);
 
+  CreateMissReportParms(prefix.c_str());
+
   fNRegions = 4;  // Defualt if not set in paramter file
 
   DBRequest list_1[] = {

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -212,6 +212,8 @@ THaAnalysisObject::EStatus THcDC::Init( const TDatime& date )
   InitHitList(fDetMap, "THcRawDCHit", fDetMap->GetTotNumChan()+1,
 	      fTDC_RefTimeCut, 0);
 
+  CreateMissReportParms(Form("%sdc",fPrefix));
+
   EStatus status;
   // This triggers call of ReadDatabase and DefineVariables
   if( (status = THaTrackingDetector::Init( date )) )

--- a/src/THcFormula.cxx
+++ b/src/THcFormula.cxx
@@ -16,12 +16,14 @@ that the cut has been tested can be accessed with cutname.`scaler` (or
 
 #include "THcFormula.h"
 #include "THcParmList.h"
+#include "THaArrayString.h"
 #include "THaVarList.h"
 #include "THaCutList.h"
 #include "THaCut.h"
 #include "TMath.h"
 
 #include <iostream>
+#include <cassert>
 #include <numeric>
 
 using namespace std;

--- a/src/THcHitList.cxx
+++ b/src/THcHitList.cxx
@@ -13,6 +13,8 @@
 
 #include "THcConfigEvtHandler.h"
 #include "THaGlobals.h"
+#include "THcGlobals.h"
+#include "THcParmList.h"
 #include "TList.h"
 
 using namespace std;
@@ -394,6 +396,19 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
   fNTDCRef_miss += (tdcref_miss ? 1 : 0);
   fNADCRef_miss += (adcref_miss ? 1 : 0);
   return fNRawHits;		// Does anything care what is returned
+}
+void THcHitList::CreateMissReportParms(const char *prefix)
+{
+  /**
+
+\brief Create parameters to hold missing reference time statistics
+
+Parameters created are ${prefix}_tdcref_miss and ${prefix}_adcref_miss
+
+  */
+  cout << "Defining " << Form("%s_tdcref_miss", prefix) << " and " << Form("%s_adcref_miss", prefix) << endl;
+  gHcParms->Define(Form("%s_tdcref_miss", prefix), "Missing TDC reference times", fNTDCRef_miss);
+  gHcParms->Define(Form("%s_adcref_miss", prefix), "Missing ADC reference times", fNADCRef_miss);
 }
 void THcHitList::MissReport(const char *name)
 {

--- a/src/THcHitList.h
+++ b/src/THcHitList.h
@@ -35,6 +35,7 @@ public:
 			    Int_t tdcref_cut=0, Int_t adcref_cut=0);
 
   TClonesArray* GetHitList() const {return fRawHitList; }
+  void          CreateMissReportParms(const char *prefix);
   void          MissReport(const char *name);
 
   UInt_t         fNRawHits;

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -238,6 +238,8 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
   //  Int_t plen=strlen(parname);
   // cout << " readdatabse hodo fnplanes = " << fNPlanes << endl;
 
+  CreateMissReportParms(Form("%sscin",prefix));
+
   fBetaNoTrk = 0.;
   fBetaNoTrkChiSq = 0.;
 

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -212,6 +212,8 @@ Int_t THcShower::ReadDatabase( const TDatime& date )
   prefix[0]=tolower(GetApparatus()->GetName()[0]);
   prefix[1]='\0';
 
+  CreateMissReportParms(Form("%scal",prefix));
+
   fNegCols = fNLayers;		// If not defined assume tube on each end
                                 // for every layer
   {

--- a/src/THcTrigDet.cxx
+++ b/src/THcTrigDet.cxx
@@ -181,6 +181,7 @@ THaAnalysisObject::EStatus THcTrigDet::Init(const TDatime& date) {
   // Initialize hitlist part of the class.
   // printf(" Init trig det hitlist\n");
   InitHitList(fDetMap, "THcTrigRawHit", 100);
+  CreateMissReportParms(fKwPrefix.c_str());
 
   fPresentP = 0;
   THaVar* vpresent = gHaVars->Find(Form("%s.present",fSpectName.Data()));


### PR DESCRIPTION
Parameters are created with the names DETECTORNAME_tdcref_miss nad DETECTORNAME_adcref_miss.   The following template lines report the missing reference times for the SHMS.

Missing Reference Times.

Detector       TDC       ADC
SHMS DC     {pdc_tdcref_miss:%6d}    {pdc_adcref_miss:%6d}
SHMS Hodo   {pscin_tdcref_miss:%6d}    {pscin_adcref_miss:%6d}
SHMS Cal    {pcal_tdcref_miss:%6d}    {pcal_adcref_miss:%6d}
SHMS Aero   {paero_tdcref_miss:%6d}    {paero_adcref_miss:%6d}
SHMS NGC    {pngcer_tdcref_miss:%6d}    {pngcer_adcref_miss:%6d}
SHMS HGC    {phgcer_tdcref_miss:%6d}    {phgcer_adcref_miss:%6d}
SHMS Trig   {t_shms_tdcref_miss:%6d}    {t_shms_adcref_miss:%6d}


Podd is also updated in this pull request.