### PR TITLE
Updated THcScalerEvtHandler

### DIFF
--- a/src/THcScalerEvtHandler.h
+++ b/src/THcScalerEvtHandler.h
@@ -59,6 +59,8 @@ private:
    Int_t fNumBCMs;
    Double_t *fBCM_Gain;
    Double_t *fBCM_Offset;
+   Double_t *fBCM_SatOffset;
+   Double_t *fBCM_SatQuadratic;
    Double_t *fBCM_delta_charge;
    Double_t fTotalTime;
    Double_t fDeltaTime;


### PR DESCRIPTION
Dave Mack introduced two new variables to the
calculation of beam current to described correction for
the nonlinearity above 60uA in BCM1 and BCM2
seen in the Fall 18, Spring 19 and Summer 19running.
See for example summer 2019
hallcweb.jlab.org/doc-private/ShowDocument?docid=1037
Fall 18/Spring 19
hallcweb.jlab.org/doc-private/ShowDocument?docid=1042

For a BCM scaler read the difference, Dcounts, from the
previous scaler and get the time difference, Dtime.
Original calculation is:
I = (Dcounts/Dtime-fBCMOffset)/BCM_Gain
Now add an non-linearity correction
I = I + fBCM_SatQuadratic*Max(I-fBCM_SatOffset,0.0)^2

Add parameters fBCM_SatOffset and fBCM_SatQuadratic
that can be optional read-in. If parameters are
not read-in the parameters are set to zero, so
there is no correction.

Add the non-linearity correction to all BCM current
calculations.