### PR TITLE
Modify THcCoinTime and THcTrigDet

### DIFF
--- a/src/THcCoinTime.cxx
+++ b/src/THcCoinTime.cxx
@@ -236,10 +236,10 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
       Double_t HMS_FPtime = theHMSTrack->GetFPTime();    
       
       //Get raw TDC Times for HMS/SHMS (3/4 trigger)
-      pTRIG1_rawTdcTime_ROC1 = fCoinDet->Get_pTRG1_ROC1_rawTdctime();  //TDC Channels (0.1 ns/Ch)
-      pTRIG4_rawTdcTime_ROC1 = fCoinDet->Get_pTRG4_ROC1_rawTdctime();
-      pTRIG1_rawTdcTime_ROC2 = fCoinDet->Get_pTRG1_ROC2_rawTdctime();
-      pTRIG4_rawTdcTime_ROC2 = fCoinDet->Get_pTRG4_ROC2_rawTdctime();
+      pTRIG1_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(0);  //SHMS
+      pTRIG4_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(1);  //HMS
+      pTRIG1_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(2);//SHMS
+      pTRIG4_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(3);//HMS
 
 	  DeltaSHMSpathLength = -0.11*atan2(shms_xptar,1)*1000 - 0.057*shms_dP;
 	  DeltaHMSpathLength = 12.462*hms_xpfp + 0.1138*hms_xpfp*hms_xfp - 0.0154*hms_xfp - 72.292*hms_xpfp*hms_xpfp - 0.0000544*hms_xfp*had_xfp - 116.52*hms_ypfp*hms_ypfp;
@@ -273,8 +273,8 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
 	  had_coinCorr_Positron = (HadPathLength) / (lightSpeed * hadArm_BetaCalc_Positron );
 
 	  //Raw, Uncorrected Coincidence Time
-	  fROC1_RAW_CoinTime =  (pTRIG1_rawTdcTime_ROC1*0.1 + SHMS_FPtime) - (pTRIG4_rawTdcTime_ROC1*0.1 + HMS_FPtime);
-	  fROC2_RAW_CoinTime =  (pTRIG1_rawTdcTime_ROC2*0.1 + SHMS_FPtime) - (pTRIG4_rawTdcTime_ROC2*0.1 + HMS_FPtime);
+	  fROC1_RAW_CoinTime =  (pTRIG1_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG4_TdcTime_ROC1 + HMS_FPtime);
+	  fROC2_RAW_CoinTime =  (pTRIG1_TdcTime_ROC2 + SHMS_FPtime) - (pTRIG4_TdcTime_ROC2 + HMS_FPtime);
 	  
 	  
 	  //Corrected Coincidence Time for ROC1/ROC2 (ROC1 Should be identical to ROC2)

--- a/src/THcCoinTime.h
+++ b/src/THcCoinTime.h
@@ -125,11 +125,11 @@ public:
   Double_t had_ypfp;     //hadron yp focal plane
   Double_t had_FPtime;   //hadron focal plane time
 
-  //Raw trigger times pTrig1 (SHMS 3/4 trig) and pTrig4 (HMS 3/4 trig)
-  Int_t pTRIG1_rawTdcTime_ROC1;
-  Int_t pTRIG4_rawTdcTime_ROC1;
-  Int_t pTRIG1_rawTdcTime_ROC2;
-  Int_t pTRIG4_rawTdcTime_ROC2;
+  // trigger times pTrig1 (SHMS 3/4 trig) and pTrig4 (HMS 3/4 trig)
+  Int_t pTRIG1_TdcTime_ROC1;
+  Int_t pTRIG4_TdcTime_ROC1;
+  Int_t pTRIG1_TdcTime_ROC2;
+  Int_t pTRIG4_TdcTime_ROC2;
 
   //--------------------------------------------------------------------
 

--- a/src/THcTrigDet.h
+++ b/src/THcTrigDet.h
@@ -32,37 +32,21 @@ class THcTrigDet : public THaDetector, public THcHitList {
     virtual Bool_t IsIgnoreType(Int_t evtype) const;
     virtual Bool_t HaveIgnoreList() const;
     Int_t          End(THaRunBase* run);
-    
-    //Funtions to get raw TdcTimes 
-    Int_t Get_pTRG1_ROC1_rawTdctime() {return pTrig1_ROC1;}
-    Int_t Get_pTRG4_ROC1_rawTdctime() {return pTrig4_ROC1;}
-    Int_t Get_pTRG1_ROC2_rawTdctime() {return pTrig1_ROC2;}
-    Int_t Get_pTRG4_ROC2_rawTdctime() {return pTrig4_ROC2;}
+    //Funtions to get TDCtime for cointime module 
+    Double_t Get_CT_Trigtime(Int_t ii) { return (fTrigId[ii]==-1 ? 0. : fTdcTime[fTrigId[ii]]) ;}
 
   protected:
     void Setup(const char* name, const char* description);
     virtual Int_t ReadDatabase(const TDatime& date);
     virtual Int_t DefineVariables(EMode mode=kDefine);
     
-    //Added for coin. time calculation
-    void SetCoinTrigTimes();
 
-    //indices to store pTrig string locations
-    Int_t fidx0;
-    Int_t fidx1;
-    Int_t fidx2;
-    Int_t fidx3;
-
-
-    Int_t pTrig1_ROC1;
-    Int_t pTrig4_ROC1;
-    Int_t pTrig1_ROC2;
-    Int_t pTrig4_ROC2;
 
     std::string fKwPrefix;
 
     Int_t fNumAdc;
     Int_t fNumTdc;
+    Int_t fTrigId[4];
 
     Double_t fAdcTdcOffset;
     Double_t fTdcOffset;
@@ -70,6 +54,7 @@ class THcTrigDet : public THaDetector, public THcHitList {
 
     std::vector<std::string> fAdcNames;
     std::vector<std::string> fTdcNames;
+    std::vector<std::string> fTrigNames;
 
     static const int fMaxAdcChannels = 200;
     static const int fMaxTdcChannels = 200;


### PR DESCRIPTION
1) THcTrigDet
   a) Modify code to use string vector fTrigNames to identify which of the trigger
     detector TDC signals to use for coincidence timing. This
      replaces the hard-coded names. The integer array fTrigId[4] keeps
     track of the array ID in the overall fTDcNames vector that goes
      with the fTrigNames[4]
   b) The fTrigNames must be in order of SHMS ROC1, HMS ROC1, SHMS ROC2
     and HMS ROC2.
   c) Default names are "pTRIG1_ROC1","pTRIG4_ROC1","pTRIG1_ROC2","pTRIG4_ROC2"
      The parameter is t_coin_trigNames
      For example:
      t_coin_trigNames="pTRIG1_ROC1 pTRIG4_ROC1 pTRIG1_ROC2 pTRIG4_ROC2"
      This parameter is read-in and then split into a string vector fTrigNames.
   d) In HcTrigDet::ReadDatabase , all members of fTrigID array are set
to -1 then a loop over all Tdc in the trigger detector looks for match between
fTdcNames amd fTrigNames to set fTrigId. If match not found the fTrigId = -1.
   e) In THcTrigDet.h made new method Get_CT_TrigTime(Int_t ii) to be used
in in THcCoinTime to get the 4 trigger times: SHMS ROC1 (ii=0), HMS ROC1 (ii=1),
SHMS ROC2 (ii=2) and HMS ROC2 (ii=3).  If fTrigId[ii]=-1 then it returns 0
otherwise returns fTdcTime[fTrigID[ii]].

2) THcCoinTime
  a) Previously used the raw trigger times and had a hard-coded 0.1 ns/channel
conversion. Now use the trigger times which already are in ns using the
ns/channel conversion set in the TrigDet.
  b) Now use the new TrigDet method Get_CT_TrigTime(ii) to get the
trigger times for SHMS ROC1, HMS ROC1, SHMS ROC2 and HMS ROC2.