### PR TITLE
Modify src/THcRaster.cxx

### DIFF
--- a/src/THcRaster.cxx
+++ b/src/THcRaster.cxx
@@ -193,7 +193,10 @@ Int_t THcRaster::ReadDatabase( const TDatime& date )
     {"usefr", &fgusefr, kInt,0,1},
     {0}
   };
-
+  //
+  fgbpma_zpos = 370.82;
+  fgbpmb_zpos = 224.96 ;// cm
+    fgbpmc_zpos = 129.30 ;// cm
   // Default offsets to zero and slopes to +/- 1
   fgbeam_xoff = 0.0;
   fgbeam_xpoff = 0.0;


### PR DESCRIPTION
In the ReadDatabase , added default values for optional values of
     fgbpma_zpos = 370.82;
    fgbpmb_zpos = 224.96 ;// cm
    fgbpmc_zpos = 129.30 ;// cm

instead of zero.

Otherwise the code would get NaN for the calculated target beam position
since it was divied by zero unless this the parameters are set externally in PARAM file.