### PR TITLE
Correct various issues reported by valgrind

### DIFF
--- a/src/THcAerogel.cxx
+++ b/src/THcAerogel.cxx
@@ -36,51 +36,56 @@ using namespace std;
 //_____________________________________________________________________________
 THcAerogel::THcAerogel( const char* name, const char* description,
                         THaApparatus* apparatus ) :
-  THaNonTrackingDetector(name,description,apparatus)
+  THaNonTrackingDetector(name,description,apparatus), fPresentP(0),
+  fAdcPosTimeWindowMin(0), fAdcPosTimeWindowMax(0), fAdcNegTimeWindowMin(0),
+  fAdcNegTimeWindowMax(0), fRegionValue(0), fPosGain(0), fNegGain(0),
+  frPosAdcPedRaw(0), frPosAdcPulseIntRaw(0), frPosAdcPulseAmpRaw(0),
+  frPosAdcPulseTimeRaw(0), frPosAdcPed(0), frPosAdcPulseInt(0),
+  frPosAdcPulseAmp(0), frPosAdcPulseTime(0), frNegAdcPedRaw(0),
+  frNegAdcPulseIntRaw(0), frNegAdcPulseAmpRaw(0), frNegAdcPulseTimeRaw(0),
+  frNegAdcPed(0), frNegAdcPulseInt(0), frNegAdcPulseAmp(0),
+  frNegAdcPulseTime(0), fPosAdcErrorFlag(0),
+  fNegAdcErrorFlag(0), fPosPedSum(0), fPosPedSum2(0), fPosPedLimit(0),
+  fPosPedCount(0), fNegPedSum(0), fNegPedSum2(0), fNegPedLimit(0), fNegPedCount(0),
+  fA_Pos(0), fA_Neg(0), fA_Pos_p(0), fA_Neg_p(0), fT_Pos(0), fT_Neg(0),
+  fPosPed(0), fPosSig(0), fPosThresh(0), fNegPed(0), fNegSig(0),
+  fNegThresh(0), fPosPedMean(0), fNegPedMean(0),
+  fPosTDCHits(0), fNegTDCHits(0), fPosADCHits(0), fNegADCHits(0)
 {
-
-  InitArrays();
-
 }
 
 //_____________________________________________________________________________
 THcAerogel::THcAerogel( ) :
-  THaNonTrackingDetector()
+  THaNonTrackingDetector(),
+  fAdcPosTimeWindowMin(0), fAdcPosTimeWindowMax(0), fAdcNegTimeWindowMin(0),
+  fAdcNegTimeWindowMax(0), fRegionValue(0), fPosGain(0), fNegGain(0),
+  frPosAdcPedRaw(0), frPosAdcPulseIntRaw(0), frPosAdcPulseAmpRaw(0),
+  frPosAdcPulseTimeRaw(0), frPosAdcPed(0), frPosAdcPulseInt(0),
+  frPosAdcPulseAmp(0), frPosAdcPulseTime(0), frNegAdcPedRaw(0),
+  frNegAdcPulseIntRaw(0), frNegAdcPulseAmpRaw(0), frNegAdcPulseTimeRaw(0),
+  frNegAdcPed(0), frNegAdcPulseInt(0), frNegAdcPulseAmp(0),
+  frNegAdcPulseTime(0), fPosAdcErrorFlag(0),
+  fNegAdcErrorFlag(0), fPosPedSum(0), fPosPedSum2(0), fPosPedLimit(0),
+  fPosPedCount(0), fNegPedSum(0), fNegPedSum2(0), fNegPedLimit(0), fNegPedCount(0),
+  fA_Pos(0), fA_Neg(0), fA_Pos_p(0), fA_Neg_p(0), fT_Pos(0), fT_Neg(0),
+  fPosPed(0), fPosSig(0), fPosThresh(0), fNegPed(0), fNegSig(0),
+  fNegThresh(0), fPosPedMean(0), fNegPedMean(0),
+  fPosTDCHits(0), fNegTDCHits(0), fPosADCHits(0), fNegADCHits(0)
 {
-  // Constructor
-  frPosAdcPedRaw       = NULL;
-  frPosAdcPulseIntRaw  = NULL;
-  frPosAdcPulseAmpRaw  = NULL;
-  frPosAdcPulseTimeRaw = NULL;
-  frPosAdcPed          = NULL;
-  frPosAdcPulseInt     = NULL;
-  frPosAdcPulseAmp     = NULL;
-  frPosAdcPulseTime    = NULL;
-  frNegAdcPedRaw       = NULL;
-  frNegAdcPulseIntRaw  = NULL;
-  frNegAdcPulseAmpRaw  = NULL;
-  frNegAdcPulseTimeRaw = NULL;
-  frNegAdcPed          = NULL;
-  frNegAdcPulseInt     = NULL;
-  frNegAdcPulseAmp     = NULL;
-  frNegAdcPulseTime    = NULL;
-  fPosAdcErrorFlag     = NULL;
-  fNegAdcErrorFlag     = NULL;
-
-  // 6 GeV variables
-  fPosTDCHits = NULL;
-  fNegTDCHits = NULL;
-  fPosADCHits = NULL;
-  fNegADCHits = NULL;
-
-  InitArrays();
-
 }
 
 //_____________________________________________________________________________
 THcAerogel::~THcAerogel()
 {
   // Destructor
+  DeleteArrays();
+}
+
+//_____________________________________________________________________________
+void THcAerogel::DeleteArrays()
+{
+  // Delete all dynamically allocated memory
+
   delete frPosAdcPedRaw;       frPosAdcPedRaw       = NULL;
   delete frPosAdcPulseIntRaw;  frPosAdcPulseIntRaw  = NULL;
   delete frPosAdcPulseAmpRaw;  frPosAdcPulseAmpRaw  = NULL;
@@ -100,59 +105,37 @@ THcAerogel::~THcAerogel()
   delete fPosAdcErrorFlag;     fPosAdcErrorFlag     = NULL;
   delete fNegAdcErrorFlag;     fNegAdcErrorFlag     = NULL;
 
+  delete [] fRegionValue;         fRegionValue = 0;
+  delete [] fAdcPosTimeWindowMin; fAdcPosTimeWindowMin = 0;
+  delete [] fAdcPosTimeWindowMax; fAdcPosTimeWindowMax = 0;
+  delete [] fAdcNegTimeWindowMin; fAdcNegTimeWindowMin = 0;
+  delete [] fAdcNegTimeWindowMax; fAdcNegTimeWindowMax = 0;
+
   // 6 GeV variables
   delete fPosTDCHits; fPosTDCHits = NULL;
   delete fNegTDCHits; fNegTDCHits = NULL;
   delete fPosADCHits; fPosADCHits = NULL;
   delete fNegADCHits; fNegADCHits = NULL;
 
-  DeleteArrays();
-
-}
-
-//_____________________________________________________________________________
-void THcAerogel::InitArrays()
-{
-  fPosGain = NULL;
-  fNegGain = NULL;
-
-  // 6 GeV variables
-  fA_Pos       = NULL;
-  fA_Neg       = NULL;
-  fA_Pos_p     = NULL;
-  fA_Neg_p     = NULL;
-  fT_Pos       = NULL;
-  fT_Neg       = NULL;
-  fPosPedLimit = NULL;
-  fNegPedLimit = NULL;
-  fPosPedMean  = NULL;
-  fNegPedMean  = NULL;
-  fPosPedSum   = NULL;
-  fPosPedSum2  = NULL;
-  fPosPedCount = NULL;
-  fNegPedSum   = NULL;
-  fNegPedSum2  = NULL;
-  fNegPedCount = NULL;
-  fPosPed      = NULL;
-  fPosSig      = NULL;
-  fPosThresh   = NULL;
-  fNegPed      = NULL;
-  fNegSig      = NULL;
-  fNegThresh   = NULL;
-}
-//_____________________________________________________________________________
-void THcAerogel::DeleteArrays()
-{
   delete [] fPosGain; fPosGain = NULL;
   delete [] fNegGain; fNegGain = NULL;
 
-  // 6 GeV variables
   delete [] fA_Pos;       fA_Pos       = NULL;
   delete [] fA_Neg;       fA_Neg       = NULL;
   delete [] fA_Pos_p;     fA_Pos_p     = NULL;
   delete [] fA_Neg_p;     fA_Neg_p     = NULL;
   delete [] fT_Pos;       fT_Pos       = NULL;
   delete [] fT_Neg;       fT_Neg       = NULL;
+
+  if (fSixGevData)
+    DeletePedestalArrays();
+}
+
+//_____________________________________________________________________________
+void THcAerogel::DeletePedestalArrays()
+{
+  // Delete all dynamically allocated memory for pedestal processing
+
   delete [] fPosPedLimit; fPosPedLimit = NULL;
   delete [] fNegPedLimit; fNegPedLimit = NULL;
   delete [] fPosPedMean;  fPosPedMean  = NULL;
@@ -232,26 +215,24 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
 
   gHcParms->LoadParmValues((DBRequest*)&listextra, prefix);
 
-  Bool_t optional = true ;
+  Bool_t optional = true;
 
   cout << "Created aerogel detector " << GetApparatus()->GetName() << "."
        << GetName() << " with " << fNelem << " PMT pairs" << endl;
+
+  DeleteArrays(); // avoid memory leak when reinitializing
 
   fPosGain = new Double_t[fNelem];
   fNegGain = new Double_t[fNelem];
 
   // 6 GeV variables
   fTdcOffset   = 0; // Offset to make reference time subtracted times positve
-  fPosPedLimit = new Int_t[fNelem];
-  fNegPedLimit = new Int_t[fNelem];
   fA_Pos       = new Float_t[fNelem];
   fA_Neg       = new Float_t[fNelem];
   fA_Pos_p     = new Float_t[fNelem];
   fA_Neg_p     = new Float_t[fNelem];
   fT_Pos       = new Float_t[fNelem];
   fT_Neg       = new Float_t[fNelem];
-  fPosPedMean  = new Double_t[fNelem];
-  fNegPedMean  = new Double_t[fNelem];
 
   // Normal constructor with name and description
   frPosAdcPedRaw       = new TClonesArray("THcSignalHit", fNelem*MaxNumAdcPulse);
@@ -273,28 +254,28 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
   fPosAdcErrorFlag     = new TClonesArray("THcSignalHit", fNelem*MaxNumAdcPulse);
   fNegAdcErrorFlag     = new TClonesArray("THcSignalHit", fNelem*MaxNumAdcPulse);
 
-  fNumPosAdcHits         = vector<Int_t>    (fNelem, 0.0);
-  fNumGoodPosAdcHits     = vector<Int_t>    (fNelem, 0.0);
-  fNumNegAdcHits         = vector<Int_t>    (fNelem, 0.0);
-  fNumGoodNegAdcHits     = vector<Int_t>    (fNelem, 0.0);
-  fNumTracksMatched      = vector<Int_t>    (fNelem, 0.0);
-  fNumTracksFired        = vector<Int_t>    (fNelem, 0.0);
-  fPosNpe                = vector<Double_t> (fNelem, 0.0);
-  fNegNpe                = vector<Double_t> (fNelem, 0.0);
-  fGoodPosAdcPed         = vector<Double_t> (fNelem, 0.0);
-  fGoodPosAdcMult         = vector<Double_t> (fNelem, 0.0);
-  fGoodPosAdcPulseInt    = vector<Double_t> (fNelem, 0.0);
-  fGoodPosAdcPulseIntRaw = vector<Double_t> (fNelem, 0.0);
-  fGoodPosAdcPulseAmp    = vector<Double_t> (fNelem, 0.0);
-  fGoodPosAdcPulseTime   = vector<Double_t> (fNelem, 0.0);
-  fGoodPosAdcTdcDiffTime   = vector<Double_t> (fNelem, 0.0);
-  fGoodNegAdcPed         = vector<Double_t> (fNelem, 0.0);
-  fGoodNegAdcMult        = vector<Double_t> (fNelem, 0.0);
-  fGoodNegAdcPulseInt    = vector<Double_t> (fNelem, 0.0);
-  fGoodNegAdcPulseIntRaw = vector<Double_t> (fNelem, 0.0);
-  fGoodNegAdcPulseAmp    = vector<Double_t> (fNelem, 0.0);
-  fGoodNegAdcPulseTime   = vector<Double_t> (fNelem, 0.0);
-  fGoodNegAdcTdcDiffTime   = vector<Double_t> (fNelem, 0.0);
+  fNumPosAdcHits.assign(fNelem, 0);
+  fNumGoodPosAdcHits.assign(fNelem, 0);
+  fNumNegAdcHits.assign(fNelem, 0);
+  fNumGoodNegAdcHits.assign(fNelem, 0);
+  fNumTracksMatched.assign(fNelem, 0);
+  fNumTracksFired.assign(fNelem, 0);
+  fPosNpe.assign(fNelem, 0.0);
+  fNegNpe.assign(fNelem, 0.0);
+  fGoodPosAdcPed.assign(fNelem, 0.0);
+  fGoodPosAdcMult.assign(fNelem, 0.0);
+  fGoodPosAdcPulseInt.assign(fNelem, 0.0);
+  fGoodPosAdcPulseIntRaw.assign(fNelem, 0.0);
+  fGoodPosAdcPulseAmp.assign(fNelem, 0.0);
+  fGoodPosAdcPulseTime.assign(fNelem, 0.0);
+  fGoodPosAdcTdcDiffTime.assign(fNelem, 0.0);
+  fGoodNegAdcPed.assign(fNelem, 0.0);
+  fGoodNegAdcMult.assign(fNelem, 0.0);
+  fGoodNegAdcPulseInt.assign(fNelem, 0.0);
+  fGoodNegAdcPulseIntRaw.assign(fNelem, 0.0);
+  fGoodNegAdcPulseAmp.assign(fNelem, 0.0);
+  fGoodNegAdcPulseTime.assign(fNelem, 0.0);
+  fGoodNegAdcTdcDiffTime.assign(fNelem, 0.0);
 
   // 6 GeV variables
   fPosTDCHits = new TClonesArray("THcSignalHit", fNelem*16);
@@ -302,15 +283,12 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
   fPosADCHits = new TClonesArray("THcSignalHit", fNelem*MaxNumAdcPulse);
   fNegADCHits = new TClonesArray("THcSignalHit", fNelem*MaxNumAdcPulse);
 
-  fPosNpeSixGev = vector<Double_t> (fNelem, 0.0);
-  fNegNpeSixGev = vector<Double_t> (fNelem, 0.0);
-
-  // Create arrays to hold pedestal results
-  if (fSixGevData) InitializePedestals();
+  fPosNpeSixGev.assign(fNelem, 0.0);
+  fNegNpeSixGev.assign(fNelem, 0.0);
 
   // Region parameters
   fRegionsValueMax = fNRegions * 8;
-  fRegionValue     = new Double_t[fRegionsValueMax];
+  fRegionValue         = new Double_t[fRegionsValueMax];
 
   fAdcPosTimeWindowMin = new Double_t [fNelem];
   fAdcPosTimeWindowMax = new Double_t [fNelem];
@@ -340,12 +318,7 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
     {"aero_six_gev_data",     &fSixGevData,       kInt,    0, 1},
     {"aero_pos_gain",         fPosGain,           kDouble, (UInt_t) fNelem},
     {"aero_neg_gain",         fNegGain,           kDouble, (UInt_t) fNelem},
-    {"aero_pos_ped_limit",    fPosPedLimit,       kInt,    (UInt_t) fNelem, optional},
-    {"aero_neg_ped_limit",    fNegPedLimit,       kInt,    (UInt_t) fNelem, optional},
-    {"aero_pos_ped_mean",     fPosPedMean,        kDouble, (UInt_t) fNelem, optional},
-    {"aero_neg_ped_mean",     fNegPedMean,        kDouble, (UInt_t) fNelem, optional},
     {"aero_tdc_offset",       &fTdcOffset,        kInt,    0,               optional},
-    {"aero_min_peds",         &fMinPeds,          kInt,    0,               optional},
     {"aero_region",           &fRegionValue[0],   kDouble, (UInt_t) fRegionsValueMax},
     {"aero_adcrefcut",        &fADC_RefTimeCut,   kInt,    0, 1},
     {0}
@@ -365,7 +338,22 @@ Int_t THcAerogel::ReadDatabase( const TDatime& date )
 
   gHcParms->LoadParmValues((DBRequest*)&list, prefix);
 
-  if (fSixGevData) cout << "6 GeV Data Analysis Flag Set To TRUE" << endl;
+  if (fSixGevData) {
+    // Create arrays to hold pedestal results
+    InitializePedestals();
+
+    DBRequest list2[]={
+      {"aero_pos_ped_limit",    fPosPedLimit,       kInt,    (UInt_t) fNelem, optional},
+      {"aero_neg_ped_limit",    fNegPedLimit,       kInt,    (UInt_t) fNelem, optional},
+      {"aero_pos_ped_mean",     fPosPedMean,        kDouble, (UInt_t) fNelem, optional},
+      {"aero_neg_ped_mean",     fNegPedMean,        kDouble, (UInt_t) fNelem, optional},
+      {"aero_min_peds",         &fMinPeds,          kInt,    0,               optional},
+      {0}
+    };
+    gHcParms->LoadParmValues((DBRequest*)&list2, prefix);
+
+    cout << "6 GeV Data Analysis Flag Set To TRUE" << endl;
+  }
 
   fIsInit = true;
 
@@ -700,7 +688,7 @@ Int_t THcAerogel::CoarseProcess( TClonesArray&  ) //tracks
 {
   Double_t StartTime = 0.0;
   if( fglHod ) StartTime = fglHod->GetStartTime();
-  //cout << " starttime = " << StartTime << endl ;
+  //cout << " starttime = " << StartTime << endl;
     // Loop over the elements in the TClonesArray
     for(Int_t ielem = 0; ielem < frPosAdcPulseInt->GetEntries(); ielem++) {
 
@@ -946,17 +934,20 @@ void THcAerogel::InitializePedestals()
   fNPedestalEvents = 0;
   fMinPeds         = 0;                    // Do not calculate pedestals by default
 
+  DeletePedestalArrays();
+  fPosPedLimit = new Int_t [fNelem];
+  fNegPedLimit = new Int_t [fNelem];
+  fPosPedMean  = new Double_t[fNelem];
+  fNegPedMean  = new Double_t[fNelem];
   fPosPedSum   = new Int_t [fNelem];
   fPosPedSum2  = new Int_t [fNelem];
-  fPosPedLimit = new Int_t [fNelem];
   fPosPedCount = new Int_t [fNelem];
   fNegPedSum   = new Int_t [fNelem];
   fNegPedSum2  = new Int_t [fNelem];
-  fNegPedLimit = new Int_t [fNelem];
   fNegPedCount = new Int_t [fNelem];
   fPosPed      = new Double_t [fNelem];
-  fNegPed      = new Double_t [fNelem];
   fPosThresh   = new Double_t [fNelem];
+  fNegPed      = new Double_t [fNelem];
   fNegThresh   = new Double_t [fNelem];
 
   for(Int_t i = 0;i < fNelem; i++) {
@@ -1052,14 +1043,16 @@ void THcAerogel::Print(const Option_t* opt) const
   THaNonTrackingDetector::Print(opt);
 
   // Print out the pedestals
-  cout << endl;
-  cout << "Aerogel Pedestals" << endl;
-  cout << "No.   Neg    Pos" << endl;
-  for(Int_t i=0; i<fNelem; i++)
-    cout << " " << i << "\t" << fNegPedMean[i] << "\t" << fPosPedMean[i] << endl;
-  cout << endl;
-  cout << " fMinPeds = " << fMinPeds << endl;
-  cout << endl;
+  if (fSixGevData) {
+    cout << endl;
+    cout << "Aerogel Pedestals" << endl;
+    cout << "No.   Neg    Pos" << endl;
+    for(Int_t i=0; i<fNelem; i++)
+      cout << " " << i << "\t" << fNegPedMean[i] << "\t" << fPosPedMean[i] << endl;
+    cout << endl;
+    cout << " fMinPeds = " << fMinPeds << endl;
+    cout << endl;
+  }
 }
 //_____________________________________________________________________________
 Int_t THcAerogel::End(THaRunBase* run)

--- a/src/THcAerogel.h
+++ b/src/THcAerogel.h
@@ -32,8 +32,6 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   virtual EStatus Init(const TDatime& run_time);
   Int_t           End(THaRunBase* run=0);
 
-  void  InitArrays();
-  void  DeleteArrays();
   Int_t GetIndex(Int_t nRegion, Int_t nValue);
 
   THcAerogel();  // for ROOT I/O
@@ -131,7 +129,7 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   vector<Double_t> fGoodNegAdcPulseIntRaw;
   vector<Double_t> fGoodNegAdcPulseAmp;
   vector<Double_t> fGoodNegAdcPulseTime;
- vector<Double_t> fGoodNegAdcTdcDiffTime;
+  vector<Double_t> fGoodNegAdcTdcDiffTime;
 
   // 6 GeV era variables
   Int_t     fAnalyzePedestals;
@@ -179,8 +177,10 @@ class THcAerogel : public THaNonTrackingDetector, public THcHitList {
   vector<Double_t> fNegNpeSixGev;
 
   void Setup(const char* name, const char* description);
+  void  DeleteArrays();
+  void  DeletePedestalArrays();
   virtual void  InitializePedestals( );
- THcHodoscope* fglHod;		// Hodoscope to get start time
+  THcHodoscope* fglHod;		// Hodoscope to get start time
 
   ClassDef(THcAerogel,0)   // Generic aerogel class
 }

--- a/src/THcAnalyzer.cxx
+++ b/src/THcAnalyzer.cxx
@@ -103,6 +103,7 @@ void THcAnalyzer::PrintReport(const char* templatefile, const char* ofile)
       } else {
 	THcFormula* formula = new THcFormula("temp",expression.c_str(),gHcParms,gHaVars,gHaCuts);
 	Double_t value=formula->Eval();
+	delete formula; formula = 0;
 	// If the value is close to integer and no format is defined
 	// use "%.0f" to print out integer
 	if(format.empty()) {

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -135,6 +135,10 @@ void THcCherenkov::DeleteArrays()
   delete [] fPedCount; fPedCount = NULL;
   delete [] fPed;      fPed      = NULL;
   delete [] fThresh;   fThresh   = NULL;
+
+  delete [] fAdcTimeWindowMin; fAdcTimeWindowMin = 0;
+  delete [] fAdcTimeWindowMax; fAdcTimeWindowMax = 0;
+  delete [] fRegionValue; fRegionValue = 0;
 }
 
 //_____________________________________________________________________________
@@ -166,7 +170,7 @@ THaAnalysisObject::EStatus THcCherenkov::Init( const TDatime& date )
     Warning(Here(here),"Hodoscope \"%s\" not found. ","hod");
   }
 
- fPresentP = 0;
+  fPresentP = 0;
   THaVar* vpresent = gHaVars->Find(Form("%s.present",GetApparatus()->GetName()));
   if(vpresent) {
     fPresentP = (Bool_t *) vpresent->GetValuePointer();

--- a/src/THcConfigEvtHandler.h
+++ b/src/THcConfigEvtHandler.h
@@ -72,6 +72,8 @@ private:
 
   std::map<Int_t, CrateInfo_t *> CrateInfoMap;
 
+  void DeleteCrateInfoMap();
+
   THcConfigEvtHandler(const THcConfigEvtHandler& fh);
   THcConfigEvtHandler& operator=(const THcConfigEvtHandler& fh);
 

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -302,9 +302,6 @@ Int_t THcDC::ReadDatabase( const TDatime& date )
   delete [] fSigma;  fSigma = new Double_t [fNPlanes];
 
   Bool_t optional = true;
-  fReadoutLR = new Int_t[fNPlanes];
-  fReadoutTB = new Int_t[fNPlanes];
-
 
   DBRequest list[]={
     {"dc_tdc_time_per_channel",&fNSperChan, kDouble},
@@ -484,6 +481,15 @@ void THcDC::DeleteArrays()
   delete [] fNChamHits; fNChamHits = NULL;
   delete [] fPlaneEvents; fPlaneEvents = NULL;
 
+  for( Int_t i = 0; i<fNPlanes; ++i )
+    delete [] fPlaneNames[i];
+  delete [] fPlaneNames;
+
+  delete [] fPlaneCoeffs; fPlaneCoeffs = 0;
+  delete [] fResiduals; fResiduals = 0;
+  delete [] fResidualsExclPlane; fResidualsExclPlane = 0;
+  delete [] fWire_hit_did; fWire_hit_did = 0;
+  delete [] fWire_hit_should; fWire_hit_should = 0;
 }
 
 //_____________________________________________________________________________

--- a/src/THcDCLookupTTDConv.cxx
+++ b/src/THcDCLookupTTDConv.cxx
@@ -5,7 +5,8 @@
 
 */
 #include "THcDCLookupTTDConv.h"
-
+#include <cstring>
+#include <cassert>
 ClassImp(THcDCLookupTTDConv)
 
 
@@ -18,18 +19,17 @@ fT0(T0), fMaxDriftDistance(MaxDriftDistance), fBinSize(BinSize),
 {
   //Normal constructor
 
+  assert( fNumBins > 0 );
   fTable = new Double_t[fNumBins];
-  for(Int_t i=0;i<fNumBins;i++) {
-    fTable[i] = Table[i];
-  }
-
+  memcpy( fTable, Table, fNumBins*sizeof(Double_t) );
 }
 
 //______________________________________________________________________________
 THcDCLookupTTDConv::~THcDCLookupTTDConv()
 {
-  // Destructor. Remove variables from global list.
+  // Destructor
 
+  delete [] fTable;
 }
 
 //______________________________________________________________________________

--- a/src/THcDriftChamber.cxx
+++ b/src/THcDriftChamber.cxx
@@ -196,22 +196,23 @@ Int_t THcDriftChamber::ReadDatabase( const TDatime& date )
   for(Int_t ipm1=0;ipm1<fNPlanes+1;ipm1++) { // Loop over missing plane1
     for(Int_t ipm2=ipm1;ipm2<fNPlanes+1;ipm2++) {
       if(ipm1==ipm2 && ipm1<fNPlanes) continue;
-      TMatrixD* AA3 = new TMatrixD(3,3);
+      TMatrixD AA3(3,3);
       for(Int_t i=0;i<3;i++) {
 	for(Int_t j=i;j<3;j++) {
-	  (*AA3)[i][j] = 0.0;
+	  AA3[i][j] = 0.0;
 	  for(Int_t ip=0;ip<fNPlanes;ip++) {
 	    if(ipm1 != ip && ipm2 != ip) {
-	      (*AA3)[i][j] += fStubCoefs[ip][i]*fStubCoefs[ip][j];
+	      AA3[i][j] += fStubCoefs[ip][i]*fStubCoefs[ip][j];
 	    }
 	  }
-	  (*AA3)[j][i] = (*AA3)[i][j];
+	  AA3[j][i] = AA3[i][j];
 	}
       }
       Int_t bitpat = allplanes & ~(1<<ipm1) & ~(1<<ipm2);
       // Should check that it is invertable
       //      if (fhdebugflagpr) cout << bitpat << " Determinant: " << AA3->Determinant() << endl;
-      AA3->Invert();
+      AA3.Invert();
+      fAA3Inv[bitpat].ResizeTo(AA3);
       fAA3Inv[bitpat] = AA3;
     }
   }
@@ -1326,11 +1327,11 @@ Double_t THcDriftChamber::FindStub(Int_t nhits, THcSpacePoint *sp,
 	/fSigma[plane_list[ihit]];
     }
   }
-  //  fAA3Inv[bitpat]->Print();
+  //  fAA3Inv[bitpat].Print();
   //  if (fhdebugflagpr) cout << TT[0] << " " << TT[1] << " " << TT[2] << endl;
-  //  TT->Print();
+  //  TT.Print();
 
-  TT *= *fAA3Inv[bitpat];
+  TT *= fAA3Inv[bitpat];
   // if (fhdebugflagpr) cout << TT[0] << " " << TT[1] << " " << TT[2] << endl;
 
   // Calculate Chi2.  Remember one power of sigma is in fStubCoefs
@@ -1373,14 +1374,12 @@ THcDriftChamber::~THcDriftChamber()
 void THcDriftChamber::DeleteArrays()
 {
   // Delete member arrays. Used by destructor.
-  delete fCosBeta; fCosBeta = NULL;
-  delete fSinBeta; fSinBeta = NULL;
-  delete fTanBeta; fTanBeta = NULL;
-  delete fSigma; fSigma = NULL;
-  delete fPsi0; fPsi0 = NULL;
-  delete fStubCoefs; fStubCoefs = NULL;
-
-  // Need to delete each element of the fAA3Inv map
+  delete [] fCosBeta; fCosBeta = NULL;
+  delete [] fSinBeta; fSinBeta = NULL;
+  delete [] fTanBeta; fTanBeta = NULL;
+  delete [] fSigma; fSigma = NULL;
+  delete [] fPsi0; fPsi0 = NULL;
+  delete [] fStubCoefs; fStubCoefs = NULL;
 
 }
 

--- a/src/THcDriftChamber.h
+++ b/src/THcDriftChamber.h
@@ -135,7 +135,7 @@ protected:
   Int_t fEasySpacePoint;	/* This event is an easy space point */
 
   Double_t* stubcoef[4];
-  std::map<int,TMatrixD*> fAA3Inv;
+  std::map<int,TMatrixD> fAA3Inv;
 
   THaDetectorBase* fParent;
 

--- a/src/THcDriftChamberPlane.cxx
+++ b/src/THcDriftChamberPlane.cxx
@@ -33,14 +33,12 @@ THcDriftChamberPlane::THcDriftChamberPlane( const char* name,
 					    const char* description,
 					    const Int_t planenum,
 					    THaDetectorBase* parent )
-  : THaSubDetector(name,description,parent)
+: THaSubDetector(name,description,parent), fTTDConv(0)
 {
   // Normal constructor with name and description
   fHits = new TClonesArray("THcDCHit",100);
   fRawHits = new TClonesArray("THcDCHit",100);
   fWires = new TClonesArray("THcDCWire", 100);
-
-  fTTDConv = NULL;
 
   fPlaneNum = planenum;
 }
@@ -59,6 +57,8 @@ THcDriftChamberPlane::THcDriftChamberPlane() :
 THcDriftChamberPlane::~THcDriftChamberPlane()
 {
   // Destructor
+  delete [] fTzeroWire;
+  delete [] fSigmaWire;
   delete fWires;
   delete fHits;
   delete fRawHits;

--- a/src/THcHallCSpectrometer.cxx
+++ b/src/THcHallCSpectrometer.cxx
@@ -762,8 +762,8 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
   if ( fNtracks > 0 ) {
     chi2Min   = 10000000000.0;
     fGoodTrack = 0;
-    Bool_t* keep      = new Bool_t [fNtracks];
-    Int_t* reject    = new Int_t  [fNtracks];
+    vector<bool> keep(fNtracks);
+    vector<Int_t> reject(fNtracks);
 
     THaTrack *testTracks[fNtracks];
 
@@ -772,7 +772,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
       keep[ptrack] = kTRUE;
       reject[ptrack] = 0;
       testTracks[ptrack] = static_cast<THaTrack*>( fTracks->At(ptrack) );
-      if (!testTracks[ptrack]) {delete[] keep; delete[] reject; return -1;}
+      if (!testTracks[ptrack]) return -1;
     }
 
     // ! Prune on xptar
@@ -786,7 +786,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
       for (Int_t ptrack = 0; ptrack < fNtracks; ptrack++ ){
 	if ( TMath::Abs( testTracks[ptrack]->GetTTheta() ) >= fPruneXp ){
 	  keep[ptrack] = kFALSE;
-	  reject[ptrack] = reject[ptrack] + 1;
+	  reject[ptrack] += 1;
 	}
       }
     }
@@ -802,7 +802,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
       for (Int_t ptrack = 0; ptrack < fNtracks; ptrack++ ){
 	if ( TMath::Abs( testTracks[ptrack]->GetTPhi() ) >= fPruneYp ){
 	  keep[ptrack] = kFALSE;
-	  reject[ptrack] = reject[ptrack] + 2;
+	  reject[ptrack] += 2;
 
 	}
       }
@@ -819,7 +819,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
       for (Int_t ptrack = 0; ptrack < fNtracks; ptrack++ ){
 	if ( TMath::Abs( testTracks[ptrack]->GetTY() ) >= fPruneYtar ){
 	  keep[ptrack] = kFALSE;
-	  reject[ptrack] = reject[ptrack] + 10;
+	  reject[ptrack] += 10;
 	}
       }
     }
@@ -835,7 +835,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
       for (Int_t ptrack = 0; ptrack < fNtracks; ptrack++ ){
 	if ( TMath::Abs( testTracks[ptrack]->GetDp() ) >= fPruneDelta ){
 	  keep[ptrack] = kFALSE;
-	  reject[ptrack] = reject[ptrack] + 20;
+	  reject[ptrack] += 20;
 	}
       }
     }
@@ -855,7 +855,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
 	Double_t betaP = p / TMath::Sqrt( p * p + fPartMass * fPartMass );
 	if ( TMath::Abs( testTracks[ptrack]->GetBeta() - betaP ) >= fPruneBeta ) {
 	  keep[ptrack] = kFALSE;
-	  reject[ptrack] = reject[ptrack] + 100;
+	  reject[ptrack] += 100;
 	}
       }
     }
@@ -871,7 +871,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
       for (Int_t ptrack = 0; ptrack < fNtracks; ptrack++ ){
 	if ( testTracks[ptrack]->GetNDoF() < fPruneDf ){
 	  keep[ptrack] = kFALSE;
-	  reject[ptrack] = reject[ptrack] + 200;
+	  reject[ptrack] += 200;
 	}
       }
     }
@@ -887,7 +887,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
       for (Int_t ptrack = 0; ptrack < fNtracks; ptrack++ ){
 	if ( testTracks[ptrack]->GetNPMT() < fPruneNPMT ){
 	  keep[ptrack] = kFALSE;
-	  reject[ptrack] = reject[ptrack] + 100000;
+	  reject[ptrack] += 100000;
 	}
       }
     }
@@ -905,7 +905,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
 	if ( ( testTracks[ptrack]->GetBetaChi2() >= fPruneChiBeta ) ||
 	     ( testTracks[ptrack]->GetBetaChi2() <= 0.01          ) ){
 	  keep[ptrack] = kFALSE;
-	  reject[ptrack] = reject[ptrack] + 1000;
+	  reject[ptrack] += 1000;
 	}
       }
     }
@@ -922,7 +922,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
       for (Int_t ptrack = 0; ptrack < fNtracks; ptrack++ ){
 	if ( TMath::Abs( testTracks[ptrack]->GetFPTime() - fHodo->GetStartTimeCenter() ) >= fPruneFpTime ) {
 	  keep[ptrack] = kFALSE;
-	  reject[ptrack] = reject[ptrack] + 2000;
+	  reject[ptrack] += 2000;
 	}
       }
     }
@@ -938,7 +938,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
       for (Int_t ptrack = 0; ptrack < fNtracks; ptrack++ ){
 	if ( testTracks[ptrack]->GetGoodPlane4() != 1 ) {
 	  keep[ptrack] = kFALSE;
-	  reject[ptrack] = reject[ptrack] + 10000;
+	  reject[ptrack] += 10000;
 	}
       }
     }
@@ -954,7 +954,7 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
       for (Int_t ptrack = 0; ptrack < fNtracks; ptrack++ ){
 	if ( testTracks[ptrack]->GetGoodPlane3() != 1 ) {
 	  keep[ptrack] = kFALSE;
-	  reject[ptrack] = reject[ptrack] + 20000;
+	  reject[ptrack] += 20000;
 	}
       }
     }

--- a/src/THcHitList.cxx
+++ b/src/THcHitList.cxx
@@ -33,7 +33,8 @@ THcHitList::THcHitList() : fMap(0), fTISlot(0), fDisableSlipCorrection(kFALSE)
 
 THcHitList::~THcHitList() {
   /// Destructor
-  delete fSignalTypes;
+  delete fRawHitList;
+  delete [] fSignalTypes;
 }
 /**
 

--- a/src/THcHodoEff.cxx
+++ b/src/THcHodoEff.cxx
@@ -36,6 +36,24 @@ THcHodoEff::~THcHodoEff()
 {
   // Destructor
 
+  delete [] fPlanes; fPlanes = 0;
+  delete [] fPosZ; fPosZ = 0;
+  delete [] fSpacing; fSpacing = 0;
+  delete [] fCenterFirst; fCenterFirst = 0;
+  delete [] fNCounters; fNCounters = 0;
+  delete [] fHodoSlop; fHodoSlop = 0;
+  delete [] fStatTrkSum; fStatTrkSum = 0;
+  delete [] fStatAndSum; fStatAndSum = 0;
+  delete [] fStatAndEff; fStatAndEff = 0;
+
+  delete [] fHodoPosEffi; fHodoPosEffi = 0;
+  delete [] fHodoNegEffi; fHodoNegEffi = 0;
+  delete [] fHodoOrEffi; fHodoOrEffi = 0;
+  delete [] fHodoAndEffi; fHodoAndEffi = 0;
+  delete [] fStatTrk; fStatTrk = 0;
+
+  delete [] fHitPlane; fHitPlane = 0;
+
   RemoveVariables();
 }
 

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -415,6 +415,11 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
   //      << " number of photo electrons = " << fNCerNPE
   //      << endl;
 
+  //Set scin Velocity/Cable to default
+  for (UInt_t i=0; i<fMaxHodoScin; i++) {
+    fHodoVelLight[i] = 15.0;
+  }
+
   if (fTofUsingInvAdc) {
     DBRequest list2[]={
       {"hodo_vel_light",                   &fHodoVelLight[0],       kDouble,  fMaxHodoScin, 1},
@@ -426,13 +431,6 @@ Int_t THcHodoscope::ReadDatabase( const TDatime& date )
       {"hodo_neg_invadc_adc",&fHodoNegInvAdcAdc[0],kDouble,fMaxHodoScin},
       {0}
     };
-    
-       for (UInt_t i=0; i<fMaxHodoScin; i++)                                                                    
-       {  
-	 //Set scin Velocity/Cable to default
-	 fHodoVelLight[i] = 15.0;
-	 
-       }
     
     gHcParms->LoadParmValues((DBRequest*)&list2,prefix);
   };

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -566,10 +566,13 @@ THcHodoscope::~THcHodoscope()
     RemoveVariables();
   if( fIsInit )
     DeleteArrays();
-  if (fTrackProj) {
-    fTrackProj->Clear();
-    delete fTrackProj; fTrackProj = 0;
+
+  for( int i = 0; i < fNPlanes; ++i ) {
+    delete fPlanes[i];
+    delete [] fPlaneNames[i];
   }
+  delete [] fPlanes;
+  delete [] fPlaneNames;
 }
 
 //_____________________________________________________________________________
@@ -584,6 +587,8 @@ void THcHodoscope::DeleteArrays()
 
   delete [] fxLoScin;             fxLoScin = NULL;
   delete [] fxHiScin;             fxHiScin = NULL;
+  delete [] fyLoScin;             fyLoScin = NULL;
+  delete [] fyHiScin;             fyHiScin = NULL;
   delete [] fHodoSlop;            fHodoSlop = NULL;
 
   delete [] fNPaddle;             fNPaddle = NULL;
@@ -603,11 +608,13 @@ void THcHodoscope::DeleteArrays()
   delete [] fHodoPosInvAdcLinear; fHodoPosInvAdcLinear = NULL;
   delete [] fHodoNegInvAdcLinear; fHodoNegInvAdcLinear = NULL;
   delete [] fHodoPosInvAdcAdc;    fHodoPosInvAdcAdc = NULL;
+  delete [] fHodoNegInvAdcAdc;    fHodoNegInvAdcAdc = NULL;
   delete [] fGoodPlaneTime;       fGoodPlaneTime = NULL;
   delete [] fNPlaneTime;          fNPlaneTime = NULL;
   delete [] fSumPlaneTime;        fSumPlaneTime = NULL;
   delete [] fNScinHits;           fNScinHits = NULL;
   delete [] fTdcOffset;           fTdcOffset = NULL;
+  delete [] fAdcTdcOffset;        fAdcTdcOffset = NULL;
   delete [] fHodoNegAdcTimeWindowMin;    fHodoNegAdcTimeWindowMin = NULL;
   delete [] fHodoNegAdcTimeWindowMax;    fHodoNegAdcTimeWindowMax = NULL;
   delete [] fHodoPosAdcTimeWindowMin;    fHodoPosAdcTimeWindowMin = NULL;
@@ -973,8 +980,8 @@ Int_t THcHodoscope::CoarseProcess( TClonesArray& tracks )
   if (tracks.GetLast()+1 > 0 ) {
 
     // **MAIN LOOP: Loop over all tracks and get corrected time, tof, beta...
-    Double_t* nPmtHit = new Double_t [ntracks];
-    Double_t* timeAtFP = new Double_t [ntracks];
+    vector<Double_t> nPmtHit(ntracks);
+    vector<Double_t> timeAtFP(ntracks);
     for ( Int_t itrack = 0; itrack < ntracks; itrack++ ) { // Line 133
       nPmtHit[itrack]=0;
       timeAtFP[itrack]=0;

--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -43,6 +43,7 @@ public:
 
   virtual Int_t      Decode( const THaEvData& );
   virtual EStatus    Init( const TDatime& run_time );
+  virtual void       Clear( Option_t* opt="" );
 
   virtual Int_t      CoarseProcess( TClonesArray& tracks );
   virtual Int_t      FineProcess( TClonesArray& tracks );
@@ -340,9 +341,8 @@ protected:
     Int_t hitNumInPlane;
     THcHodoHit *hit;
     TOFPInfo () : onTrack(kFALSE), keep_pos(kFALSE), keep_neg(kFALSE),
-      time_pos(-99.0), time_neg(-99.0),
-
-scin_pos_time(0.0), scin_neg_time(0.0) {}
+		  time_pos(-99.0), time_neg(-99.0), scin_pos_time(0.0),
+		  scin_neg_time(0.0) {}
   };
   std::vector<TOFPInfo> fTOFPInfo;
 
@@ -380,11 +380,12 @@ scin_pos_time(0.0), scin_neg_time(0.0) {}
     Bool_t goodScinTime;
     Bool_t goodTdcNeg;
     Bool_t goodTdcPos;
+    GoodFlags() : onTrack(false), goodScinTime(false),
+		  goodTdcNeg(false), goodTdcPos(false) {}
   };
   std::vector<std::vector<std::vector<GoodFlags> > > fGoodFlags;
   //
 
-  void           ClearEvent();
   void           DeleteArrays();
   virtual Int_t  ReadDatabase( const TDatime& date );
   virtual Int_t  DefineVariables( EMode mode = kDefine );

--- a/src/THcParmList.cxx
+++ b/src/THcParmList.cxx
@@ -56,6 +56,7 @@ An instance of THaTextvars is created to hold the string parameters.
 #include <cassert>
 #include <cstdlib>
 #include <stdexcept>
+#include <memory>
 
 using namespace std;
 Int_t  fDebug   = 1;  // Keep this at one while we're working on the code

--- a/src/THcParmList.cxx
+++ b/src/THcParmList.cxx
@@ -60,6 +60,12 @@ An instance of THaTextvars is created to hold the string parameters.
 using namespace std;
 Int_t  fDebug   = 1;  // Keep this at one while we're working on the code
 
+#if __cplusplus < 201103L
+# define SMART_PTR auto_ptr
+#else
+# define SMART_PTR unique_ptr
+#endif
+
 ClassImp(THcParmList)
 
 /// Create empty numerical and string parameter lists
@@ -261,7 +267,7 @@ The ENGINE CTP support parameter "blocks" which were marked with
       if(line.find_first_not_of("0123456789-,")==string::npos) { // Interpret as runnum range
 	// Interpret line as a list of comma separated run numbers or ranges
 	TString runnums(line.c_str());
-	TObjArray *runnumarr = runnums.Tokenize(",");
+	SMART_PTR<TObjArray> runnumarr( runnums.Tokenize(",") );
 	Int_t nranges=runnumarr->GetLast()+1;
 
 	InRunRange = 0;

--- a/src/THcScalerEvtHandler.h
+++ b/src/THcScalerEvtHandler.h
@@ -26,7 +26,7 @@ class HCScalerLoc { // Utility class used by THcScalerEvtHandler
 	      UInt_t iki, Int_t iv) :
    name(nm), description(desc), index(idx), islot(s1), ichan(ich),
    ikind(iki), ivar(iv) { };
-  ~HCScalerLoc();
+  ~HCScalerLoc() {}
   TString name, description;
   UInt_t index, islot, ichan, ikind, ivar;
 };

--- a/src/THcScintillatorPlane.cxx
+++ b/src/THcScintillatorPlane.cxx
@@ -33,7 +33,30 @@ THcScintillatorPlane::THcScintillatorPlane( const char* name,
 					    const char* description,
 					    const Int_t planenum,
 					    THaDetectorBase* parent )
-: THaSubDetector(name,description,parent)
+: THaSubDetector(name,description,parent),
+  fParentHitList(0), frPosAdcErrorFlag(0), frNegAdcErrorFlag(0),
+  frPosTDCHits(0), frNegTDCHits(0), frPosADCHits(0), frNegADCHits(0),
+  frPosADCSums(0), frNegADCSums(0), frPosADCPeds(0), frNegADCPeds(0),
+  fHodoHits(0), frPosTdcTimeRaw(0), frPosAdcPedRaw(0),
+  frPosAdcPulseIntRaw(0), frPosAdcPulseAmpRaw(0),
+  frPosAdcPulseTimeRaw(0), frPosTdcTime(0), frPosAdcPed(0),
+  frPosAdcPulseInt(0), frPosAdcPulseAmp(0), frPosAdcPulseTime(0),
+  frNegTdcTimeRaw(0), frNegAdcPedRaw(0), frNegAdcPulseIntRaw(0),
+  frNegAdcPulseAmpRaw(0), frNegAdcPulseTimeRaw(0), frNegTdcTime(0),
+  frNegAdcPed(0), frNegAdcPulseInt(0), frNegAdcPulseAmp(0),
+  frNegAdcPulseTime(0), fPosCenter(0), fHodoPosMinPh(0),
+  fHodoNegMinPh(0), fHodoPosPhcCoeff(0), fHodoNegPhcCoeff(0),
+  fHodoPosTimeOffset(0), fHodoNegTimeOffset(0), fHodoVelLight(0),
+  fHodoPosInvAdcOffset(0), fHodoNegInvAdcOffset(0),
+  fHodoPosAdcTimeWindowMin(0), fHodoPosAdcTimeWindowMax(0),
+  fHodoNegAdcTimeWindowMin(0), fHodoNegAdcTimeWindowMax(0),
+  fHodoPosInvAdcLinear(0), fHodoNegInvAdcLinear(0),
+  fHodoPosInvAdcAdc(0), fHodoNegInvAdcAdc(0), fHodoVelFit(0),
+  fHodoCableFit(0), fHodo_LCoeff(0), fHodoPos_c1(0), fHodoNeg_c1(0),
+  fHodoPos_c2(0), fHodoNeg_c2(0), fHodoSigma(0), fPosPedSum(0),
+  fPosPedSum2(0), fPosPedLimit(0), fPosPedCount(0), fNegPedSum(0),
+  fNegPedSum2(0), fNegPedLimit(0), fNegPedCount(0), fPosPed(0),
+  fPosSig(0), fPosThresh(0), fNegPed(0), fNegSig(0), fNegThresh(0)
 {
   // Normal constructor with name and description
   fHodoHits = new TClonesArray("THcHodoHit",16);
@@ -77,14 +100,14 @@ THcScintillatorPlane::THcScintillatorPlane( const char* name,
   fPlaneNum = planenum;
   fTotPlanes = planenum;
   fNScinHits = 0;
-
-  fPosCenter = NULL;
 }
 
 //______________________________________________________________________________
 THcScintillatorPlane::~THcScintillatorPlane()
 {
   // Destructor
+  if( fIsSetup )
+    RemoveVariables();
   delete  frPosAdcErrorFlag; frPosAdcErrorFlag = NULL;
   delete  frNegAdcErrorFlag; frNegAdcErrorFlag = NULL;
 
@@ -122,7 +145,7 @@ THcScintillatorPlane::~THcScintillatorPlane()
   delete frNegAdcPulseAmp;
   delete frNegAdcPulseTime;
 
-  delete [] fPosCenter;
+  delete [] fPosCenter; fPosCenter = 0;
 
   delete [] fHodoPosMinPh; fHodoPosMinPh = NULL;
   delete [] fHodoNegMinPh; fHodoNegMinPh = NULL;
@@ -153,6 +176,18 @@ THcScintillatorPlane::~THcScintillatorPlane()
   delete [] fHodoVelLight; fHodoVelLight = NULL;
   delete [] fHodoSigma; fHodoSigma = NULL;
 
+  delete [] fPosPedSum; fPosPedSum = 0;
+  delete [] fPosPedSum2; fPosPedSum2 = 0;
+  delete [] fPosPedLimit; fPosPedLimit = 0;
+  delete [] fPosPedCount; fPosPedCount = 0;
+  delete [] fNegPedSum; fNegPedSum = 0;
+  delete [] fNegPedSum2; fNegPedSum2 = 0;
+  delete [] fNegPedLimit; fNegPedLimit = 0;
+  delete [] fNegPedCount; fNegPedCount = 0;
+  delete [] fPosPed; fPosPed = 0;
+  delete [] fNegPed; fNegPed = 0;
+  delete [] fPosThresh; fPosThresh = 0;
+  delete [] fNegThresh; fNegThresh = 0;
 }
 
 //______________________________________________________________________________

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -19,19 +19,26 @@
 #include "TClonesArray.h"
 #include "THaTrackProj.h"
 #include "TMath.h"
+#include "Helper.h"
 
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
 #include <numeric>
+#include <cassert>
 
 using namespace std;
 
 //_____________________________________________________________________________
 THcShower::THcShower( const char* name, const char* description,
 				  THaApparatus* apparatus ) :
-  THaNonTrackingDetector(name,description,apparatus)
+  THaNonTrackingDetector(name,description,apparatus),
+  fPosAdcTimeWindowMin(0), fNegAdcTimeWindowMin(0),
+  fPosAdcTimeWindowMax(0), fNegAdcTimeWindowMax(0),
+  fShPosPedLimit(0), fShNegPedLimit(0), fPosGain(0), fNegGain(0),
+  fClusterList(0), fLayerNames(0), fLayerZPos(0), BlockThick(0),
+  fNBlocks(0), fXPos(0), fYPos(0), fZPos(0), fPlanes(0), fArray(0)
 {
   // Constructor
   fNLayers = 0;			// No layers until we make them
@@ -43,7 +50,12 @@ THcShower::THcShower( const char* name, const char* description,
 
 //_____________________________________________________________________________
 THcShower::THcShower( ) :
-  THaNonTrackingDetector()
+  THaNonTrackingDetector(),
+  fPosAdcTimeWindowMin(0), fNegAdcTimeWindowMin(0),
+  fPosAdcTimeWindowMax(0), fNegAdcTimeWindowMax(0),
+  fShPosPedLimit(0), fShNegPedLimit(0), fPosGain(0), fNegGain(0),
+  fClusterList(0), fLayerNames(0), fLayerZPos(0), BlockThick(0),
+  fNBlocks(0), fXPos(0), fYPos(0), fZPos(0), fPlanes(0), fArray(0)
 {
   // Constructor
 }
@@ -572,14 +584,24 @@ THcShower::~THcShower()
 {
   // Destructor. Remove variables from global list.
 
+  Clear();
   if( fIsSetup )
     RemoveVariables();
   if( fIsInit )
     DeleteArrays();
-  if (fTrackProj) {
-    fTrackProj->Clear();
-    delete fTrackProj; fTrackProj = 0;
+
+  for (THcShowerClusterListIt i=fClusterList->begin(); i!=fClusterList->end();
+       ++i) {
+    Podd::DeleteContainer(**i);
+    delete *i;
   }
+  delete fClusterList; fClusterList = 0;
+
+  for( UInt_t i = 0; i<fNLayers; ++i) {
+    delete fPlanes[i];
+  }
+  delete [] fPlanes; fPlanes = 0;
+  delete fArray; fArray = 0;
 }
 
 //_____________________________________________________________________________
@@ -587,10 +609,25 @@ void THcShower::DeleteArrays()
 {
   // Delete member arrays. Used by destructor.
 
+  for (UInt_t i = 0; i<fNTotLayers; ++i)
+    delete [] fLayerNames[i];
+  delete [] fLayerNames; fLayerNames = 0;
+
+  delete [] fPosAdcTimeWindowMin; fPosAdcTimeWindowMin = 0;
+  delete [] fNegAdcTimeWindowMin; fNegAdcTimeWindowMin = 0;
+  delete [] fPosAdcTimeWindowMax; fPosAdcTimeWindowMax = 0;
+  delete [] fNegAdcTimeWindowMax; fNegAdcTimeWindowMax = 0;
+  delete [] fShPosPedLimit; fShPosPedLimit = 0;
+  delete [] fShNegPedLimit; fShNegPedLimit = 0;
+  delete [] fPosGain; fPosGain = 0;
+  delete [] fNegGain; fNegGain = 0;
   delete [] BlockThick;  BlockThick = NULL;
   delete [] fNBlocks;  fNBlocks = NULL;
   delete [] fLayerZPos;  fLayerZPos = NULL;
+  for (UInt_t i = 0; i<fNLayers; ++i)
+    delete [] fXPos[i];
   delete [] fXPos;  fXPos = NULL;
+  delete [] fYPos;  fYPos = NULL;
   delete [] fZPos;  fZPos = NULL;
 }
 
@@ -635,11 +672,10 @@ void THcShower::Clear(Option_t* opt)
 
   for (THcShowerClusterListIt i=fClusterList->begin(); i!=fClusterList->end();
        ++i) {
+    Podd::DeleteContainer(**i);
     delete *i;
-    *i = 0;
   }
   fClusterList->clear();
-
 }
 
 //_____________________________________________________________________________
@@ -766,6 +802,7 @@ Int_t THcShower::CoarseProcess( TClonesArray& tracks)
   // Fill list of clusters.
 
   ClusterHits(HitSet, fClusterList);
+  assert( HitSet.empty() );  // else bug in ClusterHits()
 
   fNclust = (*fClusterList).size();   //number of clusters
 

--- a/src/THcShower.h
+++ b/src/THcShower.h
@@ -268,8 +268,6 @@ protected:
   THcShowerPlane** fPlanes;     // [fNLayers] Shower Plane objects
   THcShowerArray* fArray;
 
-  TClonesArray*  fTrackProj;    // projection of track onto plane
-
   void           ClearEvent();
   void           DeleteArrays();
   virtual Int_t  ReadDatabase( const TDatime& date );

--- a/src/THcShowerArray.cxx
+++ b/src/THcShowerArray.cxx
@@ -20,12 +20,13 @@
 #include "THaTrackProj.h"
 #include "THcCherenkov.h"         //for efficiency calculations
 #include "THcHallCSpectrometer.h"
+#include "Helper.h"
 
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
-
+#include <cassert>
 #include <fstream>
 
 using namespace std;
@@ -61,11 +62,15 @@ THcShowerArray::~THcShowerArray()
 {
   // Destructor
 
+  Clear(); // deletes allocations in fClusterList
   for (UInt_t i=0; i<fNRows; i++) {
     delete [] fXPos[i];
     delete [] fYPos[i];
     delete [] fZPos[i];
   }
+  delete [] fXPos; fXPos = 0;
+  delete [] fYPos; fYPos = 0;
+  delete [] fZPos; fZPos = 0;
 
   delete [] fPedLimit;
   delete [] fGain;
@@ -95,6 +100,11 @@ THcShowerArray::~THcShowerArray()
 
   //delete [] fE;
   delete [] fBlock_ClusterID;
+
+  delete fClusterList; fClusterList = 0;
+
+  delete [] fAdcTimeWindowMin; fAdcTimeWindowMin = 0;
+  delete [] fAdcTimeWindowMax; fAdcTimeWindowMax = 0;
 }
 
 //_____________________________________________________________________________
@@ -479,8 +489,8 @@ void THcShowerArray::Clear( Option_t* )
 
   for (THcShowerClusterListIt i=fClusterList->begin(); i!=fClusterList->end();
        ++i) {
+    Podd::DeleteContainer(**i);
     delete *i;
-    *i = 0;
   }
   fClusterList->clear();
 
@@ -570,6 +580,7 @@ Int_t THcShowerArray::CoarseProcess( TClonesArray& tracks )
   // Cluster hits and fill list of clusters.
 
   static_cast<THcShower*>(fParent)->ClusterHits(HitSet, fClusterList);
+  assert( HitSet.empty() );  // else bug in ClusterHits()
 
   fNclust = (*fClusterList).size();         //number of clusters
 


### PR DESCRIPTION
valgrind revealed a large number of memory leaks, including a particularly nasty leak in the shower code that caused several hundred bytes to be lost _per event_.

This pull request patches all the hcana-related leaks reported when running `UTIL_KAONLT/scripts_Replay/replay_production_coin.C(4914,10000)`.

Additionally, it patches some of several invalid memory access issues. The issues not yet fixed have been reported in #427 and #428.
