### PR TITLE
Modify THcCherenkov.cxx and THcCherenkov.h

### DIFF
--- a/src/THcCherenkov.h
+++ b/src/THcCherenkov.h
@@ -104,6 +104,8 @@ class THcCherenkov : public THaNonTrackingDetector, public THcHitList {
   Double_t* fPedMean; 	  /* Can be supplied in parameters and then */
   Double_t* fPed;
   Double_t* fThresh;
+  Double_t* fAdcPulseAmpTest;
+  Int_t*    fAdcGoodElem;
 
   // 12 Gev FADC variables
   TClonesArray* frAdcPedRaw;


### PR DESCRIPTION
Modify CoarseProcess so that if more than one hit in PMT is within the time window of the difference between pulse time and hodoscope start time the hit with the largest ADC value is selected as the good ADC hit for the PMT.  Previously it used the last hit within the time window.

Before accepting would like others to test.