### PR TITLE
Modify THcHallCSpectrometer and THcDC

### DIFF
--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -27,6 +27,7 @@ the number of parameters per plane.
 #include "TMath.h"
 #include "TVectorD.h"
 #include "THaApparatus.h"
+#include "THcHallCSpectrometer.h"
 
 #include <cstring>
 #include <cstdio>
@@ -413,6 +414,7 @@ Int_t THcDC::DefineVariables( EMode mode )
     { "chisq", "chisq/dof (golden track) ", "fChisq_best"},
     { "sp1_id", " (golden track) ", "fSp1_ID_best"},
     { "sp2_id", " (golden track) ", "fSp2_ID_best"},
+    { "InsideDipoleExit", " ","fInSideDipoleExit_best"},
     { "gtrack_nsp", " Number of space points in golden track ", "fNsp_best"},
     { "residual", "Residuals", "fResiduals"},
     { "residualExclPlane", "Residuals", "fResidualsExclPlane"},
@@ -507,6 +509,7 @@ void THcDC::ClearEvent()
   fYp_fp_best=-10000.;
   fChisq_best=kBig;
   fNsp_best=0;
+  fInSideDipoleExit_best = kTRUE;
   for(UInt_t i=0;i<fNChambers;i++) {
     fChambers[i]->Clear();
   }
@@ -648,6 +651,8 @@ void THcDC::SetFocalPlaneBestTrack(Int_t golden_track_index)
       fY_fp_best=tr1->GetY();
       fXp_fp_best=tr1->GetXP();
       fYp_fp_best=tr1->GetYP();
+      THcHallCSpectrometer *app = dynamic_cast<THcHallCSpectrometer*>(GetApparatus());
+      fInSideDipoleExit_best = app->InsideDipoleExitWindow(fX_fp_best, fXp_fp_best ,fY_fp_best,fYp_fp_best);
       fSp1_ID_best=tr1->GetSp1_ID();
       fSp2_ID_best=tr1->GetSp2_ID();
       fChisq_best=tr1->GetChisq();

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -176,6 +176,7 @@ protected:
   Double_t fChisq_best;
   Int_t fSp1_ID_best;
   Int_t fSp2_ID_best;
+  Bool_t fInSideDipoleExit_best;
  // For accumulating statitics for efficiencies
   Int_t fTotEvents;
   Int_t* fNChamHits;

--- a/src/THcHallCSpectrometer.h
+++ b/src/THcHallCSpectrometer.h
@@ -24,6 +24,7 @@
 #include "THcDriftChamberPlane.h"
 #include "THcDriftChamber.h"
 #include "TMath.h"
+#include "TCutG.h"
 
 #include "THaSubDetector.h"
 #include "TClonesArray.h"
@@ -68,13 +69,19 @@ public:
   virtual Int_t GetNumTypes() { return eventtypes.size(); };
   virtual Bool_t IsPresent() {return fPresent;};
 
+  Bool_t InsideDipoleExitWindow(Double_t x_fp, Double_t xp_fp, Double_t y_fp, Double_t yp_fp);
 
 protected:
   void InitializeReconstruction();
 
-  //  Bool_t*      fKeep;
+  void SetSHMSDipoleExitWindow();
+  void SetHMSDipoleExitWindow();
+  TCutG *fDipoleExitWindowCutG;
+  Double_t fDipoleExitWindowZpos;
+ //  Bool_t*      fKeep;
   //  Int_t*       fReject;
 
+  Double_t     fPruneDipoleExit;
   Double_t     fPartMass;
   Double_t     fPruneXp;
   Double_t     fPruneYp;


### PR DESCRIPTION
1) THcHallCspectrometer
a) add SetSHMSDipoleExitWindow which creates the TCutG
fDipoleExitWindowCutG based on SHMS exit window size
and sets fDipoleExitWindowZpos which is distance from
focal plane to SHMS exit window. Called in ReadDatabase.
b) add SetHMSDipoleExitWindow which creates the TCutG
fDipoleExitWindowCutG based on HMS exit window size
and sets fDipoleExitWindowZpos which is distance from
focal plane to HMS exit window. Called in ReadDatabase.
c) add Bool_t InsideDipoleExitWindow method which calculates the x and y
position at the exit window and checks if it is inside
the fDipoleExitWindowCutG
d) Add another check to the BestTrackUsingPrune method
to flag the tracks are inside the exit. Parameter
prune_DipoleExit needs to be set to 1 to use this check.
By default prune_DipoleExit is set to 0.

Modify THcDC.cxx
1) Added Bool_t tree variable dc.InSideDipoleExit
=  fInSideDipoleExit_best which is
set in method SetFocalPlaneBestTrack. This method calls
THcHallCSpectrometer::InsideDipoleExitWindow to check
whether the best track was inside the dipole
exit window and sets fInSideDipoleExit_best.