### PR TITLE
Fix to THcScalerEvtHandler.cxx

### DIFF
--- a/src/THcScalerEvtHandler.cxx
+++ b/src/THcScalerEvtHandler.cxx
@@ -555,7 +555,7 @@ Int_t THcScalerEvtHandler::AnalyzeBuffer(UInt_t* rdata, Bool_t onlysync)
       UInt_t scaldata = scalers[idx]->GetData(ichan);
       if ( scal_current > fbcm_Current_Threshold) {
 	UInt_t diff;
-	if(nscal > 0 && scaldata < scal_prev_read[nscal-1]) {
+	if(scaldata < dvars_prev_read[ivar]) {
 	  diff = (kMaxUInt-(dvars_prev_read[ivar] - 1)) + scaldata;
 	} else {
 	  diff = scaldata - dvars_prev_read[ivar];


### PR DESCRIPTION
In THcScalerEvtHandler::AnalyzeBuffer there is a loop over
the scalers to keep track of scalers with a cut on the current.
There was a mistake in using scal_prev_read[nscal-1] instead of
dvars_prev_read[ivar] in the IF statement.