### PR TITLE
Updated DC Classes to have DC Sigma per wire

### DIFF
--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -92,7 +92,6 @@ protected:
   Int_t fdebugtrackprint;
   Int_t fdebugprintdecodeddc;
   Int_t fHMSStyleChambers;
-
   Int_t fTDC_RefTimeCut;
 
   UInt_t fNDCTracks;

--- a/src/THcDCHit.h
+++ b/src/THcDCHit.h
@@ -32,6 +32,7 @@ public:
 
   // Get and Set Functions
   THcDCWire* GetWire() const { return fWire; }
+  Double_t GetWireSigma() const { return fWire->GetSigma(); }
   Int_t    GetWireNum() const { return fWire->GetNum(); }
   Int_t    GetRawTime() const { return fRawTime; }
   Int_t    GetRawNoRefCorrTime() const { return fRawNoRefCorrTime; }

--- a/src/THcDCWire.h
+++ b/src/THcDCWire.h
@@ -14,9 +14,9 @@ class THcDCWire : public TObject {
 
 public:
 
-  THcDCWire( Int_t num=0, Double_t pos=0.0, Double_t offset=0.0,
+ THcDCWire( Int_t num=0, Double_t pos=0.0, Double_t offset=0.0, Double_t sigma=0.0,
 	     THcDCTimeToDistConv* ttd=NULL ) :
-    fNum(num), fFlag(0), fPos(pos), fTOffset(offset), fTTDConv(ttd) {}
+  fNum(num), fFlag(0), fPos(pos), fTOffset(offset), fSigmaWire(sigma), fTTDConv(ttd) {}
   virtual ~THcDCWire() {}
 
   // Get and Set Functions
@@ -24,12 +24,14 @@ public:
   Int_t    GetFlag()    const { return fFlag; }
   Double_t GetPos()     const { return fPos; }
   Double_t GetTOffset() const { return fTOffset; }
+  Double_t GetSigma() const { return fSigmaWire; }
   THcDCTimeToDistConv * GetTTDConv() { return fTTDConv; }
 
   void SetNum  (Int_t num)  {fNum = num;}
   void SetFlag (Int_t flag) {fFlag = flag;}
   void SetPos  (Double_t pos)       { fPos = pos; }
   void SetTOffset (Double_t tOffset){ fTOffset = tOffset; }
+  void SetSigma(Double_t tSigma){ fSigmaWire = tSigma; }
   void SetTTDConv (THcDCTimeToDistConv * ttdConv){ fTTDConv = ttdConv;}
 
 protected:
@@ -37,6 +39,7 @@ protected:
   Int_t    fFlag;                      //Flag for errors (e.g. Bad wire)
   Double_t fPos;                       //Position within the plane
   Double_t fTOffset;                      //Timing Offset
+  Double_t fSigmaWire;                   //Added SIgma per Wire  --Carlos
   THcDCTimeToDistConv* fTTDConv;     //!Time to Distance Converter
 
 private:

--- a/src/THcDriftChamberPlane.h
+++ b/src/THcDriftChamberPlane.h
@@ -89,6 +89,7 @@ protected:
   Int_t fPlaneIndex;		/* Index of this plane within it's chamber */
   Int_t fChamberNum;
   Int_t fUsingTzeroPerWire;
+  Int_t fUsingSigmaPerWire;
   Int_t fNRawhits;
   Int_t fNWires;
   Int_t fTdcWinMin;
@@ -116,6 +117,7 @@ protected:
   Double_t fNSperChan;		/* TDC bin size */
 
   Double_t* fTzeroWire;
+  Double_t* fSigmaWire;
 
   virtual Int_t  ReadDatabase( const TDatime& date );
   virtual Int_t  DefineVariables( EMode mode = kDefine );


### PR DESCRIPTION
1) THcDCWire.h
  a) added sigma to THcDCWire constructor which fills fSigmaWire
  b) added GetSimga method
  c) added SetSigma method

2) THcDCHit.h
 a) Added GetWireSigma method

3) THcDriftChamberPlane.h
 a) Added flag fUsingSigmaPerWire
 b) Added array fSigmaWire

4) THcDriftChamberPlane.cxx
 a) In ReadDatabase, set fUsingSigmaPerWire=0 by default
    with reading of parameter h_using_sigma_per_wire optional
    for setting fUsingSigmaPerWire.
 b) If fUsingSigmaPerWire=0 then sets all wires in array fSigmaWire to
   fSigma ( which is the simga per plane).
 c) If fUsingSigmaPerWire=1 then reads in the sigma per wire from
   a parameter file.
 d) Used new THcDCWire constructor to set the sigma for wire to fSigmaWire[nwire]
 e) Also change code so that the tzero offset is set in the  THcDCWire constructor
 f) In ProcessHits , use wire->GetTOffSet instead of the fTzeroWire array when setting
    the time.

5) THcDC.cxx
 a) In TrackFit, replace fSigma with hit->GetWireSigma()