### PR TITLE
Updated THcRaster and THcHallCSpectrmeter

### DIFF
--- a/src/THcHallCSpectrometer.cxx
+++ b/src/THcHallCSpectrometer.cxx
@@ -282,9 +282,31 @@ Int_t THcHallCSpectrometer::ReadDatabase( const TDatime& date )
   fSelUsingPrune = 0;
   fPhi_lab = 0.;
   fSatCorr=0.;
-  fMispointing_x=0.;
-  fMispointing_y=0.;
+  fMispointing_x=999.;
+  fMispointing_y=999.;
   gHcParms->LoadParmValues((DBRequest*)&list,prefix);
+  //  mispointing in transport system y is horizontal and +x is vertical down
+  if (fMispointing_y == 999.) {
+    if (prefix[0]=='h') {
+       fMispointing_y = 0.1*(0.52-0.012*40.+0.002*40.*40.);
+       if (fTheta_lab < 40) fMispointing_y = 0.1*(0.52-0.012*TMath::Abs(fTheta_lab)+0.002*fTheta_lab*fTheta_lab);
+    }
+    if (prefix[0]=='p') fMispointing_y = 0.1*(-0.6);
+	cout << prefix[0] << " From Formula Mispointing_y = " << fMispointing_y << endl;
+  } else {
+	cout << prefix[0] << " From Parameter Set Mispointing_y = " << fMispointing_y << endl;
+  }
+  if (fMispointing_x == 999.) {
+    if (prefix[0]=='h')  {
+         fMispointing_x = 0.1*(2.37-0.086*50+0.0012*50.*50.);
+         if (fTheta_lab < 50)fMispointing_x = 0.1*(2.37-0.086*TMath::Abs(fTheta_lab)+0.0012*fTheta_lab*fTheta_lab);
+    }
+    if (prefix[0]=='p') fMispointing_x = 0.1*(-1.26);
+	cout << prefix[0] << " From Formula Mispointing_x = " << fMispointing_x << endl;
+  } else {
+	cout << prefix[0] << " From Parameter Set Mispointing_x = " << fMispointing_x << endl;
+  }
+  //
 
   EnforcePruneLimits();
 

--- a/src/THcRaster.h
+++ b/src/THcRaster.h
@@ -107,6 +107,16 @@ class THcRaster : public THaBeamDet, public THcHitList {
   Double_t       fYA_pos;     // YA position
   Double_t       fXB_pos;     // XB position
   Double_t       fYB_pos;     // YB position
+  Double_t       fXbpm_tar;     // X BPM at target (+X is beam right)
+  Double_t       fYbpm_tar;     // Y BPM at target  (+Y is up)
+  Double_t       fXbpm_A;     // X BPM at BPMA (+X is beam right)
+  Double_t       fYbpm_A;     // Y BPM at BPMA (+Y is up)
+  Double_t       fXbpm_B;     // X BPM at BPMB (+X is beam right)
+  Double_t       fYbpm_B;     // Y BPM at BPMB (+Y is up)
+  Double_t       fXbpm_C;     // X BPM at BPMC (+X is beam right)
+  Double_t       fYbpm_C;     // Y BPM at BPMC (+Y is up)
+  Double_t       fXbeam_prev[4];     // 
+  Double_t       fYbeam_prev[4];     // 
 
   Double_t       fFrXA_ADC_zero_offset;
   Double_t       fFrYA_ADC_zero_offset;


### PR DESCRIPTION
Modified THcRaster.cxx and THcRaster.h

1) Add tree variables for the three BPMs and projections to target
in the EPICs coordinate system (+X beam right, +Y up)
rb.raster.fr_xbpm_tar
rb.raster.fr_ybpm_tar
rb.raster.fr_xbpmA
rb.raster.fr_ybpmA
rb.raster.fr_xbpmB
rb.raster.fr_ybpmB
rb.raster.fr_xbpmC
rb.raster.fr_ybpmC

2) Modified code so that it only modifies the BPM variables if they
are all !=0 ( beam on) . Otherwise it sets them to the previous EPICS
read. This gets rid of all zero EPICS reads,except if the first EPICs
read the beam is off.

3) Removed the reading of gpbeam from the global parameter list in the Process
  method and just have it in ReadDatabase.

4) Change the calculation of beam at target to use the projection of
   BPM_A and BPM_C instead of BPM_A and BPM_B.

5) Remove setting the raster position to the hcana beam coordinate system
   with (+X beam left). The raster is in the EPICS coordinate system.
    This makes it easier to interpret the carbon hole runs.

Update THcHallCSpectrometer.cxx

Added setting of spectrometer mispointing according the the input
spectrometer angle if the mispointing is not set by a parameter.

The formulas for deteriming the mispointing comes from fits to sureys.

If one wants to use different spectrometer mispointings then
it is best to set hmispointing_x,hmispointing_y for HMS
and pmispointing_x,pmispointing_y for SHMS in the kinematics setting file
such as standard.kinematics .