### PR TITLE
Helicity decoding improvements:

### DIFF
--- a/src/THcHelicity.h
+++ b/src/THcHelicity.h
@@ -50,10 +50,12 @@ protected:
   Int_t fFirstCycle;
   Bool_t fFixFirstCycle;
   Double_t fFreq;
+  Double_t fRecommendedFreq;
 
   Double_t fTIPeriod;		// Reversal period in TI time units
 
   Double_t fPeriodCheck;
+  Double_t fPeriodCheckOffset;
   Double_t fCycle;
 
   Bool_t fFirstEvProcessed;


### PR DESCRIPTION
1.  If THcHelicity is told about the THcHelicityScaler object with
    the SetHelicityScaler method, it will use helicity scaler events
    to jump start generating the seed
2.  When beam off, helicity decoding can get lost if the helicity_freq
    parameter is not very close to the actual helicity reversal frequency
    (which seems to drift).  THcHelicity now calculates a recommended value
    of helicity_freq.