### PR TITLE
Modify THcExtTar.cxx

### DIFF
--- a/src/THcExtTarCor.cxx
+++ b/src/THcExtTarCor.cxx
@@ -103,7 +103,12 @@ Int_t THcExtTarCor::Process( const THaEvData& )
   Double_t yptar;
   Double_t delta;
   Double_t p=0;
+  Double_t p_before_xtar_corr;
+  Double_t delta_before_xtar_corr;
+  Double_t xptar_before_xtar_corr;
+  Double_t p_after_xtar_corr=0;
   TVector3 pvect;
+  TVector3 pvect_final;
   TVector3 pointing_off=spectro->GetPointingOffset();
   Double_t xtar_new=-vertex[1];
   TClonesArray* tracks = spectro->GetTracks();
@@ -113,25 +118,31 @@ Int_t THcExtTarCor::Process( const THaEvData& )
   for( Int_t i = 0; i<ntracks; i++ ) {
     THaTrack* theTrack = static_cast<THaTrack*>( tracks->At(i) );
     if( theTrack == spectro->GetGoldenTrack() ) {
+      delta_before_xtar_corr=theTrack->GetDp();
+      p_before_xtar_corr=theTrack->GetP();
+      xptar_before_xtar_corr=theTrack->GetTTheta();
       // Calculate corrections & recalculate ,,,track parameters
+      Double_t xptar_save=0.,xptar_diff=10000.;
       Double_t x_tg = -vertex[1]-pointing_off[0]; // units of cm, beam position in spectrometer coordinate system
       spectro->CalculateTargetQuantities(theTrack,x_tg,xptar,ytar,yptar,delta);
+      xptar_save = xptar;
+      Int_t niter=0;
+      while ( xptar_diff > 2 && niter < 5) {
       p  = spectro->GetPcentral() * ( 1.0+delta );
       spectro->TransportToLab( p, xptar, yptar, pvect );
       Double_t theta=spectro->GetThetaSph();
       xtar_new = x_tg - xptar*ztarg*cos(theta); //units of cm
-      // Get a second-iteration value for x_tg based on the 
       spectro->CalculateTargetQuantities(theTrack,xtar_new,xptar,ytar,yptar,delta);
-      fDeltaDp = delta*100 -theTrack->GetDp();
-      fDeltaP = p - theTrack->GetP();
-      fDeltaTh = xptar -  theTrack->GetTTheta();
+      xptar_diff = abs(xptar-xptar_save)*1000;
+      xptar_save = xptar;
+      niter++;
+      }
      theTrack->SetTarget(xtar_new, ytar*100.0, xptar, yptar);
     theTrack->SetDp(delta*100.0);	// Percent.  
-    Double_t ptemp =spectro->GetPcentral()*(1+theTrack->GetDp()/100.0);
-      theTrack->SetMomentum(ptemp);
-    TVector3 pvect_temp;
-    spectro->TransportToLab(theTrack->GetP(),theTrack->GetTTheta(),theTrack->GetTPhi(),pvect_temp);
-    theTrack->SetPvect(pvect_temp);
+    p_after_xtar_corr =spectro->GetPcentral()*(1+theTrack->GetDp()/100.0);
+      theTrack->SetMomentum(p_after_xtar_corr);
+    spectro->TransportToLab(theTrack->GetP(),theTrack->GetTTheta(),theTrack->GetTPhi(),pvect_final);
+    theTrack->SetPvect(pvect_final);
       if (strcmp(spectro->GetName(),"H")==0) {
      fxsieve=xtar_new+xptar*168.;
      fysieve=ytar*100.+yptar*168.;
@@ -141,13 +152,16 @@ Int_t THcExtTarCor::Process( const THaEvData& )
       Double_t delta_per=delta*100;
       fysieve=ytar*100+yptar*253.-(0.019+40.*.01*0.052)*delta_per+(0.00019+40*.01*.00052)*delta_per*delta_per;
     }
-        
+      fDeltaDp = delta_before_xtar_corr -theTrack->GetDp();
+      fDeltaP = p_before_xtar_corr - theTrack->GetP();
+      fDeltaTh = xptar_before_xtar_corr -  theTrack->GetTTheta();
+      //      cout << xtar_new << " " << fDeltaDp << " " << fDeltaP << " " << fDeltaTh << endl;
     }
   }
  // Save results in our TrackInfo
- // cout << spectro->GetName() << " exttarcor = " << xptar << " " << delta*100 << endl;
-  trkifo->Set( p, delta*100, xtar_new,100*ytar, xptar, yptar, pvect );
-  fTrkIfo.Set( p, delta*100, xtar_new,100*ytar, xptar, yptar, pvect );
+  //cout << spectro->GetName() << " exttarcor = " << xptar << " " << delta*100 << " " << p_after_xtar_corr << endl;
+  trkifo->Set( p_after_xtar_corr, delta*100, xtar_new,100*ytar, xptar, yptar, pvect_final );
+  fTrkIfo.Set( p_after_xtar_corr, delta*100, xtar_new,100*ytar, xptar, yptar, pvect_final );
   fDataValid = true;
   return 0;
 }


### PR DESCRIPTION
Update so that the vertical target position (xtar)
correction is iteratived up to 5 times or until the
xptar changes by less than 2mr.
Need for the long extended target and large 5mm raster
were xtar can become up to 2cm.

Previously the xtar correction was only iterated once.