### PR TITLE
Exit if an array in parameter file smaller than requested.

### DIFF
--- a/src/THcParmList.cxx
+++ b/src/THcParmList.cxx
@@ -657,7 +657,11 @@ Int_t THcParmList::ReadArray(const char* attrC, T* array, Int_t size)
   }
   Int_t sz = var->GetLen();
   const void *vp = var->GetValuePointer();
-  if(size != sz) {
+  if(size > sz) {
+    cout << "*** ERROR: requested " << size << " elements of " << attrC <<
+      " which has only " << sz << " elements" << endl;
+    exit(EXIT_FAILURE);
+  } else if(size < sz) {
     cout << "*** WARNING: requested " << size << " elements of " << attrC <<
       " which has length " << sz << endl;
   }


### PR DESCRIPTION
Currently, if you request an array with THcParmList::LoadParmValues and the array defined in the parameter files is smaller than the requested size, then a warning message is printed.  Since a smaller than requested array can leave some elements of the array undefined, it is preferable to simply crash the analyzer instead of printing a warning that will probably be ignored.

Currently the SHMS shower counter has the lines:

pcal_c_cor = 0 0
pcal_d_cor = 0 0

that should have been 

pcal_c_cor = 0, 0
pcal_d_cor = 0, 0

and there could other errors in the parameter files.  We will wait a bit to merge this pull request until users have a chance to fix their parameter files.
