### PR TITLE
Peter updates

### DIFF
--- a/src/THcCoinTime.cxx
+++ b/src/THcCoinTime.cxx
@@ -158,18 +158,28 @@ Int_t THcCoinTime::DefineVariables( EMode mode )
   const RVarDef vars[] = {
     {"epCoinTime_ROC1",    "ROC1 Corrected ep Coincidence Time",  "fROC1_epCoinTime"},
     {"epCoinTime_ROC2",    "ROC2 Corrected ep Coincidence Time",  "fROC2_epCoinTime"},
+    {"epCoinTime_TRIG1",    "TRIG1 Corrected ep Coincidence Time",  "fTRIG1_epCoinTime"},
+    {"epCoinTime_TRIG4",    "TRIG4 Corrected ep Coincidence Time",  "fTRIG4_epCoinTime"},
   
     {"eKCoinTime_ROC1",    "ROC1 Corrected eK Coincidence Time",  "fROC1_eKCoinTime"},
     {"eKCoinTime_ROC2",    "ROC2 Corrected eK Coincidence Time",  "fROC2_eKCoinTime"},
+    {"eKCoinTime_TRIG1",    "TRIG1 Corrected eK Coincidence Time",  "fTRIG1_eKCoinTime"},
+    {"eKCoinTime_TRIG4",    "TRIG4 Corrected eK Coincidence Time",  "fTRIG4_eKCoinTime"},
     
     {"ePiCoinTime_ROC1",    "ROC1 Corrected ePi Coincidence Time",  "fROC1_ePiCoinTime"},
     {"ePiCoinTime_ROC2",    "ROC2 Corrected ePi Coincidence Time",  "fROC2_ePiCoinTime"},
+    {"ePiCoinTime_TRIG1",    "TRIG1 Corrected ePi Coincidence Time",  "fTRIG1_ePiCoinTime"},
+    {"ePiCoinTime_TRIG4",    "TRIG4 Corrected ePi Coincidence Time",  "fTRIG4_ePiCoinTime"},
       
     {"ePositronCoinTime_ROC1",    "ROC1 Corrected e-Positorn Coincidence Time",  "fROC1_ePosCoinTime"},
     {"ePositronCoinTime_ROC2",    "ROC2 Corrected e-Positron Coincidence Time",  "fROC2_ePosCoinTime"},
+    {"ePositronCoinTime_TRIG1",    "TRIG1 Corrected e-Positorn Coincidence Time",  "fTRIG1_ePosCoinTime"},
+    {"ePositronCoinTime_TRIG4",    "TRIG4 Corrected e-Positron Coincidence Time",  "fTRIG4_ePosCoinTime"},
     
     {"CoinTime_RAW_ROC1",    "ROC1 RAW Coincidence Time",  "fROC1_RAW_CoinTime"},
     {"CoinTime_RAW_ROC2",    "ROC2 RAW Coincidence Time",  "fROC2_RAW_CoinTime"},
+    {"CoinTime_RAW_TRIG1",    "TRIG1 RAW Coincidence Time",  "fTRIG1_RAW_CoinTime"},
+    {"CoinTime_RAW_TRIG4",    "TRIG4 RAW Coincidence Time",  "fTRIG4_RAW_CoinTime"},
     {"DeltaSHMSPathLength","DeltaSHMSpathLength (cm)","DeltaSHMSpathLength"},
     {"DeltaHMSPathLength", "DeltaHMSpathLength (cm)","DeltaHMSpathLength"},
     {"had_coinCorr_Positron",    "",  "had_coinCorr_Positron"},
@@ -284,6 +294,8 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
 	  //Raw, Uncorrected Coincidence Time
 	  fROC1_RAW_CoinTime =  (pTRIG1_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG4_TdcTime_ROC1 + HMS_FPtime);
 	  fROC2_RAW_CoinTime =  (pTRIG1_TdcTime_ROC2 + SHMS_FPtime) - (pTRIG4_TdcTime_ROC2 + HMS_FPtime);
+	  fTRIG1_RAW_CoinTime =  (pTRIG1_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG1_TdcTime_ROC2 + HMS_FPtime);
+	  fTRIG4_RAW_CoinTime =  (pTRIG4_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG4_TdcTime_ROC2 + HMS_FPtime);
 	  
 	  
 	  //Corrected Coincidence Time for ROC1/ROC2 (ROC1 Should be identical to ROC2)
@@ -291,19 +303,26 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
 	  //PROTON
 	  fROC1_epCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
 	  fROC2_epCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
+	  fTRIG1_epCoinTime = fTRIG1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
+	  fTRIG4_epCoinTime = fTRIG4_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
 
 	  //KAON
 	  fROC1_eKCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
 	  fROC2_eKCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
+	  fTRIG1_eKCoinTime = fTRIG1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
+	  fTRIG4_eKCoinTime = fTRIG4_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
 	
 	  //PION
 	  fROC1_ePiCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;	  
 	  fROC2_ePiCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;
+	  fTRIG1_ePiCoinTime = fTRIG1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;	  
+	  fTRIG4_ePiCoinTime = fTRIG4_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;
 
 	  //POSITRON
 	  fROC1_ePosCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset ;	  
 	  fROC2_ePosCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
-
+	  fTRIG1_ePosCoinTime = fTRIG1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset ;	  
+	  fTRIG4_ePosCoinTime = fTRIG4_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
          
    
   

--- a/src/THcCoinTime.h
+++ b/src/THcCoinTime.h
@@ -83,19 +83,29 @@ public:
 
   Double_t fROC1_RAW_CoinTime;
   Double_t fROC2_RAW_CoinTime;
+  Double_t fTRIG1_RAW_CoinTime;
+  Double_t fTRIG4_RAW_CoinTime;
   
   
   Double_t fROC1_epCoinTime;
   Double_t fROC2_epCoinTime;
+  Double_t fTRIG1_epCoinTime;
+  Double_t fTRIG4_epCoinTime;
 
   Double_t fROC1_eKCoinTime;
   Double_t fROC2_eKCoinTime;
- 
+  Double_t fTRIG1_eKCoinTime;
+  Double_t fTRIG4_eKCoinTime;
+
   Double_t fROC1_ePiCoinTime;
   Double_t fROC2_ePiCoinTime;
+  Double_t fTRIG1_ePiCoinTime;
+  Double_t fTRIG4_ePiCoinTime;
  
   Double_t fROC1_ePosCoinTime;   //electron-positron coin time 
   Double_t fROC2_ePosCoinTime;
+  Double_t fTRIG1_ePosCoinTime;   //electron-positron coin time 
+  Double_t fTRIG4_ePosCoinTime;
   
   Double_t elec_coinCorr;
   Double_t elecArm_BetaCalc;

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -736,11 +736,11 @@ void THcDC::LinkStubs()
   std::vector<THcSpacePoint*> fSp;
   fNSp=0;
   fSp.clear();
-  fSp.reserve(10);
+  fSp.reserve(100);
   fNDCTracks=0;		// Number of Focal Plane tracks found
   fDCTracks->Delete();
   // Make a vector of pointers to the SpacePoints
-  if (fChambers[0]->GetNSpacePoints()+fChambers[1]->GetNSpacePoints()>10) return;
+  //if (fChambers[0]->GetNSpacePoints()+fChambers[1]->GetNSpacePoints()>10) return;
 
   for(UInt_t ich=0;ich<fNChambers;ich++) {
     Int_t nchamber=fChambers[ich]->GetChamberNum();
@@ -750,7 +750,8 @@ void THcDC::LinkStubs()
       fSp[fNSp]->fNChamber = nchamber;
       fSp[fNSp]->fNChamber_spnum = isp;
       fNSp++;
-      if (fNSp>10) break;
+      if (ich==0 && fNSp>50) break;
+      if (fNSp>100) break;
     }
   }
   Double_t stubminx = 999999;
@@ -817,7 +818,7 @@ void THcDC::LinkStubs()
 		fStubTest = 1;
 		//stubtest=1;  Used in h_track_tests.f
 		// Make a new track if there are not to many
-		if(fNDCTracks < MAXTRACKS) {
+		if(fNDCTracks < fNTracksMaxFP) {
 		  sptracks=0; // Number of tracks with this seed
 		  stub_tracks[sptracks++] = fNDCTracks;
 		  THcDCTrack *theDCTrack = new( (*fDCTracks)[fNDCTracks++]) THcDCTrack(fNPlanes);

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -189,7 +189,7 @@ protected:
   // double tan_angle, sin_angle, cos_angle;
 
   // Intermediate structure for building
-  static const UInt_t MAXTRACKS = 10;
+  static const UInt_t MAXTRACKS = 50;
 
   std::vector<THcDriftChamberPlane*> fPlanes; // List of plane objects
   std::vector<THcDriftChamber*> fChambers; // List of chamber objects

--- a/src/THcHallCSpectrometer.cxx
+++ b/src/THcHallCSpectrometer.cxx
@@ -137,6 +137,7 @@ Int_t THcHallCSpectrometer::DefineVariables( EMode mode )
   fIsSetup = ( mode == kDefine );
   RVarDef vars[] = {
     { "tr.betachisq", "Chi2 of beta", "fTracks.THaTrack.GetBetaChi2()"},
+    { "tr.PruneSelect", "Prune Select ID", "fPruneSelect"},
     { "present", "Trigger Type includes this spectrometer", "fPresent"},
     { 0 }
   };
@@ -280,6 +281,15 @@ Int_t THcHallCSpectrometer::ReadDatabase( const TDatime& date )
   // Default values
   fSelUsingScin = 0;
   fSelUsingPrune = 0;
+  fPruneXp = .2;
+  fPruneYp = .2;
+  fPruneYtar = 20.;
+  fPruneDelta = 30.;
+  fPruneBeta = 30.;
+  fPruneDf= 1;
+  fPruneChiBeta= 100.;
+  fPruneNPMT= 6;
+  fPruneFpTime= 1000.;
   fPhi_lab = 0.;
   fSatCorr=0.;
   fMispointing_x=999.;
@@ -341,7 +351,7 @@ Int_t THcHallCSpectrometer::ReadDatabase( const TDatime& date )
   //
   
   
-  EnforcePruneLimits();
+  //EnforcePruneLimits();
 
 #ifdef WITH_DEBUG
   cout <<  "\n\n\nhodo planes = " <<  fNPlanes << endl;
@@ -480,7 +490,7 @@ Int_t THcHallCSpectrometer::FindVertices( TClonesArray& tracks )
     TransportToLab(track->GetP(),track->GetTTheta(),track->GetTPhi(),pvect_temp);
     track->SetPvect(pvect_temp);
   }
-
+  fPruneSelect=-1.;
   if (fHodo==0 || (( fSelUsingScin == 0 ) && ( fSelUsingPrune == 0 )) ) {
     BestTrackSimple();
   } else if (fHodo!=0 && fSelUsingPrune !=0) {
@@ -774,7 +784,8 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
       testTracks[ptrack] = static_cast<THaTrack*>( fTracks->At(ptrack) );
       if (!testTracks[ptrack]) return -1;
     }
-
+    fPruneSelect = 0;
+    Double_t PruneSelect=0;
     // ! Prune on xptar
     nGood = 0;
     for (Int_t ptrack = 0; ptrack < fNtracks; ptrack++ ){
@@ -790,7 +801,8 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
 	}
       }
     }
-
+    PruneSelect++;
+    if (nGood==1 && fPruneSelect ==0 && fNtracks>1) fPruneSelect=PruneSelect;
     // ! Prune on yptar
     nGood = 0;
     for (Int_t ptrack = 0; ptrack < fNtracks; ptrack++ ){
@@ -807,6 +819,8 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
 	}
       }
     }
+    PruneSelect++;
+    if (nGood==1 && fPruneSelect ==0 && fNtracks>1) fPruneSelect=PruneSelect;
 
     // !     Prune on ytar
     nGood = 0;
@@ -823,6 +837,8 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
 	}
       }
     }
+    PruneSelect++;
+    if (nGood==1 && fPruneSelect ==0 && fNtracks>1) fPruneSelect=PruneSelect;
 
     // !     Prune on delta
     nGood = 0;
@@ -839,6 +855,8 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
 	}
       }
     }
+    PruneSelect++;
+    if (nGood==1 && fPruneSelect ==0 && fNtracks>1) fPruneSelect=PruneSelect;
 
     // !     Prune on beta
     nGood = 0;
@@ -859,6 +877,8 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
 	}
       }
     }
+    PruneSelect++;
+    if (nGood==1 && fPruneSelect ==0 && fNtracks>1) fPruneSelect=PruneSelect;
 
     // !     Prune on deg. freedom for track chisq
     nGood = 0;
@@ -876,6 +896,8 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
       }
     }
 
+    PruneSelect++;
+    if (nGood==1 && fPruneSelect ==0 && fNtracks>1) fPruneSelect=PruneSelect;
     //!     Prune on num pmt hits
     nGood = 0;
     for (Int_t ptrack = 0; ptrack < fNtracks; ptrack++ ){
@@ -891,6 +913,8 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
 	}
       }
     }
+    PruneSelect++;
+    if (nGood==1 && fPruneSelect ==0 && fNtracks>1) fPruneSelect=PruneSelect;
 
     // !     Prune on beta chisqr
     nGood = 0;
@@ -909,6 +933,8 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
 	}
       }
     }
+    PruneSelect++;
+    if (nGood==1 && fPruneSelect ==0 && fNtracks>1) fPruneSelect=PruneSelect;
 
     // !     Prune on fptime
     nGood = 0;
@@ -926,6 +952,8 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
 	}
       }
     }
+    PruneSelect++;
+    if (nGood==1 && fPruneSelect ==0 && fNtracks>1) fPruneSelect=PruneSelect;
 
     // !     Prune on Y2 being hit
     nGood = 0;
@@ -942,6 +970,8 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
 	}
       }
     }
+    PruneSelect++;
+    if (nGood==1 && fPruneSelect ==0 && fNtracks>1) fPruneSelect=PruneSelect;
 
     // !     Prune on X2 being hit
     nGood = 0;
@@ -958,6 +988,8 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
 	}
       }
     }
+    PruneSelect++;
+    if (nGood==1 && fPruneSelect ==0 && fNtracks>1) fPruneSelect=PruneSelect;
 
     // !     Pick track with best chisq if more than one track passed prune tests
     Double_t chi2PerDeg = 0.;
@@ -970,7 +1002,9 @@ Int_t THcHallCSpectrometer::BestTrackUsingPrune()
 	chi2Min = chi2PerDeg;
       }
     }
-    // Set index=0 for fGoodTrack 
+     PruneSelect++;
+    if (fPruneSelect ==0 && fNtracks>1) fPruneSelect=PruneSelect;
+   // Set index=0 for fGoodTrack 
     for (Int_t iitrack = 0; iitrack < fNtracks; iitrack++ ){
       THaTrack* aTrack = dynamic_cast<THaTrack*>( fTracks->At(iitrack) );
       aTrack->SetIndex(1);

--- a/src/THcHallCSpectrometer.h
+++ b/src/THcHallCSpectrometer.h
@@ -86,6 +86,7 @@ protected:
   Double_t     fPruneFpTime;
   Double_t     fPruneNPMT;
   Double_t     fSatCorr;
+  Double_t     fPruneSelect;
 
   Int_t        fGoodTrack;
   Int_t        fSelUsingScin;

--- a/src/THcHodoscope.h
+++ b/src/THcHodoscope.h
@@ -148,7 +148,9 @@ protected:
 
   TH1F *hTime;
   // Calibration
-
+  Double_t fRatio_xpfp_to_xfp;
+  Double_t trackeff_scint_ydiff_max ;
+  Double_t trackeff_scint_xdiff_max ;
   // Per-event data
   Bool_t fSHMS;
   Bool_t fGoodStartTime;

--- a/src/THcScintPlaneCluster.cxx
+++ b/src/THcScintPlaneCluster.cxx
@@ -1,0 +1,8 @@
+/** \class THcScintPlaneCluster
+    \ingroup DetSupport
+
+*/
+
+#include "THcScintPlaneCluster.h"
+
+ClassImp(THcScintPlaneCluster)

--- a/src/THcScintPlaneCluster.h
+++ b/src/THcScintPlaneCluster.h
@@ -1,0 +1,43 @@
+#ifndef ROOT_THcScintPlaneCluster
+#define ROOT_THcScintPlaneCluster
+
+/////////////////////////////////////////////////////////////////////////////
+//                                                                         //
+// THcScintPlaneCluster                                                             //
+//                                                                         //
+/////////////////////////////////////////////////////////////////////////////
+
+#include "TObject.h"
+#include <cstdio>
+
+class THcScintPlaneCluster : public TObject {
+
+ public:
+ THcScintPlaneCluster(Int_t cluster=0, Double_t pos=0.0) :
+  fClusterNumber(cluster), fClusterPosition(pos) {}
+  virtual ~THcScintPlaneCluster() {}
+
+  Int_t GetClusterNumber() {return fClusterNumber;}
+  Double_t GetClusterPosition() {return fClusterPosition;}
+  Double_t GetClusterSize() {return fClusterSize;}
+  Double_t GetClusterFlag() {return fClusterFlag;}
+  Double_t GetClusterUsedFlag() {return fClusterUsedFlag;}
+
+  virtual void Set(Int_t cluster, Double_t pos)
+  { fClusterNumber=cluster; fClusterPosition=pos; fClusterFlag=0.; fClusterUsedFlag=0.;}
+
+  void SetSize(Double_t size) {fClusterSize=size;}
+  void SetFlag(Double_t flag) {fClusterFlag=flag;}
+  void SetUsedFlag(Double_t flag) {fClusterUsedFlag=flag;}
+
+ private:
+  Int_t fClusterNumber;
+  Double_t fClusterPosition;
+  Double_t fClusterSize;
+  Double_t fClusterFlag;
+  Double_t fClusterUsedFlag;
+
+  ClassDef(THcScintPlaneCluster,0); // Single signal value and wire/counter number
+};
+/////////////////////////////////////////////////////////////////
+#endif

--- a/src/THcScintillatorPlane.h
+++ b/src/THcScintillatorPlane.h
@@ -14,6 +14,7 @@
 
 #include "THaSubDetector.h"
 #include "TClonesArray.h"
+#include "THcScintPlaneCluster.h"
 
 using namespace std;
 
@@ -57,21 +58,30 @@ class THcScintillatorPlane : public THaSubDetector {
   Double_t GetPosOffset() {return fPosOffset;};
   Double_t GetPosCenter(Int_t PaddleNo) {return fPosCenter[PaddleNo];}; // counting from zero!
   Double_t GetFpTime() {return fFptime;};
+  Double_t GetNumberClusters() {return fNumberClusters;}; // number of paddle clusters
 
   void SetFpTime(Double_t f) {fFptime=f;};
   void SetNGoodHits(Int_t ng) {fNGoodHits=ng;};
   void SetHitDistance(Double_t f) {fHitDistance=f;}; // Distance between track and hit paddle
   void SetTrackXPosition(Double_t f) {fTrackXPosition=f;}; // Distance track X position at plane
   void SetTrackYPosition(Double_t f) {fTrackYPosition=f;}; // Distance track Y position at plane
+  void SetNumberClusters(Int_t nclus) {fNumberClusters=nclus;}; // number of paddle 
+  void SetCluster(Int_t ic,Double_t pos) {((THcScintPlaneCluster*) fCluster->ConstructedAt(ic))->Set(ic,pos);}
+  void SetClusterSize(Int_t ic,Double_t size) {((THcScintPlaneCluster*) fCluster->ConstructedAt(ic))->SetSize(size);}
+  void SetClusterFlag(Int_t ic,Double_t flag) {((THcScintPlaneCluster*) fCluster->ConstructedAt(ic))->SetFlag(flag);}
+  void SetClusterUsedFlag(Int_t ic,Double_t flag) {((THcScintPlaneCluster*) fCluster->ConstructedAt(ic))->SetUsedFlag(flag);}
 
   TClonesArray* fParentHitList;
 
   TClonesArray* GetHits() { return fHodoHits;};
 
+  TClonesArray* fCluster;
+
  protected:
 
   TClonesArray* frPosAdcErrorFlag;
   TClonesArray* frNegAdcErrorFlag;
+
 
   TClonesArray* frPosTDCHits;
   TClonesArray* frNegTDCHits;
@@ -111,6 +121,7 @@ class THcScintillatorPlane : public THaSubDetector {
   Int_t fTotNumPosAdcHits;
   Int_t fTotNumNegAdcHits;
   Int_t fTotNumAdcHits;
+  Int_t fNumberClusters;
 
   Int_t fTotNumPosTdcHits;
   Int_t fTotNumNegTdcHits;


### PR DESCRIPTION
Commit 1) Update THcCoinTime to add new ways to calculate coincidence time (see commit)

Commit 2)Modify HallCSpectrometer to have a tree variable for monitor which cut is used in the BestTrackUsingPruning method

Commit 3) Modify THcDC

In THcDC.h change MAXTRACKS from 10 to 50. The maximum number of tracks is set by parameter ntracks_max_fp
Previously the LinkStubs method would not create any tracks if the total number of spacepoints in
the two chambers was larger than 10.
Now LinkStubs will create a vector of THcSpacePoints of up to 100 spacepoints with no more than
50 spacepoints from chamber 1 and use that to find possible tracks.
Commit 4) Add THcScintPlaneClust, Modify THcHodoscope and THcScintillatorPlane
1) THcScintPlaneCluster is a new class to hold information about scintillator plane clusters of paddle hits. The clusters of paddles for each plane are formed in THcHodoscope::TrackEffTest which is used in the tracking efficiency.
2) Modify THcScintillatorPlane so that the cluster information (number of clusters, size,pos, flag if cluster used) is in the tree.
3) Modify THcHodoscope::TrackEffTest so position difference are taken for all clusters in X1 (or Y1)
with all clusters in X2 (Y2).