### PR TITLE
Fix memory leaks

### DIFF
--- a/src/THcDCHit.h
+++ b/src/THcDCHit.h
@@ -19,7 +19,7 @@ public:
   THcDCHit( THcDCWire* wire=NULL, Int_t rawnorefcorrtime=0, Int_t rawtime=0, Double_t time=0.0,
     THcDriftChamberPlane* wp=0) :
     fWire(wire), fRawNoRefCorrTime(rawnorefcorrtime), fRawTime(rawtime), fTime(time), fWirePlane(wp),
-    fDist(0.0), ftrDist(kBig) {
+      fDist(0.0), fLR(0), ftrDist(kBig) {
       if (wire) ConvertTimeToDist();
       fCorrected = 0;
     }

--- a/src/THcDCTrack.cxx
+++ b/src/THcDCTrack.cxx
@@ -31,11 +31,13 @@ void THcDCTrack::AddSpacePoint( THcSpacePoint* sp )
 {
   // Add to list of space points in this track
   // Need a check for maximum spacepoints of 10
+  if (fnSP <10) {
   fSp[fnSP++] = sp;
   // Copy all the hits from the space point into the track
   // Will need to also copy the corrected distance and lr information
   for(Int_t ihit=0;ihit<sp->GetNHits();ihit++) {
     AddHit(sp->GetHit(ihit),sp->GetHitDist(ihit),sp->GetHitLR(ihit));
+  }
   }
 }
 

--- a/src/THcHodoEff.cxx
+++ b/src/THcHodoEff.cxx
@@ -377,6 +377,8 @@ Int_t THcHodoEff::Process( const THaEvData& evdata )
 
   for(Int_t ip=0;ip<fNPlanes;ip++) {
     Int_t hitcounter = hitCounter[ip];
+    if (hitcounter>=fNCounters[ip]) hitcounter=fNCounters[ip]-1;
+    if (hitcounter<0) hitcounter=0;    
     Double_t dist = hitDistance[ip];
     Int_t nphits=fPlanes[ip]->GetNScinHits();
     TClonesArray* hodoHits = fPlanes[ip]->GetHits();
@@ -387,7 +389,6 @@ Int_t THcHodoEff::Process( const THaEvData& evdata )
       Bool_t onTrack, goodScinTime, goodTdcNeg, goodTdcPos;
       fHod->GetFlags(trackIndex,ip,ihit,
 		     onTrack, goodScinTime, goodTdcNeg, goodTdcPos);
-
       if(TMath::Abs(dist) <= fStatSlop &&
 	 TMath::Abs(hitcounter-counter) <= checkHit[ip] &&
 	 fHitPlane[ip] == 0 &&

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -646,7 +646,7 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
   Int_t nexthit = 0;
 
   fNfptimes=0;
-  Int_t thits=0;
+  Int_t thits = 0;
   for(Int_t ip=0;ip<fNPlanes;ip++) {
 
     fPlaneCenter[ip] = fPlanes[ip]->GetPosCenter(0) + fPlanes[ip]->GetPosOffset();
@@ -676,7 +676,7 @@ Int_t THcHodoscope::Decode( const THaEvData& evdata )
 }
 
 //_____________________________________________________________________________
-void THcHodoscope::EstimateFocalPlaneTime( void )
+void THcHodoscope::EstimateFocalPlaneTime()
 {
   /*! \brief Calculates the Drift Chamber start time and fBetaNoTrk (velocity determined without track info)
    *

--- a/src/THcScalerEvtHandler.cxx
+++ b/src/THcScalerEvtHandler.cxx
@@ -143,14 +143,8 @@ Int_t THcScalerEvtHandler::ReadDatabase(const TDatime& date )
     fbcm_Current_Threshold_Index = 0;
     gHcParms->LoadParmValues((DBRequest*)&list2, prefix);
     vector<string> bcm_names = vsplit(bcm_namelist);
-    fBCM_Name = new char* [fNumBCMs];
     for(Int_t i=0;i<fNumBCMs;i++) {
-      fBCM_Name[i] = new char[bcm_names[i].length()+1];
-      strcpy(fBCM_Name[i], bcm_names[i].c_str());
-      strcat(fBCM_Name[i],".scal");
-      //    cout << fBCM_Gain[i] << " " << fBCM_Offset[i] << " " << fBCM_Name[i] << endl;
-    }
-    for(Int_t i=0;i<fNumBCMs;i++) {
+      fBCM_Name.push_back(bcm_names[i]+".scal");
       fBCM_delta_charge[i]=0.;
     }
   }

--- a/src/THcScalerEvtHandler.h
+++ b/src/THcScalerEvtHandler.h
@@ -17,6 +17,8 @@
 #include <set>
 #include "TTree.h"
 #include "TString.h"
+#include <cstring>
+
 
 class HCScalerLoc { // Utility class used by THaScalerEvtHandler
  public:
@@ -62,7 +64,7 @@ private:
    Double_t fbcm_Current_Threshold;
    Double_t fClockFreq;
    Int_t fbcm_Current_Threshold_Index;
-   char** fBCM_Name;
+   std::vector <std::string> fBCM_Name;
    UInt_t evcount;
    Double_t evcountR;
    UInt_t evNumber;

--- a/src/THcSpacePoint.h
+++ b/src/THcSpacePoint.h
@@ -15,7 +15,7 @@ class THcSpacePoint : public TObject {
 public:
 
   THcSpacePoint(Int_t nhits=0, Int_t ncombos=0) :
-    fNHits(nhits), fNCombos(ncombos) {
+  fNHits(nhits), fNCombos(ncombos),fSetStubFlag(kFALSE) {
     fHits.clear();
   }
   virtual ~THcSpacePoint() {}
@@ -42,6 +42,7 @@ public:
   void SetNHits(Int_t nhits) {fNHits = nhits;};
   Double_t GetX() {return fX;};
   Double_t GetY() {return fY;};
+  Bool_t GetSetStubFlag() {return fSetStubFlag;};
   THcDCHit* GetHit(Int_t ihit) {return fHits[ihit].dchit;};
   //  std::vector<THcDCHit*>* GetHitVectorP() {return &fHits;};
   //std::vector<Hit>* GetHitStuffVectorP() {return &fHits;};
@@ -60,6 +61,7 @@ public:
     for(Int_t i=0;i<4;i++) {
       fStub[i] = stub[i];
     }
+    fSetStubFlag=kTRUE;
   };
   Double_t GetHitDist(Int_t ihit) { return fHits[ihit].distCorr; };
   Int_t GetHitLR(Int_t ihit) { return fHits[ihit].lr; };
@@ -87,6 +89,7 @@ protected:
   std::vector<Hit> fHits;
   //std::vector<THcDCHit*> fHits;
   Double_t fStub[4];
+  Bool_t fSetStubFlag;
   // Should we also have a pointer back to the chamber object
 
   ClassDef(THcSpacePoint,0);   // Space Point/stub track in a single drift chamber


### PR DESCRIPTION
 Modify THcDC, THcDriftChamber, THcSpacePoint

THcSpacePoint
  1) added fSetStubFlag which is intialized
     to kFALSE in constructor and set to kTRUE
     when SetStub is called.
   2) added method GetSetStubFlag which
      returns fSetStubFlag.

THcDriftchamber
   1) In ProcessHits increased fHits reserve to 40
   2) In FindSpacePoints use fSpacePoints->Delete();
   3) In LeftRight ,only SetStub if the Stub is fit.

THcDC
   1) In LinkStubs
      a) only link stubs if number of total spacepoints <10
      b) only link stubs if both spacepoints have SetStubFlag true

THcDCHit.h
   1) In constructor initalize fLR to 0

THcDCTrack.cxx
   1) AddSpacePoint check if fnSP < 10

 Modify THcHodoEff

In Process add if statement to be sure that hitcounter is
  greater than zero and less than total number of paddles
  in the plane

 Modify THcHodoscope

Eliminate "void" in THcHodoscope::EstimateFocalPlaneTime( void )

 Modify THcScalerEvtHandler

Change fBCM_Name to vector of strings .
Fixed memory leak when it was array of char.