### PR TITLE
Add new Track Efficiency Test to THcHodoscope

### DIFF
--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -49,6 +49,8 @@ public:
   virtual Int_t      End(THaRunBase* run=0);
 
   void EstimateFocalPlaneTime(void);
+  void OriginalTrackEffTest(void);
+  void TrackEffTest(void);
   virtual Int_t      ApplyCorrections( void );
   Double_t GetStartTime() const { return fStartTime; }
   Bool_t IsStartTimeGood() const {return fGoodStartTime;};
@@ -336,6 +338,8 @@ scin_pos_time(0.0), scin_neg_time(0.0) {}
   std::vector<Int_t > fNScinHit;		        // # scins hit for the track
   std::vector<std::vector<Int_t> > fScinHitPaddle;	// Vector over hits in a plane #
   std::vector<Int_t > fNClust;		                // # scins clusters for the plane
+  std::vector<std::vector<Int_t> > fClustSize;		                // # scin cluster size
+  std::vector<std::vector<Double_t> > fClustPos;		                // # scin cluster position
   std::vector<Int_t > fThreeScin;	                // # scins three clusters for the plane
   std::vector<Int_t > fGoodScinHitsX;                   // # hits in fid x range
   // Could combine the above into a structure


### PR DESCRIPTION
Moved the old track efficiency tests to OriginalTrackEffTest method and
this is presently commented out. Eventually can be eliminated.

The old track efficiency assumed that both planes had matching
  paddlle spacing which is not true for SHMS.

Added new method TrackEffTest which calculates the number of clusters
  in each plane and the position for the cluster for scintillator
  paddle that had good times in both ends. Selects events with
  one cluster with size of 1 or 2 in either 4 of 4 planes
  or 3 of 4 planes. Also checks that the events are inside
  a given range of scintillator paddles.