### PR TITLE
Improvements to helicity decoding

### DIFF
--- a/src/THcHelicity.h
+++ b/src/THcHelicity.h
@@ -94,6 +94,9 @@ protected:
   Double_t fErrorCode;
  
   Int_t fEvtype; // Current CODA event type
+  Int_t fLastActualHelicity;
+  Int_t fEvNumCheck;
+  Bool_t fDisabled;
  
   static const Int_t NHIST = 2;
   TH1F* fHisto[NHIST];  

--- a/src/THcRawAdcHit.cxx
+++ b/src/THcRawAdcHit.cxx
@@ -276,7 +276,7 @@ void THcRawAdcHit::SetDataTimePedestalPeak(
 ) {
   if (fNPulses >= fMaxNPulses) {
     throw std::out_of_range(
-      "`THcRawAdcHit::SetData`: too many pulses!"
+      "`THcRawAdcHit::SetDataTimePedestalPeak`: too many pulses!"
     );
   }
   fPulseInt[fNPulses] = data;


### PR DESCRIPTION
 Previously the helicity code was not always setting the actual
  helicity.  It would then just use the helicity from the last event.
  This was almost always OK.  With this change, the helicity (T.helicity.hel)
  should be always defined.
  It is now sufficient to use just this variable when sorting events into
  plus and minus helicity.  The helicity value will be zero if the event
  occured during the settle period, or if the helicity decoder has not
  got enough data to have a seed.

Also use the correct method name in a throw message.