### PR TITLE
Modify THcDC and THcHallCSpectrometer

### DIFF
--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -27,6 +27,7 @@ the number of parameters per plane.
 #include "TMath.h"
 #include "TVectorD.h"
 #include "THaApparatus.h"
+#include "THcHallCSpectrometer.h"
 
 #include <cstring>
 #include <cstdio>
@@ -413,6 +414,7 @@ Int_t THcDC::DefineVariables( EMode mode )
     { "chisq", "chisq/dof (golden track) ", "fChisq_best"},
     { "sp1_id", " (golden track) ", "fSp1_ID_best"},
     { "sp2_id", " (golden track) ", "fSp2_ID_best"},
+    { "InsideDipoleExit", " ","fInSideDipoleExit_best"},
     { "gtrack_nsp", " Number of space points in golden track ", "fNsp_best"},
     { "residual", "Residuals", "fResiduals"},
     { "residualExclPlane", "Residuals", "fResidualsExclPlane"},
@@ -507,6 +509,7 @@ void THcDC::ClearEvent()
   fYp_fp_best=-10000.;
   fChisq_best=kBig;
   fNsp_best=0;
+  fInSideDipoleExit_best = kTRUE;
   for(UInt_t i=0;i<fNChambers;i++) {
     fChambers[i]->Clear();
   }
@@ -648,6 +651,8 @@ void THcDC::SetFocalPlaneBestTrack(Int_t golden_track_index)
       fY_fp_best=tr1->GetY();
       fXp_fp_best=tr1->GetXP();
       fYp_fp_best=tr1->GetYP();
+      THcHallCSpectrometer *app = dynamic_cast<THcHallCSpectrometer*>(GetApparatus());
+      fInSideDipoleExit_best = app->InsideDipoleExitWindow(fX_fp_best, fXp_fp_best ,fY_fp_best,fYp_fp_best);
       fSp1_ID_best=tr1->GetSp1_ID();
       fSp2_ID_best=tr1->GetSp2_ID();
       fChisq_best=tr1->GetChisq();

--- a/src/THcDC.h
+++ b/src/THcDC.h
@@ -176,6 +176,7 @@ protected:
   Double_t fChisq_best;
   Int_t fSp1_ID_best;
   Int_t fSp2_ID_best;
+  Bool_t fInSideDipoleExit_best;
  // For accumulating statitics for efficiencies
   Int_t fTotEvents;
   Int_t* fNChamHits;

--- a/src/THcHallCSpectrometer.h
+++ b/src/THcHallCSpectrometer.h
@@ -68,13 +68,19 @@ public:
   virtual Int_t GetNumTypes() { return eventtypes.size(); };
   virtual Bool_t IsPresent() {return fPresent;};
 
+  Bool_t InsideDipoleExitWindow(Double_t x_fp, Double_t xp_fp, Double_t y_fp, Double_t yp_fp);
 
 protected:
   void InitializeReconstruction();
 
-  //  Bool_t*      fKeep;
+  Bool_t SHMSDipoleExitWindow(Double_t x_dip, Double_t y_dip);
+  Bool_t HMSDipoleExitWindow(Double_t x_dip, Double_t y_dip);
+  Bool_t fUseSHMSDipoleExitWindow;
+  Bool_t fUseHMSDipoleExitWindow;
+ //  Bool_t*      fKeep;
   //  Int_t*       fReject;
 
+  Double_t     fPruneDipoleExit;
   Double_t     fPartMass;
   Double_t     fPruneXp;
   Double_t     fPruneYp;


### PR DESCRIPTION
1) THcDC
a) Add variable to tree called dc.InsideDipoleExit
which is a Bool_t flag that is kTRUE if golden track is inside the
dipole exit. Uses THcHallCSpectrometer::InsideDipoleExitWindow
in THcDC::SetFocalPlaneBestTrack to set variable.

2) THcHallCSpectrometer
a) Add method Bool_t InsideDipoleExitWindow which checks whether
the track is within the dipole exit window. Checks
prefix used for database to set flag
fUseSHMSDipoleExitWindow or fUseHMSDipoleExitWindow
to be true which is used in InsideDipoleExitWindow
to select either SHMSDipoleExitWindow or
HMSDipoleExitWindow method to be used as the test.
b) Hardcoded z distance from spectrometer focal plane to
dipole exit window.
c) Methods Bool_t SHMSDipoleExitWindow and
Bool_t HMSDipoleExitWindow return true/false if
the track was inside/outside the dipole exit window.
d) Added dipole exit window test to the BestTrackUsingPrune
method. Need to set parameter hprune_DipoleExit=1 or
pprune_DipoleExit=1 to use the test in the method.
By default it is turned off.