### PR TITLE
Modify fFpTimeAll filling in THcHodoscope

### DIFF
--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -1295,7 +1295,8 @@ Int_t THcHodoscope::CoarseProcess( TClonesArray& tracks )
 	  fFPTime[ip] = 1000. * ( ip + 1 );
 	}
       }
-      Double_t fptime = FPTimeSum/nFPTimeSum;
+      Double_t fptime=-1000;
+      if (nFPTimeSum>0) fptime = FPTimeSum/nFPTimeSum;
       fFPTimeAll = fptime;
       Double_t dedx=0.0;
       for(UInt_t ih=0;ih<fTOFCalc.size();ih++) {
@@ -1666,6 +1667,7 @@ Int_t THcHodoscope::FineProcess( TClonesArray&  tracks  )
     THaTrack* theTrack = static_cast<THaTrack*>( tracks[itrk] );
     if (theTrack->GetIndex()==0) {
     fBeta=theTrack->GetBeta();
+    fFPTimeAll=theTrack->GetFPTime();
     Double_t shower_track_enorm = theTrack->GetEnergy()/theTrack->GetP();
     for (Int_t ip = 0; ip < fNumPlanesBetaCalc; ip++ ){
         Double_t pl_xypos=0;


### PR DESCRIPTION
fFPTimeAll is the average focal plane time from all
  scintillator times. In EstimatedFocalPlaneTime fFPTimeAll is set to
  starttime which is the average FP time without using the DC track info.

If there are tracks, then a focal plane time is calculated
for each track using the track information to improve the focal
plane time calculation and save for each track. Previously
 fFPTimeAll was being filled for each track, so in effect
fFPTimeAll was being filled with the FP time of the last track.
ALso there was no check that nFPTimeSum was not zero when
calculating average FP time, so one could get NaN values for
fFPTimeAll

To fix the problem , added  and modified line

Double_t fptime=-1000;
if (nFPTimeSum>0) fptime = FPTimeSum/nFPTimeSum;

And moved setting fFPTimeAll to THcHodoscope::FineProcess
Now fFPTimeAll is set to the average focal plane time of
the golden track.