### PR TITLE
added function to get Min/Max time Windows

### DIFF
--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -71,6 +71,28 @@ public:
     return ( Side == 0 ? fPosGain[nelem] : fNegGain[nelem]);
   }
 
+  Double_t GetWindowMin(Int_t NBlock, Int_t NLayer, Int_t Side) {
+    if (Side!=0&&Side!=1) {
+      cout << "*** Wrong Side in GetWindowMin:" << Side << " ***" << endl;
+      return -1;
+    }
+    Int_t nelem = 0;
+    for (Int_t i=0; i<NLayer; i++) nelem += fNBlocks[i];
+    nelem += NBlock;
+    return ( Side == 0 ? fPosAdcTimeWindowMin[nelem] : fNegAdcTimeWindowMin[nelem] );
+  }
+
+  Double_t GetWindowMax(Int_t NBlock, Int_t NLayer, Int_t Side) {
+    if (Side!=0&&Side!=1) {
+      cout << "*** Wrong Side in GetWindowMax:" << Side << " ***" << endl;
+      return -1;
+    }
+    Int_t nelem = 0;
+    for (Int_t i=0; i<NLayer; i++) nelem += fNBlocks[i];
+    nelem += NBlock;
+    return ( Side == 0 ? fPosAdcTimeWindowMax[nelem] : fNegAdcTimeWindowMax[nelem] );
+  }
+
   Int_t GetADCMode() {
     return fADCMode;
   }

--- a/src/THcShowerPlane.cxx
+++ b/src/THcShowerPlane.cxx
@@ -744,14 +744,9 @@ void THcShowerPlane::FillADC_DynamicPedestal()
 {
   Double_t StartTime = 0.0;
   if( fglHod ) StartTime = fglHod->GetStartTime();
-  Double_t* PosAdcTimeWindowMin=static_cast<THcShower*>(fParent)->GetPosAdcTimeWindowMin();
-  Double_t* NegAdcTimeWindowMin=static_cast<THcShower*>(fParent)->GetNegAdcTimeWindowMin();
-  Double_t* PosAdcTimeWindowMax=static_cast<THcShower*>(fParent)->GetPosAdcTimeWindowMax();
-  Double_t* NegAdcTimeWindowMax=static_cast<THcShower*>(fParent)->GetNegAdcTimeWindowMax();
   for (Int_t ielem=0;ielem<frNegAdcPulseInt->GetEntries();ielem++) {
-    Int_t    npad         = ((THcSignalHit*) frNegAdcPulseInt->ConstructedAt(ielem))->GetPaddleNumber() - 1;
-    Int_t    nblock	  = npad*(fLayerNum-1)+npad;
-    Double_t pulseInt     = ((THcSignalHit*) frNegAdcPulseInt->ConstructedAt(ielem))->GetData();
+   Int_t    npad         = ((THcSignalHit*) frNegAdcPulseInt->ConstructedAt(ielem))->GetPaddleNumber() - 1;
+   Double_t pulseInt     = ((THcSignalHit*) frNegAdcPulseInt->ConstructedAt(ielem))->GetData();
     Double_t pulsePed     = ((THcSignalHit*) frNegAdcPed->ConstructedAt(ielem))->GetData();
     Double_t pulseAmp     = ((THcSignalHit*) frNegAdcPulseAmp->ConstructedAt(ielem))->GetData();
     Double_t pulseIntRaw  = ((THcSignalHit*) frNegAdcPulseIntRaw->ConstructedAt(ielem))->GetData();
@@ -759,8 +754,10 @@ void THcShowerPlane::FillADC_DynamicPedestal()
     Double_t adctdcdiffTime = StartTime-pulseTime;
     Double_t threshold    = ((THcSignalHit*) frNegAdcThreshold->ConstructedAt(ielem))->GetData();
     Bool_t   errorflag    = ((THcSignalHit*) frNegAdcErrorFlag->ConstructedAt(ielem))->GetData();
-    Bool_t   pulseTimeCut = (adctdcdiffTime > NegAdcTimeWindowMin[nblock]) && (adctdcdiffTime < NegAdcTimeWindowMax[nblock]);
+    Bool_t   pulseTimeCut = (adctdcdiffTime > static_cast<THcShower*>(fParent)->GetWindowMin(npad,fLayerNum-1,1)) && (adctdcdiffTime < static_cast<THcShower*>(fParent)->GetWindowMax(npad,fLayerNum-1,1) );
+
     
+ 
     if (!errorflag)
       {
 	fGoodNegAdcMult.at(npad) += 1;
@@ -789,9 +786,8 @@ void THcShowerPlane::FillADC_DynamicPedestal()
   }
   //
   for (Int_t ielem=0;ielem<frPosAdcPulseInt->GetEntries();ielem++) {
-    Int_t    npad         = ((THcSignalHit*) frPosAdcPulseInt->ConstructedAt(ielem))->GetPaddleNumber() - 1;
-    Int_t    nblock	  = npad*(fLayerNum-1)+npad;
-    Double_t pulsePed     = ((THcSignalHit*) frPosAdcPed->ConstructedAt(ielem))->GetData();
+   Int_t    npad         = ((THcSignalHit*) frPosAdcPulseInt->ConstructedAt(ielem))->GetPaddleNumber() - 1;
+      Double_t pulsePed     = ((THcSignalHit*) frPosAdcPed->ConstructedAt(ielem))->GetData();
     Double_t threshold    = ((THcSignalHit*) frPosAdcThreshold->ConstructedAt(ielem))->GetData();
     Double_t pulseAmp     = ((THcSignalHit*) frPosAdcPulseAmp->ConstructedAt(ielem))->GetData();
     Double_t pulseInt     = ((THcSignalHit*) frPosAdcPulseInt->ConstructedAt(ielem))->GetData();
@@ -799,8 +795,10 @@ void THcShowerPlane::FillADC_DynamicPedestal()
     Double_t pulseTime    = ((THcSignalHit*) frPosAdcPulseTime->ConstructedAt(ielem))->GetData();
      Double_t adctdcdiffTime = StartTime-pulseTime;
    Bool_t   errorflag    = ((THcSignalHit*) frPosAdcErrorFlag->ConstructedAt(ielem))->GetData();
-    Bool_t   pulseTimeCut = (adctdcdiffTime > PosAdcTimeWindowMin[nblock]) &&  (adctdcdiffTime < PosAdcTimeWindowMax[nblock]);
-       
+   Bool_t   pulseTimeCut = (adctdcdiffTime > static_cast<THcShower*>(fParent)->GetWindowMin(npad,fLayerNum-1,0)) && (adctdcdiffTime < static_cast<THcShower*>(fParent)->GetWindowMax(npad,fLayerNum-1,0) );
+
+
+
     if (!errorflag)
       {
 	fGoodPosAdcMult.at(npad) += 1;


### PR DESCRIPTION
Add functions to THcShower.h to get Min/Max time windows. 
Used by THcShowerPlane for cuts in Hodoscope starttime - ADC Time.
Fixes bug in THcShowerPlane which was calculating the wrong index for the Min/Max Time Windows
on the  Hodoscope starttime - ADC Time.