### PR TITLE
Change threshold for helicity signals.

### DIFF
--- a/src/THcHelicityReader.h
+++ b/src/THcHelicityReader.h
@@ -52,6 +52,8 @@ protected:
   Bool_t fIsHelp;
   Bool_t fIsHelm;
 
+  Int_t fADCThreshold;		// Threshold for On/Off of helicity signals
+
   ROCinfo  fROCinfo[kCount];
 
   Int_t    fQWEAKDebug;          // Debug level


### PR DESCRIPTION
  For KaonLT, the kPulsePedestal values being returned for
  the helicity signal channels was 0 and 16380.  For SIDIS, the
  values for off and on are ~2000 and ~1400.  Made the default
  threshold 8000 instead of 1000.  Also added an optional parameter,
  "helicity_fadcthreshold" so that this threshold can be changed
  at run time.