### PR TITLE
Bug fixes borrowed from THaScalerEventHandler

### DIFF
--- a/src/THcScalerEvtHandler.h
+++ b/src/THcScalerEvtHandler.h
@@ -20,13 +20,15 @@
 #include <cstring>
 
 
-class HCScalerLoc { // Utility class used by THaScalerEvtHandler
+class HCScalerLoc { // Utility class used by THcScalerEvtHandler
  public:
- HCScalerLoc(TString nm, TString desc, UInt_t isc, UInt_t ich, UInt_t iki) :
-   name(nm), description(desc), iscaler(isc), ichan(ich), ikind(iki) { };
+  HCScalerLoc(TString nm, TString desc, UInt_t idx, Int_t s1, UInt_t ich,
+	      UInt_t iki, Int_t iv) :
+   name(nm), description(desc), index(idx), islot(s1), ichan(ich),
+   ikind(iki), ivar(iv) { };
   ~HCScalerLoc();
   TString name, description;
-  UInt_t iscaler, ichan, ivar, ikind;
+  UInt_t index, islot, ichan, ikind, ivar;
 };
 
 class THcScalerEvtHandler : public THaEvtTypeHandler {
@@ -69,7 +71,7 @@ private:
    Double_t evcountR;
    UInt_t evNumber;
    Double_t evNumberR;
-   Int_t Nvars, ifound, fNormIdx, nscalers;
+   Int_t Nvars, ifound, fNormIdx, fNormSlot, nscalers;
    Double_t *dvars;
    UInt_t *dvars_prev_read;
    std::vector<UInt_t> scal_prev_read;


### PR DESCRIPTION
Don't confuse index of scalers with slot number

See https://github.com/JeffersonLab/analyzer/commit/cd7c26b5b1161115a0e35a4824148b78a189e986

NOTE:
This changes the format of the "variable" lines in the db map file that
defines the scaler layout.

The number after the variable directive is now the slot number instead of
the index of which scaler module (starting from zero) is being used.
Updated DBASE/db_PScalevt.dat and DBASE/db_HScalevt.dat files which have
been generated by an updated MAPS/SCALERS/make_scaler_db.py.  This change is
made so that the "variable" line format is the same as used in
THaScalerEvtHandler.cxx.