### PR TITLE
Tdc conv fix

### DIFF
--- a/src/THcCoinTime.cxx
+++ b/src/THcCoinTime.cxx
@@ -141,9 +141,14 @@ Int_t THcCoinTime::ReadDatabase( const TDatime& date )
 
   HMScentralPathLen = 22.0*100.;
   SHMScentralPathLen = 18.1*100.;
-
-  
+ 
   gHcParms->LoadParmValues((DBRequest*)&list, "");
+
+  DBRequest listGbl[] = {
+    {"caen1190_convFactor", &fTdcToNs, kDouble},
+    {0}
+  };
+  gHcParms->LoadParmValues((DBRequest*) &listGbl);
 
   return kOK;
 }
@@ -273,9 +278,8 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
 	  had_coinCorr_Positron = (HadPathLength) / (lightSpeed * hadArm_BetaCalc_Positron );
 
 	  //Raw, Uncorrected Coincidence Time
-	  fROC1_RAW_CoinTime =  (pTRIG1_rawTdcTime_ROC1*0.1 + SHMS_FPtime) - (pTRIG4_rawTdcTime_ROC1*0.1 + HMS_FPtime);
-	  fROC2_RAW_CoinTime =  (pTRIG1_rawTdcTime_ROC2*0.1 + SHMS_FPtime) - (pTRIG4_rawTdcTime_ROC2*0.1 + HMS_FPtime);
-	  
+	  fROC1_RAW_CoinTime =  (pTRIG1_rawTdcTime_ROC1*fTdcToNs + SHMS_FPtime) - (pTRIG4_rawTdcTime_ROC1*fTdcToNs + HMS_FPtime);
+	  fROC2_RAW_CoinTime =  (pTRIG1_rawTdcTime_ROC2*fTdcToNs + SHMS_FPtime) - (pTRIG4_rawTdcTime_ROC2*fTdcToNs + HMS_FPtime);
 	  
 	  //Corrected Coincidence Time for ROC1/ROC2 (ROC1 Should be identical to ROC2)
           // 

--- a/src/THcCoinTime.h
+++ b/src/THcCoinTime.h
@@ -125,6 +125,8 @@ public:
   Double_t had_ypfp;     //hadron yp focal plane
   Double_t had_FPtime;   //hadron focal plane time
 
+  Double_t fTdcToNs;  // tdc to ns conversion factor
+
   //Raw trigger times pTrig1 (SHMS 3/4 trig) and pTrig4 (HMS 3/4 trig)
   Int_t pTRIG1_rawTdcTime_ROC1;
   Int_t pTRIG4_rawTdcTime_ROC1;

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -114,7 +114,6 @@ void THcDC::Setup(const char* name, const char* description)
   DBRequest list[]={
     {"dc_num_planes",&fNPlanes, kInt},
     {"dc_num_chambers",&fNChambers, kInt},
-    {"dc_tdc_time_per_channel",&fNSperChan, kDouble},
     {"dc_wire_velocity",&fWireVelocity,kDouble},
     {"dc_plane_names",&planenamelist, kString},
     {"dc_version", &fVersion, kInt, 0, optional},
@@ -131,6 +130,11 @@ void THcDC::Setup(const char* name, const char* description)
     fHMSStyleChambers = 0;
   }
 
+  DBRequest listGbl[] = {
+    {"caen1190_convFactor", &fNSperChan, kDouble},
+    {0}
+  };
+  gHcParms->LoadParmValues((DBRequest*) &listGbl);
 
   cout << "Plane Name List: " << planenamelist << endl;
   cout << "Drift Chambers: " <<  fNPlanes << " planes in " << fNChambers << " chambers" << endl;
@@ -307,7 +311,6 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
 
 
   DBRequest list[]={
-    {"dc_tdc_time_per_channel",&fNSperChan, kDouble},
     {"dc_wire_velocity",&fWireVelocity,kDouble},
 
     {"dc_xcenter", fXCenter, kDouble, fNChambers},
@@ -359,6 +362,12 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
 
 
   gHcParms->LoadParmValues((DBRequest*)&list,fPrefix);
+
+  DBRequest listGbl[] = {
+    {"caen1190_convFactor", &fNSperChan, kDouble},
+    {0}
+  };
+  gHcParms->LoadParmValues((DBRequest*) &listGbl);
 
   //Set the default plane x,y positions to those of the chamber
    for(Int_t ip=0; ip<fNPlanes;ip++) {

--- a/src/THcDriftChamberPlane.cxx
+++ b/src/THcDriftChamberPlane.cxx
@@ -371,7 +371,7 @@ Int_t THcDriftChamberPlane::ProcessHits(TClonesArray* rawhits, Int_t nexthit)
       /* Sort into early, late and ontime */
       Int_t rawnorefcorrtdc = hit->GetRawTdcHit().GetTimeRaw(mhit); // Get the ref time subtracted time
       Int_t rawtdc = hit->GetRawTdcHit().GetTime(mhit); // Get the ref time subtracted time
-      Double_t time = - rawtdc*fNSperChan + fPlaneTimeZero - wire->GetTOffset(); // fNSperChan > 0 for 1877
+      Double_t time = rawtdc*fNSperChan + fPlaneTimeZero - wire->GetTOffset(); // fNSperChan > 0 for 1877
       new( (*fRawHits)[nextRawHit++] ) THcDCHit(wire, rawnorefcorrtdc,rawtdc, time, this);	
      if(rawtdc < fTdcWinMin) {
 	// Increment early counter  (Actually late because TDC is backward)

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -319,7 +319,6 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
     {"NumPlanesBetaCalc",                       &fNumPlanesBetaCalc,            kInt,            0,  1},
     {"start_time_center",                &fStartTimeCenter,                      kDouble},
     {"start_time_slop",                  &fStartTimeSlop,                        kDouble},
-    {"scin_tdc_to_time",                 &fScinTdcToTime,                        kDouble},
     {"scin_tdc_min",                     &fScinTdcMin,                           kDouble},
     {"scin_tdc_max",                     &fScinTdcMax,                           kDouble},
     {"tof_tolerance",                    &fTofTolerance,          kDouble,         0,  1},
@@ -397,6 +396,12 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
       cout << "Data for TOF calibration not being written." << endl;
     }
   }
+
+  DBRequest listGbl[] = {
+    {"caen1190_convFactor", &fScinTdcToTime, kDouble},
+    {0}
+  };
+  gHcParms->LoadParmValues((DBRequest*) &listGbl);
 
   // cout << " x1 lo = " << fxLoScin[0]
   //      << " x2 lo = " << fxLoScin[1]

--- a/src/THcRawTdcHit.cxx
+++ b/src/THcRawTdcHit.cxx
@@ -82,7 +82,6 @@ Returned time is corrected for reference time, if available.
 
 THcRawTdcHit::THcRawTdcHit() :
   TObject(),
-  fChannelToTimeFactor(0.1),
   fTime(), fRefTime(0), fHasRefTime(kFALSE), fNHits(0)
 {}
 

--- a/src/THcRawTdcHit.h
+++ b/src/THcRawTdcHit.h
@@ -26,8 +26,6 @@ class THcRawTdcHit : public TObject {
   protected:
     static const UInt_t fMaxNHits = 128;
 
-    Double_t fChannelToTimeFactor;
-
     Int_t fTime[fMaxNHits];
     Int_t fRefTime;
 

--- a/src/THcTrigDet.cxx
+++ b/src/THcTrigDet.cxx
@@ -288,7 +288,6 @@ Int_t THcTrigDet::Decode(const THaEvData& evData) {
        if (good_hit==999) good_hit=0;
       fTdcTimeRaw[cnt] = rawTdcHit.GetTimeRaw(good_hit);
       fTdcTime[cnt] = rawTdcHit.GetTime(good_hit)*fTdcChanperNS+fTdcOffset;
-
       fTdcMultiplicity[cnt] = rawTdcHit.GetNHits();
     }
     else {
@@ -326,12 +325,11 @@ Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
     {"_tdcNames", &tdcNames, kString},  // Names of TDC channels.
     {"_tdcoffset", &fTdcOffset, kDouble,0,1},  // Offset of tdc channels
     {"_adc_tdc_offset", &fAdcTdcOffset, kDouble,0,1},  // Offset of Adc Pulse time (ns)
-    {"_tdcchanperns", &fTdcChanperNS, kDouble,0,1},  // Convert channesl to ns
     {"_trig_tdcrefcut", &fTDC_RefTimeCut, kInt, 0, 1},
     {"_trig_adcrefcut", &fADC_RefTimeCut, kInt, 0, 1},
     {0}
   };
-  fTdcChanperNS=0.1;
+  
   fTdcOffset=300.;
   fAdcTdcOffset=200.;
   fTDC_RefTimeCut=-1000.;
@@ -359,6 +357,12 @@ Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
   };
 
   gHcParms->LoadParmValues(list2, fKwPrefix.c_str());
+
+  DBRequest listGbl[] = {
+    {"caen1190_convFactor", &fTdcChanperNS, kDouble},
+    {0}
+  };
+  gHcParms->LoadParmValues((DBRequest*) &listGbl);
 
   // Split the names to std::vector<std::string>.
   fAdcNames = vsplit(adcNames);


### PR DESCRIPTION
Remove multiple instances of the CAEN 1990 tdc to ns conversion factor and instead utilize single global parameter.  Also remove instances of hard coded conversion factors.

This PR is dependent on the JeffersonLab/hallc_replay commit f78d9d2