### PR TITLE
Fix mistake in THcCoinTime.h

### DIFF
--- a/src/THcCoinTime.h
+++ b/src/THcCoinTime.h
@@ -126,10 +126,10 @@ public:
   Double_t had_FPtime;   //hadron focal plane time
 
   // trigger times pTrig1 (SHMS 3/4 trig) and pTrig4 (HMS 3/4 trig)
-  Int_t pTRIG1_TdcTime_ROC1;
-  Int_t pTRIG4_TdcTime_ROC1;
-  Int_t pTRIG1_TdcTime_ROC2;
-  Int_t pTRIG4_TdcTime_ROC2;
+  Double_t pTRIG1_TdcTime_ROC1;
+  Double_t pTRIG4_TdcTime_ROC1;
+  Double_t pTRIG1_TdcTime_ROC2;
+  Double_t pTRIG4_TdcTime_ROC2;
 
   //--------------------------------------------------------------------
 


### PR DESCRIPTION
Important fix! Peter found this bug. This change should improve the coincidence time
resolution. Since we had been using integer values so 1ns resolution.

The pTRIG1_TdcTime_ROC1, pTRIG4_TdcTime_ROC1
and pTRIG1_TdcTime_ROC2, pTRIG4_TdcTime_ROC2

should have been Double_t instead of Int_t
since the THcTrigDet.h function Get_CT_Trigtime
returns a Double_t which is the time convert to ns.