### PR TITLE
Starttime fix

### DIFF
--- a/src/THcDCTrack.h
+++ b/src/THcDCTrack.h
@@ -44,7 +44,7 @@ public:
   Double_t GetXP()                 const {return fXp_fp;}
   Double_t GetYP()                 const {return fYp_fp;}
   Double_t GetSp1_ID()                 const {return fSp1_ID;}
-  Double_t GetSp2_ID()                 const {return fSp1_ID;}
+  Double_t GetSp2_ID()                 const {return fSp2_ID;}
   Double_t GetChisq()              const {return fChi2_fp;}
   void SetNFree(Int_t nfree)           {fNfree = nfree;}
   void SetCoord(Int_t ip, Double_t coord) {fCoords[ip] = coord;}

--- a/src/THcDriftChamber.cxx
+++ b/src/THcDriftChamber.cxx
@@ -1146,8 +1146,8 @@ void THcDriftChamber::LeftRight()
 	  if((pindex1%2)==0) { // Odd plane (or even index)
 	    for(Int_t ihit2=0;ihit2<nhits;ihit2++) {
 	      THcDCHit* hit2 = sp->GetHit(ihit2);
-	      if(hit2->GetPlaneIndex()-pindex1 == 1) { // Adjacent plane
-		if(hit2->GetPos() <= hit1->GetPos()) {
+	      if(hit2->GetPlaneIndex()-pindex1 == 1 && TMath::Abs(hit2->GetPos()-hit1->GetPos())<0.51) { // Adjacent plane
+		if(hit2->GetPos() <= hit1->GetPos() ) {
 		  plusminusknown[ihit1] = -1;
 		  plusminusknown[ihit2] = 1;
 		} else {

--- a/src/THcDriftChamberPlane.cxx
+++ b/src/THcDriftChamberPlane.cxx
@@ -365,6 +365,7 @@ Int_t THcDriftChamberPlane::SubtractStartTime()
      THcDCHit *thishit = (THcDCHit*) fHits->At(ihit);
      Double_t temptime= thishit->GetTime()-StartTime;
      thishit->SetTime(temptime);
+     thishit->ConvertTimeToDist();
    }
   return 0;
 }

--- a/src/THcDriftChamberPlane.h
+++ b/src/THcDriftChamberPlane.h
@@ -42,6 +42,9 @@ public:
 
   virtual Int_t ProcessHits(TClonesArray* rawhits, Int_t nexthit);
 
+  virtual Int_t SubtractStartTime();
+
+
   // Get and Set functions
   Int_t        GetNWires()   const { return fWires->GetLast()+1; }
   THcDCWire*  GetWire(Int_t i) const

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -163,6 +163,7 @@ THaAnalysisObject::EStatus THcHodoscope::Init( const TDatime& date )
   // maximum number of hits after setting up the detector map
   // But it needs to happen before the sub detectors are initialized
   // so that they can get the pointer to the hitlist.
+  cout << " Hodo tdc ref time cut = " << fTDC_RefTimeCut << " " << fADC_RefTimeCut << endl;
 
   InitHitList(fDetMap, "THcRawHodoHit", fDetMap->GetTotNumChan()+1,
 	      fTDC_RefTimeCut, fADC_RefTimeCut);
@@ -645,6 +646,7 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
   Int_t nexthit = 0;
 
   fNfptimes=0;
+  Int_t thits=0;
   for(Int_t ip=0;ip<fNPlanes;ip++) {
 
     fPlaneCenter[ip] = fPlanes[ip]->GetPosCenter(0) + fPlanes[ip]->GetPosOffset();
@@ -654,11 +656,12 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
     // GN: select only events that have reasonable TDC values to start with
     // as per the Engine h_strip_scin.f
     nexthit = fPlanes[ip]->ProcessHits(fRawHitList,nexthit);
+    thits+=fPlanes[ip]->GetNScinHits();
   }
-  EstimateFocalPlaneTime();
+    fStartTime=-1000;
+    if (thits>0 ) EstimateFocalPlaneTime();
 
   if (fdebugprintscinraw == 1) {
-    cout << " Event number = " << evdata.GetEvNum()<<endl;
   for(UInt_t ihit = 0; ihit < fNRawHits ; ihit++) {
 //    THcRawHodoHit* hit = (THcRawHodoHit *) fRawHitList->At(ihit);
 //    cout << ihit << " : " << hit->fPlane << ":" << hit->fCounter << " : "


### PR DESCRIPTION
Modify THcDC, THcDriftChamberPlane

THcDriftChamberPlane

  1) Remove subtraction of hodoscope starttime from ProcessHits
    which is called by THcDC::Decode.
  The hodoscope start time is determined in hodoscope Decode
   which is called after THcDC::Decode. So drift chamber
   was using the starttime from the previous event.

   2) Create method SubtractStartTime which is called by THcDC:CoarseTrack
        Add call ConvertTimeToDist in SubtractStartTime method

THcDriftChamber
    1) Move fChambers[ic]->ProcessHits() to CoarseTrack
    2) Before looping through fChambers[ic]->ProcessHits() in CoarseTrack
        loop through all planes and call fPlanes[ip]->SubtractStartTime()

Modify THcDCTrack.h   Fix type in GetSp2_ID()

Updated THcDriftChamber.cxx
          In LeftRight method when using SmallAngle Approximation and
          additional condition that the wires in adjacent plane have to
          be within 0.51cm.

Updated THcHodoscope.cxx
     Modify so default starttime is -1000.
     Modify so if no hits in scintillator then EstimateFocalPlane is not called.