### PR TITLE
In THcParmList::Load only look for run ranges in top file.

### DIFF
--- a/src/THcParmList.cxx
+++ b/src/THcParmList.cxx
@@ -257,7 +257,7 @@ The ENGINE CTP support parameter "blocks" which were marked with
     linecount++;
     // If RunNumber>0 and first line we encounter is not a run range, need to
     // print an error
-    if(RunNumber>0) {
+    if(RunNumber>0 && nfiles==1) {
       if(line.find_first_not_of("0123456789-,")==string::npos) { // Interpret as runnum range
 	// Interpret line as a list of comma separated run numbers or ranges
 	TString runnums(line.c_str());


### PR DESCRIPTION
In THcParmList::Load only look for run ranges in top file.
      Previously, if load was called with a run number, array continuation
      lines in included files were being interpreted as lists of run numbers.
      Still we have the limitation that in the top file, if we define an array
      with multiple lines, the continuation lines will be interpreted as
      run number lists and mess things up.  But it is unlikely that we would
      need to define arrays in the top file when we are in run number
      mode.

Also update podd.