### PR TITLE
Restore ability to analyze 6 GeV data

### DIFF
--- a/examples/PARAM/hcana.param
+++ b/examples/PARAM/hcana.param
@@ -7,6 +7,7 @@ hhodo_num_planes = 4
 hhodo_plane_names = "1x 1y 2x 2y"
 hhodo_AdcTimeWindowMin = 0., 0., 0., 0.
 hhodo_AdcTimeWindowMax = 3200., 3200., 3200., 3200.
+hhodo_adc_mode = 0 # Standard ADC
 
 hcal_num_layers = 4
 
@@ -50,6 +51,8 @@ shodo_plane_names = "1x 1y 2x 2y"
 
 shodo_AdcTimeWindowMin = 0., 0., 0., 0.
 shodo_AdcTimeWindowMax = 3200., 3200., 3200., 3200.
+
+shodo_adc_mode = 0 # Standard ADC
 
 scal_num_layers = 4
 

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -1791,7 +1791,8 @@ Int_t THcHodoscope::FineProcess( TClonesArray&  tracks  )
 	  if ( fTOFCalc[ih].good_tdc_pos && fTOFCalc[ih].good_tdc_neg ) {
 	    Bool_t sh_pid=(shower_track_enorm > fTOFCalib_shtrk_lo && shower_track_enorm < fTOFCalib_shtrk_hi);
 	    Bool_t beta_pid=( fBeta > fTOFCalib_beta_lo &&  fBeta < fTOFCalib_beta_hi);
-	    Bool_t cer_pid=( fCherenkov->GetCerNPE() > fTOFCalib_cer_lo);
+	    // cer_pid is true if there is no Cherenkov detector
+	    Bool_t cer_pid=(fCherenkov?(fCherenkov->GetCerNPE()>fTOFCalib_cer_lo):kTRUE);
 	    if(fDumpTOF && Ntracks==1 && fGoodEventTOFCalib && sh_pid && beta_pid && cer_pid) {
 	      fDumpOut << fixed << setprecision(2);
 	      fDumpOut  << showpoint << " 1" << setw(3) << ip+1 << setw(3) << hit->GetPaddleNumber()  << setw(10) << hit->GetPosTDC()*fScinTdcToTime  << setw(10) << fTOFPInfo[ih].pathp << setw(10) << fTOFPInfo[ih].zcor  << setw(10) << fTOFPInfo[ih].time_pos << setw(10) << hit->GetPosADC() << endl;

--- a/src/THcInterface.cxx
+++ b/src/THcInterface.cxx
@@ -103,9 +103,9 @@ void THcInterface::PrintLogo( Bool_t lite )
      Printf("  *            W E L C O M E  to  the            *");
      Printf("  *          H A L L C ++  A N A L Y Z E R       *");
      Printf("  *                                              *");
-     Printf("  *  hcana release %10s %18s *",HC_VERSION,HC_DATE);
-     Printf("  *  PODD release  %10s %18s *",HA_VERSION,HA_DATE);
-     Printf("  *  ROOT            %8s %18s *",root_version,root_date);
+     Printf("  *  hcana release %12s %16s *",HC_VERSION,HC_DATE);
+     Printf("  *  PODD release %13s %16s *",HA_VERSION,HA_DATE);
+     Printf("  *  ROOT            %10s %16s *",root_version,root_date);
      Printf("  *                                              *");
      Printf("  *            For information visit             *");
      Printf("  *      http://hallcweb.jlab.org/hcana/docs/    *");

--- a/src/THcScintillatorPlane.cxx
+++ b/src/THcScintillatorPlane.cxx
@@ -893,12 +893,15 @@ Int_t THcScintillatorPlane::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
     } else if (fADCMode == kADCSampleIntegral) {
       adcint_pos = hit->GetRawAdcHitPos().GetSampleIntRaw() - fPosPed[index];
       adcint_neg = hit->GetRawAdcHitNeg().GetSampleIntRaw() - fNegPed[index];
+      badcraw_pos = badcraw_neg = kTRUE;
     } else if (fADCMode == kADCSampIntDynPed) {
       adcint_pos = hit->GetRawAdcHitPos().GetSampleInt();
       adcint_neg = hit->GetRawAdcHitNeg().GetSampleInt();
+      badcraw_pos = badcraw_neg = kTRUE;
     } else {
       adcint_pos = hit->GetRawAdcHitPos().GetPulseIntRaw()-fPosPed[index];
       adcint_neg = hit->GetRawAdcHitNeg().GetPulseIntRaw()-fNegPed[index];
+      badcraw_pos = badcraw_neg = kTRUE;
     }
     if (adcint_pos >= fADCDiagCut) {
       ((THcSignalHit*) frPosADCHits->ConstructedAt(nrPosADCHits))->Set(padnum, adcint_pos);


### PR DESCRIPTION
Restore ability to analyze 6 GeV data.
      Set hodoscopes to standard ADC mode for example hodtest.C script
      badcraw_pos and badcraw_neg always true if not Dynamic pedestal mode
      Don't crash in hodoscope if there is no Cherenkov.

Also fix formatting of welcome text.