### PR TITLE
Modify CMake and SCons scripts for new Podd directory layout

### DIFF
--- a/SConscript.py
+++ b/SConscript.py
@@ -106,6 +106,14 @@ f.close()
 
 print ('LIBS = %s\n' % pbaseenv.subst('$LIBS'))
 
+# SCons seems to ignore $RPATH on macOS... sigh
+if pbaseenv['PLATFORM'] == 'darwin':
+    try:
+        for rp in pbaseenv['RPATH']:
+            pbaseenv.Append(LINKFLAGS = ['-Wl,-rpath,'+rp])
+    except KeyError:
+        pass
+
 analyzer = pbaseenv.Program(target = 'hcana', source = 'src/main.o')
 pbaseenv.Install('./bin',analyzer)
 pbaseenv.Alias('install',['./bin'])

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 
 target_link_libraries(${LIBNAME}
   PUBLIC
-    Podd::HallA
+    Podd::Podd
     Podd::Decode
   )
 set_target_properties(${LIBNAME} PROPERTIES


### PR DESCRIPTION
Tested with Podd at commit f5437c8db1c9e17b8c7313ac5809355af59bbd19

Currently both CMake and SCons build not only libPodd, but also libHallA,
even though it is not required for hcana. hcana is linked only against
libPodd, however, so libHallA is simply a spurious byproduct.