### PR TITLE
Modify THcRaster

### DIFF
--- a/src/THcRaster.cxx
+++ b/src/THcRaster.cxx
@@ -82,7 +82,9 @@ THcRaster::THcRaster( const char* name, const char* description,
   fFrYB_ADC_zero_offset =0;
 
   frPosAdcPulseIntRaw  = NULL;
-
+  fEbeamEpics_read=0.;
+  fEbeamEpics_prev=0.;
+  fEbeamEpics=0.;
   for(Int_t i=0;i<4;i++){
 
 	fPedADC[i] = 0;
@@ -269,6 +271,7 @@ Int_t THcRaster::DefineVariables( EMode mode )
     {"fr_ybpmB",  "Y BPM at BPMB (+Y is up)",    "fYbpm_B"},
     {"fr_xbpmC",  "X BPM at BPMC (+X is beam right)",    "fXbpm_C"},
     {"fr_ybpmC",  "Y BPM at BPMC (+Y is up)",    "fYbpm_C"},
+    {"ebeam_epics",  "Beam energy of epics variable HALLC:p",    "fEbeamEpics"},
     { 0 }
   };
  
@@ -441,6 +444,9 @@ Int_t THcRaster::Decode( const THaEvData& evdata )
            if (fEpicsHandler->IsLoaded("IPM3H07C.YRAW")){
             BPMYC_raw = atof(fEpicsHandler->GetString("IPM3H07C.YRAW"));
            }
+           if (fEpicsHandler->IsLoaded("HALLC:p")){
+            fEbeamEpics_read = atof(fEpicsHandler->GetString("HALLC:p"));
+           }
    }
 
   return 0;
@@ -525,6 +531,8 @@ Int_t THcRaster::Process(){
         fYbeam_prev[2]=BPMYB_pos;
         fXbeam_prev[3]=BPMXC_pos;
         fYbeam_prev[3]=BPMYC_pos;
+        fEbeamEpics = fEbeamEpics_read;
+	fEbeamEpics_prev=fEbeamEpics_read;
  }else{
 	  fgbeam_xoff = fXbeam_prev[0];
 	  fgbeam_yoff = fYbeam_prev[0];
@@ -536,7 +544,8 @@ Int_t THcRaster::Process(){
         BPMYC_pos=fYbeam_prev[3];
 	  fgbeam_xpoff = 0;
 	  fgbeam_ypoff = 0;
-  }
+         fEbeamEpics = fEbeamEpics_prev;
+ }
 
   fXbpm_tar= -fgbeam_xoff; 
   fYbpm_tar= fgbeam_yoff;

--- a/src/THcRaster.h
+++ b/src/THcRaster.h
@@ -117,6 +117,11 @@ class THcRaster : public THaBeamDet, public THcHitList {
   Double_t       fYbpm_C;     // Y BPM at BPMC (+Y is up)
   Double_t       fXbeam_prev[4];     // 
   Double_t       fYbeam_prev[4];     // 
+  //
+  Double_t        fEbeamEpics;
+  Double_t        fEbeamEpics_read;
+  Double_t        fEbeamEpics_prev;
+  //
 
   Double_t       fFrXA_ADC_zero_offset;
   Double_t       fFrYA_ADC_zero_offset;

--- a/src/THcRaster.h
+++ b/src/THcRaster.h
@@ -109,6 +109,8 @@ class THcRaster : public THaBeamDet, public THcHitList {
   Double_t       fYB_pos;     // YB position
   Double_t       fXbpm_tar;     // X BPM at target (+X is beam right)
   Double_t       fYbpm_tar;     // Y BPM at target  (+Y is up)
+  Double_t       fXpbpm_tar;     // Xp BPM at target (+X is beam right)
+  Double_t       fYpbpm_tar;     // Yp BPM at target  (+Y is up)
   Double_t       fXbpm_A;     // X BPM at BPMA (+X is beam right)
   Double_t       fYbpm_A;     // Y BPM at BPMA (+Y is up)
   Double_t       fXbpm_B;     // X BPM at BPMB (+X is beam right)
@@ -117,6 +119,9 @@ class THcRaster : public THaBeamDet, public THcHitList {
   Double_t       fYbpm_C;     // Y BPM at BPMC (+Y is up)
   Double_t       fXbeam_prev[4];     // 
   Double_t       fYbeam_prev[4];     // 
+  Double_t       fXpbeam_prev;     // 
+  Double_t       fYpbeam_prev;     // 
+  Bool_t         fFlag_use_EPICS_bpm;
   //
   Double_t        fEbeamEpics;
   Double_t        fEbeamEpics_read;


### PR DESCRIPTION
first commit
---------------
Modify THcRaster to add variable of EPICS beam energy

Add the variable ebeam_epics to the tree. This is the EPICS
value of HALLC:p  . For now this is good for monitoring changes in the
beam energy but needs to be check how it compares to the Hall C
beam energy measurement.

Second commit
------------------

Modify THCRaster

Main change was to allow the beam X and Y positions and angle
at the target to be read in through parameters instead of
always using the EPICS data. This gives added flexibility.

If either of the beam position parameters (gbeam_xoff or
gbeam_yoff) are read-in as parameters, then the code uses
the read-in parameters as the BPM position at target. If
there are other beam position or angle parameter that are
not read in then they are set to zero.


1) Modify THcRaster.h
   a) Added variables for X and Y beam angles at target.
   b) Added variable fFlag_use_EPICS_bpm which is a flag
     that is determines whether the code uses the parameters
     or EPICS reads.

2) Modified THcRaster.cxx
   a) set default BPM z-positions to Fall 2018 survey.
   b) Modified Process method so that the BPM position/angle variables
     that are set by parameters are no longer recalculated. Just
     use the existing variables fXbpm_tar, fYbpm_tar, fXpbpm_tar
      and fYPbpm_tar throughout the method.