### PR TITLE
Modify THcExtTarCor to calculate xsieve, ysieve for spectrometer

### DIFF
--- a/src/THcExtTarCor.cxx
+++ b/src/THcExtTarCor.cxx
@@ -37,6 +37,17 @@ THcExtTarCor::~THcExtTarCor()
 
   DefineVariables( kDelete );
 }
+//_____________________________________________________________________________
+void THcExtTarCor::Clear( Option_t* opt )
+{
+  // Clear all event-by-event variables.
+  
+  THaPhysicsModule::Clear(opt);
+  TrkIfoClear();
+  fDeltaTh = fDeltaDp = fDeltaP = 0.0;
+  fxsieve = kBig;
+  fysieve = kBig;
+}
 
 //_____________________________________________________________________________
 Int_t THcExtTarCor::DefineVariables( EMode mode )
@@ -52,6 +63,8 @@ Int_t THcExtTarCor::DefineVariables( EMode mode )
     { "delta_p",  "Size of momentum correction",    "fDeltaP" },
     { "delta_dp", "Size of delta correction (%)",       "fDeltaDp" },
     { "delta_xptar", "Size of xptar correction (rad)", "fDeltaTh" },
+    { "xsieve", "Golden track vertical position at sieve location (cm)", "fxsieve" },
+    { "ysieve", "Golden track horizontal position at sieve location (cm) (cm)", "fysieve" },
     { 0 }
   };
   DefineVarsFromList( var2, mode );
@@ -119,6 +132,16 @@ Int_t THcExtTarCor::Process( const THaEvData& )
     TVector3 pvect_temp;
     spectro->TransportToLab(theTrack->GetP(),theTrack->GetTTheta(),theTrack->GetTPhi(),pvect_temp);
     theTrack->SetPvect(pvect_temp);
+      if (strcmp(spectro->GetName(),"H")==0) {
+     fxsieve=xtar_new+xptar*168.;
+     fysieve=ytar*100.+yptar*168.;
+    }
+    if (strcmp(spectro->GetName(),"P")==0) {
+      fxsieve=xtar_new+xptar*253.;
+      Double_t delta_per=delta*100;
+      fysieve=ytar*100+yptar*253.-(0.019+40.*.01*0.052)*delta_per+(0.00019+40*.01*.00052)*delta_per*delta_per;
+    }
+        
     }
   }
  // Save results in our TrackInfo

--- a/src/THcExtTarCor.h
+++ b/src/THcExtTarCor.h
@@ -20,10 +20,13 @@ public:
   
   virtual Int_t     Process( const THaEvData& );
 
+  Double_t fxsieve,fysieve;
+
 protected:
 
   virtual Int_t DefineVariables( EMode mode = kDefine );
   virtual Int_t ReadDatabase( const TDatime& date );
+   virtual void      Clear( Option_t* opt="" );
 
   ClassDef(THcExtTarCor,0)   //Extended target corrections module
 };


### PR DESCRIPTION
1) THcExtTarCor.h
   a) add variables fxsieve and fysieve
   b) Added clear method so that fxsieve and fysieve could be set to kBig at start of each event.

2) THcExtTarCor.cxx
   a) Add variables extcor.xsieve and extcor.ysieve to tree
   b) Added clear method.
   c) Added calculation of xsieve and ysieve for golden track. The
      calculation depends on spectrometer. SHMS includes delta dependence
      when calculating ysieve.