### PR TITLE
Update to THcHallCSpectrometer and THcDriftChamber

### DIFF
--- a/src/THcDriftChamber.cxx
+++ b/src/THcDriftChamber.cxx
@@ -1194,7 +1194,7 @@ void THcDriftChamber::LeftRight()
 	  iswhit <<= 1;
 	}
       }
-      if (nplaneshit >= fNPlanes-1) {
+      if ( (nplaneshit >= fNPlanes-1) || (nplaneshit >= fNPlanes-2 && !fHMSStyleChambers)) {
 	Double_t chi2;
 	chi2 = FindStub(nhits, sp,plane_list, bitpat, plusminus, stub);
 	if (fdebugstubchisq) cout << " pmloop = " << pmloop << " chi2 = " << chi2 << endl;

--- a/src/THcHallCSpectrometer.cxx
+++ b/src/THcHallCSpectrometer.cxx
@@ -563,11 +563,15 @@ Int_t THcHallCSpectrometer::TrackCalc()
 {
   if( fNtracks > 0 ) {
     Int_t hit_gold_track=0; // find track with index =0 which is best track
+    Int_t hit_dc_track=1; // 
     for (Int_t itrack = 0; itrack < fNtracks; itrack++ ){
       THaTrack* aTrack = static_cast<THaTrack*>( fTracks->At(itrack) );
-      if (aTrack->GetIndex()==0) hit_gold_track=itrack;  
+      if (aTrack->GetIndex()==0) {
+	hit_gold_track=itrack;
+        hit_dc_track = aTrack->GetTrkNum();
+      }  
     }
-    fDC->SetFocalPlaneBestTrack(hit_gold_track);
+    fDC->SetFocalPlaneBestTrack(hit_dc_track-1);
     fGoldenTrack = static_cast<THaTrack*>( fTracks->At(hit_gold_track) );
     fTrkIfo      = *fGoldenTrack;
     fTrk         = fGoldenTrack;


### PR DESCRIPTION
1) Updated THcHallCSpectrometer.cxx

In method TrackCalc get the proper THcDCTrack array index
from the golden track by using method GetTrkNum
for use in the THcDC method
SetFocalPlaneBestTrack.

When creating the THaTrack array in THcDC::CoarseTrack
the array index between THaTrack and THcDCTrack arrays
 match. The THaTrack is also associated with the THcDCTrack
array index with the call SetTrkNum(index+1)

When selecting best track by lowest chi-squared the
THaTrack are sorted from lowest to highest chi-squared
The code made a mistake in the index used in
 SetFocalPlaneBestTrack. It used the array index of the
THaTrack which is now not in sync with the THcDCTrack.
Fixed problem by using the THaTrack method GetTrkNum
which gets the proper THcDCTrack array index.


This did NOT effect reconstructed target variables or
physics variables. It only effected the focal plane
varaiables that were selected as the "best" or "golden"
to be used for the tree for dc.x_fp , dc.xp_fp,
dc.y_fp , dc.yp_fp and for the residuals.

2)   Update ThcDriftChamber::LeftRight

The LeftRight method determines the sign of the wire
distance for each hit in the spacepoint by looping
through all combinations of wire signs and fitting each
combination with a line  and selecting
the combination with the lowest chi-squared.
The fit to the line is known as the "stub" which
is an array of the x,dx/dz, y and dy/dz of the fit
and is associated each spacepoint. The stubs are
used later in LinkStubs method
to match spacepoints between two chambers to give a
possible tracks.

Previously the LeftRight method would only fit a
stub for a spacepoint with 4 hits in the chamber if the
parameter flag  HMSStyleChamber was true.
HMSStyleChamber refers to the 6 GeV HMS chambers
and we do not have them anymore.
But not fitting the spacepoint, the stub
was filled with zeros for x,dx/dz,y and dy/dz
and these spacepoints would never be matched with
other spacepoints to form a possible track.