### PR TITLE
THcHitList mod to correct for FADC trigger time slippage

### DIFF
--- a/src/THcHitList.cxx
+++ b/src/THcHitList.cxx
@@ -21,7 +21,7 @@
 using namespace std;
 
 #define SUPPRESSMISSINGADCREFTIMEMESSAGES 1
-THcHitList::THcHitList() : fMap(0), fTISlot(0)
+THcHitList::THcHitList() : fMap(0), fTISlot(0), fDisableSlipCorrection(kFALSE)
 {
   /// Normal constructor.
 
@@ -167,6 +167,8 @@ void THcHitList::InitHitList(THaDetMap* detmap,
 
   fNTDCRef_miss = 0;
   fNADCRef_miss = 0;
+
+  //  DisableSlipCorrection();
 }
 
 /**
@@ -213,9 +215,10 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
       }
     }
   }
+  if(fDisableSlipCorrection) fTISlot = -1;
     
   Int_t titime = 0;
-  if(fTISlot!=0) {
+  if(fTISlot>0) {
 #define FUDGE 7
     titime = evdata.GetData(fTICrate, fTISlot, 2, 0)-FUDGE;
     // Need to get the FADC time for all modules in this crate
@@ -487,7 +490,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
     }
   }
 #if 1
-  if(fTISlot) {
+  if(fTISlot>0) {
     //    cout << "TI ROC: " << fTICrate << "   TI Time: " << titime << endl;
     map<Int_t, Int_t>::iterator it;
     for(it=fTrigTimeShiftMap.begin(); it!=fTrigTimeShiftMap.end(); it++) {

--- a/src/THcHitList.h
+++ b/src/THcHitList.h
@@ -40,6 +40,7 @@ public:
   TClonesArray* GetHitList() const {return fRawHitList; }
   void          CreateMissReportParms(const char *prefix);
   void          MissReport(const char *name);
+  void          DisableSlipCorrection() {fDisableSlipCorrection = kTRUE;}
 
   UInt_t         fNRawHits;
   Int_t         fNMaxRawHits;
@@ -82,6 +83,7 @@ protected:
   Decoder::THaCrateMap* fMap;	/* The Crate map */
   Int_t fTISlot;
   Int_t fTICrate;
+  Double_t fDisableSlipCorrection;
   std::map<Int_t, Int_t> fTrigTimeShiftMap;
   std::map<Int_t, Decoder::Fadc250Module*> fFADCSlotMap;
 

--- a/src/THcHitList.h
+++ b/src/THcHitList.h
@@ -7,8 +7,11 @@
 #include "TClonesArray.h"
 #include "TObject.h"
 #include "Decoder.h"
+#include "THaCrateMap.h"
+#include "Fadc250Module.h"
 
 #include <iomanip>
+#include <map>
 
 using namespace std;
 
@@ -29,7 +32,7 @@ public:
 
   THcHitList();
 
-  virtual Int_t DecodeToHitList( const THaEvData&, Bool_t suppress=kFALSE );
+  virtual Int_t DecodeToHitList( const THaEvData& evdata, Bool_t suppress=kFALSE );
   void          InitHitList(THaDetMap* detmap,
 			    const char *hitclass, Int_t maxhits,
 			    Int_t tdcref_cut=0, Int_t adcref_cut=0);
@@ -75,6 +78,12 @@ protected:
 
   Int_t fNTDCRef_miss;
   Int_t fNADCRef_miss;
+
+  Decoder::THaCrateMap* fMap;	/* The Crate map */
+  Int_t fTISlot;
+  Int_t fTICrate;
+  std::map<Int_t, Int_t> fTrigTimeShiftMap;
+  std::map<Int_t, Decoder::Fadc250Module*> fFADCSlotMap;
 
   ClassDef(THcHitList,0);  // List of raw hits sorted by plane, counter
 };


### PR DESCRIPTION
Implement a correction for FADC trigger time slippage
      Correction is done in the hitlist by comparing the trigger time
      from the TI to the trigger time in the FADC.  These generally have
      a fixed offset.  A FUDGE offset is included to make the difference
      between the FADC and TI times zero or close to zero.
    
      The FADC delivers times in units of 0.0625 ns.  The trigger time is in
      units of 4ns.  So the FADCs will be shifted by 64 units for each unit
      of trigger time slippage.

Podd is updated to include some changes that are needed by this modification.
