### PR TITLE
change to prevent the first good pulse from being overwritten

### DIFF
--- a/src/THcShowerArray.cxx
+++ b/src/THcShowerArray.cxx
@@ -894,7 +894,7 @@ void THcShowerArray::FillADC_DynamicPedestal()
       fTotNumAdcHits++;
       fGoodAdcPulseIntRaw.at(npad) = pulseIntRaw;
 
-      if(fGoodAdcPulseIntRaw.at(npad) >  fThresh[npad]) {
+      if(fGoodAdcPulseIntRaw.at(npad) >  fThresh[npad] && fGoodAdcPulseInt.at(npad)==0) {
        fTotNumGoodAdcHits++;
        fGoodAdcPulseInt.at(npad) = pulseInt;
        fE.at(npad) = fGoodAdcPulseInt.at(npad)*fGain[npad];


### PR DESCRIPTION
I changed how the good pulse information is saved to match what is down for the HMS and Preshower (THcShowerPlane.cxx).  Before the first good pulse was being overwritten when there was multiple hits (with good timing) in one block.  This was noticed as a low energy peak in etracknorm after applying good electron cuts.
 