### PR TITLE
Modify THcHodoscope and THcScintillator

### DIFF
--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -546,7 +546,10 @@ Int_t THcHodoscope::DefineVariables( EMode mode )
     {"starttime",         "Hodoscope Start Time",                         "fStartTime"},
     {"goodstarttime",     "Hodoscope Good Start Time (logical flag)",                    "fGoodStartTime"},
     {"goodscinhit",       "Hit in fid area",                              "fGoodScinHits"},
-    { 0 }
+    {"TimeHist_Sigma",       "",                              "fTimeHist_Sigma"},
+    {"TimeHist_Peak",       "",                              "fTimeHist_Peak"},
+    {"TimeHist_Hits",       "",                              "fTimeHist_Hits"},
+     { 0 }
   };
   return DefineVarsFromList( vars, mode );
   //  return kOK;
@@ -632,6 +635,9 @@ void THcHodoscope::ClearEvent()
    *  Called by  THcHodoscope::Decode
    *
    */
+  fTimeHist_Sigma=  kBig;
+  fTimeHist_Peak=  kBig;
+  fTimeHist_Hits=  kBig;
 
   fBeta = 0.0;
   fBetaNoTrk = 0.0;
@@ -780,6 +786,9 @@ void THcHodoscope::EstimateFocalPlaneTime()
   Bool_t goodplanetime[fNPlanes];
   Bool_t twogoodtimes[nscinhits];
   Double_t tmin = 0.5*hTime->GetMaximumBin();
+  fTimeHist_Peak=  tmin;
+  fTimeHist_Sigma=  hTime->GetRMS();
+  fTimeHist_Hits=  hTime->Integral();
   for(Int_t ip=0;ip<fNumPlanesBetaCalc;ip++) {
     goodplanetime[ip] = kFALSE;
     Int_t nphits=fPlanes[ip]->GetNScinHits();

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -778,6 +778,7 @@ void THcHodoscope::EstimateFocalPlaneTime()
     }
   }
   //
+  //
   ihit = 0;
   Double_t fpTimeSum = 0.0;
   fNfptimes=0;
@@ -827,7 +828,7 @@ void THcHodoscope::EstimateFocalPlaneTime()
       }
       ihit++;
     }
-    fPlanes[ip]->SetFpTime(Plane_fptime_sum/float(Ngood_hits_plane));
+    if (Ngood_hits_plane) fPlanes[ip]->SetFpTime(Plane_fptime_sum/float(Ngood_hits_plane));
     fPlanes[ip]->SetNGoodHits(Ngood_hits_plane);
   }
 
@@ -840,7 +841,8 @@ void THcHodoscope::EstimateFocalPlaneTime()
     fGoodStartTime=kFALSE;
     fFPTimeAll = fStartTime ;
   }
-  //
+    //
+   //
   hTime->Reset();
   //
   if((goodplanetime[0]||goodplanetime[1]) &&(goodplanetime[2]||goodplanetime[3])) {
@@ -943,7 +945,6 @@ void THcHodoscope::EstimateFocalPlaneTime()
     if ((fNumPlanesBetaCalc==4)&&goodplanetime[0]&&goodplanetime[1]&&goodplanetime[2]&&goodplanetime[3]&&fPlanes[0]->GetNGoodHits()==1&&fPlanes[1]->GetNGoodHits()==1&&fPlanes[2]->GetNGoodHits()==1&&fPlanes[3]->GetNGoodHits()==1) fGoodEventTOFCalib=kTRUE;
     if ((fNumPlanesBetaCalc==3)&&goodplanetime[0]&&goodplanetime[1]&&goodplanetime[2]&&fPlanes[0]->GetNGoodHits()==1&&fPlanes[1]->GetNGoodHits()==1&&fPlanes[2]->GetNGoodHits()==1) fGoodEventTOFCalib=kTRUE;
     //
-
     //
   }
 }
@@ -1104,8 +1105,10 @@ Int_t THcHodoscope::CoarseProcess( TClonesArray& tracks )
 		  /TMath::Sqrt(TMath::Max(20.0*.020,adc_pos));
 	      } else {
 	        //Double_t tw_corr_pos = fHodoPos_c1[fPIndex]/pow(adcamp_pos/fTdc_Thrs,fHodoPos_c2[fPIndex]) -  fHodoPos_c1[fPIndex]/pow(200./fTdc_Thrs, fHodoPos_c2[fPIndex]);
-		Double_t tw_corr_pos = 1./pow(adcamp_pos/fTdc_Thrs,fHodoPos_c2[fPIndex]) -  1./pow(200./fTdc_Thrs, fHodoPos_c2[fPIndex]);            
-		timep += -tw_corr_pos + fHodo_LCoeff[fPIndex];
+		Double_t tw_corr_pos=0.;
+		pathp=scinLongCoord;
+		if (adcamp_pos>0) tw_corr_pos = 1./pow(adcamp_pos/fTdc_Thrs,fHodoPos_c2[fPIndex]) -  1./pow(200./fTdc_Thrs, fHodoPos_c2[fPIndex]);            
+		timep += -tw_corr_pos + fHodo_LCoeff[fPIndex]+ pathp/fHodoVelFit[fPIndex];
 	      }
 	      fTOFPInfo[ihhit].scin_pos_time = timep;
  	      timep -= zcor;
@@ -1126,9 +1129,10 @@ Int_t THcHodoscope::CoarseProcess( TClonesArray& tracks )
 		  + fHodoNegInvAdcAdc[fPIndex]
 		  /TMath::Sqrt(TMath::Max(20.0*.020,adc_neg));
 	      } else {
-		// Double_t tw_corr_neg = fHodoNeg_c1[fPIndex]/pow(adcamp_neg/fTdc_Thrs,fHodoNeg_c2[fPIndex]) -  fHodoNeg_c1[fPIndex]/pow(200./fTdc_Thrs, fHodoNeg_c2[fPIndex]);
-		Double_t tw_corr_neg = 1./pow(adcamp_neg/fTdc_Thrs,fHodoNeg_c2[fPIndex]) -  1./pow(200./fTdc_Thrs, fHodoNeg_c2[fPIndex]);              
-		timen += -tw_corr_neg- 2*fHodoCableFit[fPIndex] + fHodo_LCoeff[fPIndex];
+		pathn=scinLongCoord ;
+		Double_t tw_corr_neg =0 ;
+		if (adcamp_neg >0) tw_corr_neg= 1./pow(adcamp_neg/fTdc_Thrs,fHodoNeg_c2[fPIndex]) -  1./pow(200./fTdc_Thrs, fHodoNeg_c2[fPIndex]);              
+		timen += -tw_corr_neg- 2*fHodoCableFit[fPIndex] + fHodo_LCoeff[fPIndex]- pathn/fHodoVelFit[fPIndex];
 
 	      }
 	      fTOFPInfo[ihhit].scin_neg_time = timen;
@@ -1145,7 +1149,6 @@ Int_t THcHodoscope::CoarseProcess( TClonesArray& tracks )
 	//-----------------------------------------------------------------------------------------------
       }
       Int_t nhits=ihhit;
-
 
 
       if(0.5*hTime->GetMaximumBin() > 0) {

--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -155,6 +155,9 @@ protected:
   Double_t fFPTimeAll;
   Int_t fNfptimes;
   Bool_t* fPresentP;
+  Double_t fTimeHist_Peak;
+  Double_t fTimeHist_Sigma;
+  Double_t fTimeHist_Hits;
 
   Double_t     fBeta;
 


### PR DESCRIPTION
1. Modify THcScintillatorPlane.cxx:  In ProcessHits add check of adc in if statements when calculating the time walk correction.

2. Modify THcHodoscope to add tree variables TimeHist_Sigma, TimeHist_Peak and TimeHist_Hits
for the peak,sigma and number of hits of the histogram of PMT times used in EstimateFocalPlaneTime

3. Modify THcHodoscope.cxx: Modify code in CoarseProcess to add (subtract) time due to hit
location in paddle for positive (negative) PMT for new hodoscope beta parameters.