### PR TITLE
Modifiy THcDC , THcDriftChamber, THcDCTrack and THcSpacePoint.h

### DIFF
--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -853,8 +853,8 @@ void THcDC::LinkStubs()
 			for(Int_t isp=0;isp<theDCTrack->GetNSpacePoints();isp++) {
 			  if(isp!=spoint) {
 			    newDCTrack->AddSpacePoint(theDCTrack->GetSpacePoint(isp));
-		            if (newDCTrack->GetSpacePoint(isp)->fNChamber==1) newDCTrack->SetSp1_ID(theDCTrack->GetSpacePoint(isp)->fNChamber_spnum);
-		            if (newDCTrack->GetSpacePoint(isp)->fNChamber==2) newDCTrack->SetSp2_ID(theDCTrack->GetSpacePoint(isp)->fNChamber_spnum);
+		            if (theDCTrack->GetSpacePoint(isp)->fNChamber==1) newDCTrack->SetSp1_ID(theDCTrack->GetSpacePoint(isp)->fNChamber_spnum);
+		            if (theDCTrack->GetSpacePoint(isp)->fNChamber==2) newDCTrack->SetSp2_ID(theDCTrack->GetSpacePoint(isp)->fNChamber_spnum);
 			  } else {
 			    newDCTrack->AddSpacePoint(sp2);
 		            if (sp2->fNChamber==1) newDCTrack->SetSp1_ID(sp2->fNChamber_spnum);

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -120,6 +120,7 @@ protected:
   Int_t fNthits;
   Int_t fN_True_RawHits;
   Int_t fNSp;                   // Number of space points
+  Int_t fNsp_best;                   // Number of space points for gloden track
   Double_t* fResiduals;         //[fNPlanes] Array of residuals
   Double_t* fWire_hit_did;      //[fNPlanes]
   Double_t* fWire_hit_should;   //[fNPlanes]
@@ -173,6 +174,8 @@ protected:
   Double_t fXp_fp_best;
   Double_t fYp_fp_best;
   Double_t fChisq_best;
+  Int_t fSp1_ID_best;
+  Int_t fSp2_ID_best;
  // For accumulating statitics for efficiencies
   Int_t fTotEvents;
   Int_t* fNChamHits;

--- a/src/THcDCTrack.cxx
+++ b/src/THcDCTrack.cxx
@@ -42,6 +42,8 @@ void THcDCTrack::Clear( const Option_t* )
 {
   // Clear the space point and hit lists
   fnSP = 0;
+  fSp1_ID=-1;
+  fSp2_ID=-1;
   ClearHits();
   // Need to set default values  (0 or -100)
   //fCoords.clear();

--- a/src/THcDCTrack.h
+++ b/src/THcDCTrack.h
@@ -42,6 +42,8 @@ public:
   Double_t GetY()                 const {return fY_fp;}
   Double_t GetXP()                 const {return fXp_fp;}
   Double_t GetYP()                 const {return fYp_fp;}
+  Double_t GetSp1_ID()                 const {return fSp1_ID;}
+  Double_t GetSp2_ID()                 const {return fSp1_ID;}
   Double_t GetChisq()              const {return fChi2_fp;}
   void SetNFree(Int_t nfree)           {fNfree = nfree;}
   void SetCoord(Int_t ip, Double_t coord) {fCoords[ip] = coord;}
@@ -50,6 +52,8 @@ public:
   void SetVector(Double_t x, Double_t y, Double_t z,
 		 Double_t xp, Double_t yp) {fX_fp = x; fY_fp=y; fZ_fp=z; fXp_fp=xp; fYp_fp=yp;}
   void SetChisq(Double_t chi2)   {fChi2_fp = chi2;}
+  void SetSp1_ID(Int_t isp1) {fSp1_ID= isp1;}
+  void SetSp2_ID(Int_t isp2) {fSp2_ID= isp2;}
 
   virtual void ClearHits( );
 
@@ -59,7 +63,8 @@ public:
 protected:
   Int_t fnSP; /* Number of space points in this track */
   THcSpacePoint* fSp[10];         /* List of space points in this track */
-
+  Int_t fSp1_ID;
+  Int_t fSp2_ID;
   Int_t fNHits;
   Int_t fNfree;		  /* Number of degrees of freedom */
   struct Hit {

--- a/src/THcDriftChamber.h
+++ b/src/THcDriftChamber.h
@@ -93,6 +93,7 @@ protected:
   Int_t fHMSStyleChambers;
   Int_t fhdebugflagpr;
   Int_t fdebugstubchisq;
+  Double_t fRatio_xpfp_to_xfp; // Used in selecting stubs 
   Double_t fZPos;
   Double_t fXCenter;
   Double_t fYCenter;

--- a/src/THcSpacePoint.h
+++ b/src/THcSpacePoint.h
@@ -67,6 +67,10 @@ public:
   void IncCombos() { fNCombos++; };
   void SetCombos(Int_t ncombos) { fNCombos=ncombos; };
   Int_t GetCombos() { return fNCombos; };
+  Double_t GetStubX() {return fStub[0];};
+  Double_t GetStubXP() {return fStub[2];};
+  Double_t GetStubY() {return fStub[1];};
+  Double_t GetStubYP() {return fStub[3];};
 
   // This is the chamber number (1,2), not index (0,1).  Sometime
   // we need figure out how to avoid confusion between number and index.

--- a/src/THcSpacePoint.h
+++ b/src/THcSpacePoint.h
@@ -75,6 +75,7 @@ public:
   // This is the chamber number (1,2), not index (0,1).  Sometime
   // we need figure out how to avoid confusion between number and index.
   Int_t fNChamber;
+  Int_t fNChamber_spnum;
 
 protected:
 


### PR DESCRIPTION
Modified THcDriftChamber

1) Add to tree variable arrays stub_x,stub_xp,stub_y and stub_yp
    and ncombos. These are arrays of the number of spacepoints in
    the chamber.

2) In ReadDatabase
   a) new variable  fRatio_xpfp_to_xfp which is set differently
       for HMS and SHMS. Used in method LeftRight
   b) Set default value of optional parameter fStubMaxXPDiff = 999.

3)  Modified method LeftRight
   a) Previously only for the old fHMSStyleChambers would
      the code only select LR combinations where
      the difference between stub_xp to space_point_X*ratio is
        with in the fStubMaxXPDiff .
      The ratio came from the HMS optics.
   b) Changed LeftRight so that if fStubMaxXPDiff < 100
         then the code will only select LR combinations where
      the difference between stub_xp to space_point_X*ratio is
        with in the fStubMaxXPDiff . The ratio is
      set in ReadDataBase according to the spectrometer.

5) In FindSpacePoints add some comments.

Modify THcDC and THcSpacePoint.h

Modified THcSpacePoint.h to have public member that keeps track
   of the spacepoint ID number for each chamber.
   Used in THcDC::LinkStubs

Modified THcDC.cxx and h
1) Add tree variables sp1_id and sp2_id which are the integer
    ID in the spacepoints in each chamber used in the golden track.
     The ID refers to index in array of spacepoints created in
     THcDriftChamber.cxx

2) Modify LinkStub to fill sp1_id and sp2_id for each track

3) For golden track fill sp1_ID_best and sp2_ID_best

Modify THCDCTrack

Add methods for setting the spacepoint integer identifier
  for two spacepoints used in the track.

Modify THcSpacePoint.h

Add calls:
+  Double_t GetStubX() {return fStub[0];};
+  Double_t GetStubXP() {return fStub[2];};
+  Double_t GetStubY() {return fStub[1];};
+  Double_t GetStubYP() {return fStub[3];};