### PR TITLE
Modify CMake and SCons scripts for new Podd directory layout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ install:
   - python --version
   - scons --version
 script:
-  - make
   - scons
+  - mkdir build; cd build; cmake ..; make; cd ..
 after_success:
   - pwd
   - ldd $HCANALYZER/hcana

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ install:
   - scons --version
 script:
   - scons
-  - mkdir build; cd build; cmake ..; make; cd ..
+  - mkdir build; cd build; cmake ..; make
 after_success:
+  - cd $TRAVIS_BUILD_DIR
   - pwd
   - ldd $HCANALYZER/hcana
   - $HCANALYZER/hcana --version

--- a/SConscript.py
+++ b/SConscript.py
@@ -106,6 +106,14 @@ f.close()
 
 print ('LIBS = %s\n' % pbaseenv.subst('$LIBS'))
 
+# SCons seems to ignore $RPATH on macOS... sigh
+if pbaseenv['PLATFORM'] == 'darwin':
+    try:
+        for rp in pbaseenv['RPATH']:
+            pbaseenv.Append(LINKFLAGS = ['-Wl,-rpath,'+rp])
+    except KeyError:
+        pass
+
 analyzer = pbaseenv.Program(target = 'hcana', source = 'src/main.o')
 pbaseenv.Install('./bin',analyzer)
 pbaseenv.Alias('install',['./bin'])

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 
 target_link_libraries(${LIBNAME}
   PUBLIC
-    Podd::HallA
+    Podd::Podd
     Podd::Decode
   )
 set_target_properties(${LIBNAME} PROPERTIES


### PR DESCRIPTION
Changes to SCons and CMake build scripts to work with the new Podd 1.7 library names and directory layout.

Tested with Podd at commit JeffersonLab/analyzer@332d761

Updated pull request to fix Travis build. Removed the make build, added CMake.

