### PR TITLE
THcHelicityReader: More robust failover to HMS for helicty info

### DIFF
--- a/src/THcHelicityReader.cxx
+++ b/src/THcHelicityReader.cxx
@@ -120,6 +120,7 @@ Int_t THcHelicityReader::ReadData( const THaEvData& evdata )
   }
 
   // Check if ROC info is correct
+
   if(!evdata.GetModule(fROCinfo[kTime].roc, fROCinfo[kTime].slot)) {
     cout << "THcHelicityReader: ROC 2 not found" << endl;
     cout << "Changing to ROC 1 (HMS)" << endl;
@@ -136,6 +137,19 @@ Int_t THcHelicityReader::ReadData( const THaEvData& evdata )
   UInt_t titime = (UInt_t) evdata.GetData(fROCinfo[kTime].roc,
 					  fROCinfo[kTime].slot,
 					  fROCinfo[kTime].index, 0);
+  // Check again if ROC info is correct
+  if(titime == 0 && fTITime_last==0) {
+    cout << "THcHelicityReader: ROC 2 not found" << endl;
+    cout << "Changing to ROC 1 (HMS)" << endl;
+    SetROCinfo(kHel,1,18,9);
+    SetROCinfo(kHelm,1,18,8);
+    SetROCinfo(kMPS,1,18,10);
+    SetROCinfo(kQrt,1,18,7);
+    SetROCinfo(kTime,1,21,2);
+    titime = (UInt_t) evdata.GetData(fROCinfo[kTime].roc,
+					  fROCinfo[kTime].slot,
+					  fROCinfo[kTime].index, 0);
+  }     
   //cout << fTITime_last << " " << titime << endl;
   if(titime < fTITime_last) {
     fTITime_rollovers++;


### PR DESCRIPTION
If SHMS crate 2 does not exists, get helicity info from crate 1.  Previously, the absence of crate 2 was determined by its absence in db_cratemap.dat.  But if crate 2 is in the crate map, the crate will  appear to be there return zeros for data.  This changes looks for a TI time of zero and switches to crate one to get the helcity info.