### PR TITLE
RFTime Class

### DIFF
--- a/src/THcCoinTime.cxx
+++ b/src/THcCoinTime.cxx
@@ -246,8 +246,7 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
 
   //Check if Database is reading the correct elec-arm particle mass
   if (felecSpectro->GetParticleMass() > 0.00052) return 1;
-   
-     
+        
       //SHMS arm
       Double_t shms_xptar = theSHMSTrack->GetTTheta();     
       Double_t shms_dP = theSHMSTrack->GetDp();            
@@ -307,8 +306,7 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
 	  fROC2_RAW_CoinTime =  (pTRIG1_TdcTime_ROC2 + SHMS_FPtime) - (pTRIG4_TdcTime_ROC2 + HMS_FPtime);
 	  fTRIG1_RAW_CoinTime =  (pTRIG1_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG1_TdcTime_ROC2 + HMS_FPtime);
 	  fTRIG4_RAW_CoinTime =  (pTRIG4_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG4_TdcTime_ROC2 + HMS_FPtime);
-	  
-	  
+	   
 	  //Corrected Coincidence Time for ROC1/ROC2 (ROC1 Should be identical to ROC2)
           // 
 	  //PROTON
@@ -335,9 +333,6 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
 	  fTRIG1_ePosCoinTime = fTRIG1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset ;	  
 	  fTRIG4_ePosCoinTime = fTRIG4_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
          
-   
-  
-  
   return 0;
 }
 

--- a/src/THcRFTime.cxx
+++ b/src/THcRFTime.cxx
@@ -1,0 +1,231 @@
+/** \class THcRFTime
+    \ingroup PhysMods
+
+// Brief Class for calculating and adding the RF Time in the Tree.
+
+// Author: Stephen JD Kay
+// University of Regina
+// Date: 12/04/21 (12th April 2021)
+// Based on THcCoinTime class from C Yero
+*/
+
+#include "THaEvData.h"
+#include "THaCutList.h"
+#include "VarDef.h"
+#include "VarType.h"
+#include "TClonesArray.h"
+
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+
+#include "THcRFTime.h"
+#include "THcTrigDet.h"
+#include "THaApparatus.h"
+#include "THcHodoHit.h"
+#include "THcGlobals.h"
+#include "THcParmList.h"
+#include "THcAnalyzer.h"
+
+using namespace std;
+
+//_____________________________________________________________________________
+THcRFTime::THcRFTime (const char *name, const char* description, const char* hadArmName, 
+		      const char* elecArmName, const char* coinname) :
+  
+  THaPhysicsModule(name, description), 
+  fCoinDetName(coinname), 
+  fhadArmName(hadArmName),                 //initialize spectro names
+  felecArmName(elecArmName),
+  fhadSpectro(NULL),                      //initialize spectro objects
+  felecSpectro(NULL),
+  fCoinDet(NULL)
+{
+
+}
+
+//_____________________________________________________________________________
+THcRFTime::~THcRFTime()
+{
+  //Destructor
+
+  RemoveVariables();
+
+}
+//_____________________________________________________________________________
+void THcRFTime::Clear( Option_t* opt )
+{
+  // Clear all event-by-event variables.
+  // Only need to clear variables that are actually used, will need to re-tweak this when the rest is set up
+  //  THaPhysicsModule::Clear(opt);
+  fHMS_RFtimeDist=kBig;
+  fSHMS_RFtimeDist=kBig;
+}
+
+//_____________________________________________________________________________
+void THcRFTime::Reset( Option_t* opt)
+// Clear event-by-event data
+{
+  Clear(opt);
+}
+
+
+//_____________________________________________________________________________
+THaAnalysisObject::EStatus THcRFTime::Init( const TDatime& run_time )
+{
+  // Initialize THcRFTime physics module
+  
+  cout << "*************************************************" << endl;
+  cout << "Initializing THcRFTime Physics Modue" << endl;
+  cout << "Hadron Arm   -------> " << fhadArmName << endl;
+  cout << "Electron Arm -------> " << felecArmName << endl;
+  cout << "TrigDet  -------> " << fCoinDetName << endl;
+  cout << "**************************************************" << endl;
+
+  fStatus = kOK;
+  // For now, read in both spectrometers by default
+  // In future, should be modified to read in one or the other (or both)
+  fhadSpectro = dynamic_cast<THcHallCSpectrometer*>
+    ( FindModule( fhadArmName.Data(), "THcHallCSpectrometer"));
+  if( !fhadSpectro ) {
+    cout << "THcRFTime module - Cannnot find Hadron Arm = " <<  fhadArmName.Data() << endl;
+    fStatus = kInitError;
+    return fStatus;
+  }
+  
+  felecSpectro = dynamic_cast<THcHallCSpectrometer*>
+    ( FindModule( felecArmName.Data(), "THcHallCSpectrometer"));
+  if( !felecSpectro ) {
+    cout << "THcRFTime module -  Cannnot find Electron Arm = " << felecArmName.Data() << endl;
+    fStatus = kInitError;
+    return fStatus;
+  }
+  // Switch to Trig Det
+  fCoinDet = dynamic_cast<THcTrigDet*>
+    ( FindModule( fCoinDetName.Data(), "THcTrigDet"));
+  if( !fCoinDet ) {
+    cout << "THcRFTime module -  Cannnot find TrigDet = " << fCoinDetName.Data() << endl;
+    fStatus = kInitError;
+    return fStatus;
+  }
+    
+  if( (fStatus=THaPhysicsModule::Init( run_time )) != kOK ) {
+    return fStatus;
+  }
+
+  return fStatus;
+}
+
+//_____________________________________________________________________________
+Int_t THcRFTime::ReadDatabase( const TDatime& date )
+{
+  // Read database. Gets variable needed for RFTime calculation
+
+  DBRequest list[]={
+    {"HMS_RF_Offset",  &HMS_RF_Offset, kDouble, 0, 1},   // RF offset for HMS
+    {"SHMS_RF_Offset",  &SHMS_RF_Offset, kDouble, 0, 1}, // RF offset for SHMS
+    {"Bunch_Spacing_Override",  &Bunch_Spacing_Override, kDouble, 0, 1}, // RF offset for SHMS
+    {0}
+  };
+  
+  //Default values if not read from param file
+  Bunch_Spacing_Override = 4.008;
+  HMS_RF_Offset = 0.0;
+  SHMS_RF_Offset = 0.0;
+  
+  gHcParms->LoadParmValues((DBRequest*)&list, "");
+
+  THcAnalyzer *analyzer = dynamic_cast<THcAnalyzer*>(THcAnalyzer::GetInstance());
+  fEpicsHandler = analyzer->GetEpicsEvtHandler(); 
+
+  return kOK;
+}
+
+//_____________________________________________________________________________
+Int_t THcRFTime::DefineVariables( EMode mode )
+{
+  // Define variables that this script will actually calculate
+  if( mode == kDefine && fIsSetup ) return kOK;
+  fIsSetup = ( mode == kDefine );
+  const RVarDef vars[] = {
+    {"HMS_RFtimeDist",    "HMS RF Time Disttribution for PID",  "fHMS_RFtimeDist"},
+    {"SHMS_RFtimeDist",    "SHMS RF Time Disttribution for PID",  "fSHMS_RFtimeDist"},
+    { 0 }
+  };
+
+  return DefineVarsFromList( vars, mode );
+
+}
+
+//_____________________________________________________________________________
+Int_t THcRFTime::Decode( const THaEvData& evdata )   
+{
+  if (fEpicsHandler) {
+    if (fEpicsHandler->IsLoaded("MOFC1DELTA")){                                                
+      Bunch_Spacing = atof(fEpicsHandler->GetString("MOFC1DELTA"));                                     
+    }   
+  }
+  else{
+    Bunch_Spacing = Bunch_Spacing_Override;
+  }
+  return 0;
+}
+
+//_____________________________________________________________________________
+Int_t THcRFTime::Process( const THaEvData& evdata )
+{
+  
+  if( !IsOK() || !gHaRun ) return -1;
+
+  //Declare track information objects for hadron/electron arm
+  THaTrackInfo* had_trkifo = fhadSpectro->GetTrackInfo();
+  THaTrackInfo* elec_trkifo = felecSpectro->GetTrackInfo();
+
+  if( !had_trkifo) cout << " no hadron track " << endl;
+  if( !elec_trkifo) cout << " no electron track " << endl;
+  //Check if the hadron/electron arm had a track
+  if( !had_trkifo || !had_trkifo->IsOK() ) return 1;
+  if( !elec_trkifo || !elec_trkifo->IsOK() ) return 1;
+
+  //Create THaTrack object for hadron/elec arms to get relevant golden track quantities
+  if (felecArmName=="H") {
+    theSHMSTrack =(fhadSpectro->GetGoldenTrack()); 
+    theHMSTrack = (felecSpectro->GetGoldenTrack());
+  } else{
+    theSHMSTrack =(felecSpectro->GetGoldenTrack()); 
+    theHMSTrack = (fhadSpectro->GetGoldenTrack());
+  }
+  
+  //Check if there was a golden track in both arms
+  if (!theSHMSTrack || !theHMSTrack)
+    {
+      return 1;
+    }
+
+  //Check if Database is reading the correct elec-arm particle mass
+  if (felecSpectro->GetParticleMass() > 0.00052) return 1;
+        
+  //SHMS arm
+  Double_t SHMS_FPtime = theSHMSTrack->GetFPTime();
+
+  //HMS arm
+  Double_t HMS_FPtime = theHMSTrack->GetFPTime();
+      
+  if (SHMS_FPtime==-2000 || HMS_FPtime==-2000)  return 1;
+  if (SHMS_FPtime==-1000 || HMS_FPtime==-1000)  return 1;
+      
+  //Get raw TDC Times for HMS/SHMS (3/4 trigger)
+  SHMS_RFtime = fCoinDet->Get_RF_TrigTime(0); // SHMS
+  HMS_RFtime = fCoinDet->Get_RF_TrigTime(1); // HMS
+
+  fHMS_RFtimeDist = (HMS_RFtime - HMS_FPtime + HMS_RF_Offset);
+  fSHMS_RFtimeDist = (SHMS_RFtime - SHMS_FPtime + SHMS_RF_Offset);
+  
+  return 0;
+}
+
+//_____________________________________________________________________________
+
+ClassImp(THcRFTime)
+////////////////////////////////////////////////////////////////////////////////

--- a/src/THcRFTime.cxx
+++ b/src/THcRFTime.cxx
@@ -7,10 +7,15 @@
 // University of Regina
 // Date: 12/04/21 (12th April 2021)
 // Based on THcCoinTime class from C Yero
+
+// 14/04/21 - Now works and reads in epics value for the accelerator frequency. This is used to determine the bunch spacing
+// In future, want to determine the RF time with some corrections for each particle type (as is done in THcCoinTime)
 */
 
 #include "THaEvData.h"
 #include "THaCutList.h"
+#include "THaDetMap.h"
+#include "THaApparatus.h"
 #include "VarDef.h"
 #include "VarType.h"
 #include "TClonesArray.h"
@@ -22,7 +27,6 @@
 
 #include "THcRFTime.h"
 #include "THcTrigDet.h"
-#include "THaApparatus.h"
 #include "THcHodoHit.h"
 #include "THcGlobals.h"
 #include "THcParmList.h"
@@ -32,17 +36,17 @@ using namespace std;
 
 //_____________________________________________________________________________
 THcRFTime::THcRFTime (const char *name, const char* description, const char* hadArmName, 
-		      const char* elecArmName, const char* coinname) :
+		      const char* elecArmName, const char* RFname) :
   
   THaPhysicsModule(name, description), 
-  fCoinDetName(coinname), 
+  fCoinDetName(RFname), 
   fhadArmName(hadArmName),                 //initialize spectro names
   felecArmName(elecArmName),
   fhadSpectro(NULL),                      //initialize spectro objects
   felecSpectro(NULL),
   fCoinDet(NULL)
 {
-
+  Bunch_Spacing_Epics = 0.0001;
 }
 
 //_____________________________________________________________________________
@@ -81,8 +85,6 @@ THaAnalysisObject::EStatus THcRFTime::Init( const TDatime& run_time )
   cout << "Hadron Arm   -------> " << fhadArmName << endl;
   cout << "Electron Arm -------> " << felecArmName << endl;
   cout << "TrigDet  -------> " << fCoinDetName << endl;
-  cout << "**************************************************" << endl;
-
   fStatus = kOK;
   // For now, read in both spectrometers by default
   // In future, should be modified to read in one or the other (or both)
@@ -125,17 +127,24 @@ Int_t THcRFTime::ReadDatabase( const TDatime& date )
   DBRequest list[]={
     {"HMS_RF_Offset",  &HMS_RF_Offset, kDouble, 0, 1},   // RF offset for HMS
     {"SHMS_RF_Offset",  &SHMS_RF_Offset, kDouble, 0, 1}, // RF offset for SHMS
-    {"Bunch_Spacing_Override",  &Bunch_Spacing_Override, kDouble, 0, 1}, // RF offset for SHMS
+    {"Bunch_Spacing_Override",  &Bunch_Spacing_Override, kDouble, 0, 1}, // Bunch spacing value, can be manually set to override the Epics read in
     {0}
   };
   
-  //Default values if not read from param file
-  Bunch_Spacing_Override = 4.008;
+  // Default values if not read from param file
+  Bunch_Spacing_Override = 1.5556; // Strangely specific value so we can check if it's set or not 
   HMS_RF_Offset = 0.0;
   SHMS_RF_Offset = 0.0;
-  
   gHcParms->LoadParmValues((DBRequest*)&list, "");
-
+  // If the override value has been set (i.e. it is NOT the default value), set it to whatever the read in is
+  if ( Bunch_Spacing_Override != 1.5556){
+    Bunch_Spacing = Bunch_Spacing_Override;
+  }
+  // If override wasn't set, assume the bunch spacing has some default value (will be overriden by Epics if it looks OK)
+  else if (Bunch_Spacing_Override == 1.5556){
+    Bunch_Spacing = 4.008;
+  }
+  
   THcAnalyzer *analyzer = dynamic_cast<THcAnalyzer*>(THcAnalyzer::GetInstance());
   fEpicsHandler = analyzer->GetEpicsEvtHandler(); 
 
@@ -159,24 +168,18 @@ Int_t THcRFTime::DefineVariables( EMode mode )
 }
 
 //_____________________________________________________________________________
-Int_t THcRFTime::Decode( const THaEvData& evdata )   
-{
-  if (fEpicsHandler) {
-    if (fEpicsHandler->IsLoaded("MOFC1DELTA")){                                                
-      Bunch_Spacing = atof(fEpicsHandler->GetString("MOFC1DELTA"));                                     
-    }   
-  }
-  else{
-    Bunch_Spacing = Bunch_Spacing_Override;
-  }
-  return 0;
-}
-
-//_____________________________________________________________________________
 Int_t THcRFTime::Process( const THaEvData& evdata )
 {
-  
   if( !IsOK() || !gHaRun ) return -1;
+  
+  if (Bunch_Spacing_Epics == 0.0001){ // If Bunch_Spacing_Epics is still the default value (0.0001), set it to the Epics read in, this is to ensure it is only set ONCE
+    Bunch_Spacing_Epics = (2.0/(atof(fEpicsHandler->GetString("MOFC1FREQ"))))*(pow(10, 9)); // Calculation of Bunch Spacing, 2/f as we get every OTHER bucket typically, converted to ns
+    if (Bunch_Spacing_Epics > 0.1 && Bunch_Spacing_Epics < 4.5){ // If the value looks sensible, check if an override value has been set
+      if (Bunch_Spacing_Override == 1.5556){ // If the Bunch_Spacing_override has NOT been set by the user, set the bunch spacing to be the epics value
+	Bunch_Spacing = Bunch_Spacing_Epics;
+      }
+    }
+  }
 
   //Declare track information objects for hadron/electron arm
   THaTrackInfo* had_trkifo = fhadSpectro->GetTrackInfo();
@@ -185,6 +188,7 @@ Int_t THcRFTime::Process( const THaEvData& evdata )
   if( !had_trkifo) cout << " no hadron track " << endl;
   if( !elec_trkifo) cout << " no electron track " << endl;
   //Check if the hadron/electron arm had a track
+  // May want to consider dropping this condition
   if( !had_trkifo || !had_trkifo->IsOK() ) return 1;
   if( !elec_trkifo || !elec_trkifo->IsOK() ) return 1;
 
@@ -196,31 +200,24 @@ Int_t THcRFTime::Process( const THaEvData& evdata )
     theSHMSTrack =(felecSpectro->GetGoldenTrack()); 
     theHMSTrack = (fhadSpectro->GetGoldenTrack());
   }
-  
-  //Check if there was a golden track in both arms
-  if (!theSHMSTrack || !theHMSTrack)
-    {
-      return 1;
-    }
 
   //Check if Database is reading the correct elec-arm particle mass
-  if (felecSpectro->GetParticleMass() > 0.00052) return 1;
+  // if (felecSpectro->GetParticleMass() > 0.00052) return 1;
         
-  //SHMS arm
-  Double_t SHMS_FPtime = theSHMSTrack->GetFPTime();
 
-  //HMS arm
-  Double_t HMS_FPtime = theHMSTrack->GetFPTime();
+  Double_t SHMS_FPtime = theSHMSTrack->GetFPTime();// SHMS arm
+  Double_t HMS_FPtime = theHMSTrack->GetFPTime();  // HMS arm
       
   if (SHMS_FPtime==-2000 || HMS_FPtime==-2000)  return 1;
   if (SHMS_FPtime==-1000 || HMS_FPtime==-1000)  return 1;
       
-  //Get raw TDC Times for HMS/SHMS (3/4 trigger)
-  SHMS_RFtime = fCoinDet->Get_RF_TrigTime(0); // SHMS
-  HMS_RFtime = fCoinDet->Get_RF_TrigTime(1); // HMS
-
-  fHMS_RFtimeDist = (HMS_RFtime - HMS_FPtime + HMS_RF_Offset);
-  fSHMS_RFtimeDist = (SHMS_RFtime - SHMS_FPtime + SHMS_RF_Offset);
+  SHMS_RFtime = fCoinDet->Get_RF_TrigTime(0); // SHMS is ID 0
+  HMS_RFtime = fCoinDet->Get_RF_TrigTime(1); // HMS is ID 1
+  
+  // RF Time dist can be utilised for PID, offsets should be set in Standard.kinematics, these are just used to "center" the distribution at a desired point
+  // Typically, other PID info needs to be utilised to establish where the relevant peaks for each particle species are in the distribution
+  fHMS_RFtimeDist = fmod((HMS_RFtime - HMS_FPtime + HMS_RF_Offset), Bunch_Spacing);
+  fSHMS_RFtimeDist = fmod((SHMS_RFtime - SHMS_FPtime + SHMS_RF_Offset), Bunch_Spacing);
   
   return 0;
 }

--- a/src/THcRFTime.cxx
+++ b/src/THcRFTime.cxx
@@ -187,37 +187,39 @@ Int_t THcRFTime::Process( const THaEvData& evdata )
 
   if( !had_trkifo) cout << " no hadron track " << endl;
   if( !elec_trkifo) cout << " no electron track " << endl;
-  //Check if the hadron/electron arm had a track
+  // Check if the hadron/electron arm had a track
   // May want to consider dropping this condition
   if( !had_trkifo || !had_trkifo->IsOK() ) return 1;
   if( !elec_trkifo || !elec_trkifo->IsOK() ) return 1;
 
   //Create THaTrack object for hadron/elec arms to get relevant golden track quantities
   if (felecArmName=="H") {
-    theSHMSTrack =(fhadSpectro->GetGoldenTrack()); 
+    theSHMSTrack = (fhadSpectro->GetGoldenTrack()); 
     theHMSTrack = (felecSpectro->GetGoldenTrack());
   } else{
-    theSHMSTrack =(felecSpectro->GetGoldenTrack()); 
+    theSHMSTrack = (felecSpectro->GetGoldenTrack()); 
     theHMSTrack = (fhadSpectro->GetGoldenTrack());
   }
 
   //Check if Database is reading the correct elec-arm particle mass
   // if (felecSpectro->GetParticleMass() > 0.00052) return 1;
-        
 
   Double_t SHMS_FPtime = theSHMSTrack->GetFPTime();// SHMS arm
   Double_t HMS_FPtime = theHMSTrack->GetFPTime();  // HMS arm
       
   if (SHMS_FPtime==-2000 || HMS_FPtime==-2000)  return 1;
   if (SHMS_FPtime==-1000 || HMS_FPtime==-1000)  return 1;
-      
+  
   SHMS_RFtime = fCoinDet->Get_RF_TrigTime(0); // SHMS is ID 0
   HMS_RFtime = fCoinDet->Get_RF_TrigTime(1); // HMS is ID 1
   
   // RF Time dist can be utilised for PID, offsets should be set in Standard.kinematics, these are just used to "center" the distribution at a desired point
   // Typically, other PID info needs to be utilised to establish where the relevant peaks for each particle species are in the distribution
-  fHMS_RFtimeDist = fmod((HMS_RFtime - HMS_FPtime + HMS_RF_Offset), Bunch_Spacing);
-  fSHMS_RFtimeDist = fmod((SHMS_RFtime - SHMS_FPtime + SHMS_RF_Offset), Bunch_Spacing);
+  // Note, this expression looks a bit odd but this is to achieve the same results as the Python a % b operation
+  // The result of this calculation will ALWAYS be a POSITIVE number between 0 and Bunch_Spacing
+  // See - https://stackoverflow.com/questions/1907565/c-and-python-different-behaviour-of-the-modulo-operation for more
+  fHMS_RFtimeDist = fmod((fmod((HMS_RFtime - HMS_FPtime + HMS_RF_Offset), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
+  fSHMS_RFtimeDist = fmod((fmod((SHMS_RFtime - SHMS_FPtime + SHMS_RF_Offset), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
   
   return 0;
 }

--- a/src/THcRFTime.h
+++ b/src/THcRFTime.h
@@ -2,7 +2,6 @@
 #define ROOT_THcRFTime
 
 ///////////////////////////////////////////////////////////////////////////////
-//                                                                           //
 // THcRFTime Physics Module                                                  //
 // Author: Stephen JD Kay                                                    //
 // University of Regina                                                      //
@@ -22,6 +21,8 @@
 #include <iostream>
 
 #include "THaPhysicsModule.h"
+#include "THaOutput.h"
+#include "THcHitList.h"
 #include "THcTrigDet.h" 
 #include "THcHodoscope.h"
 #include "THcHallCSpectrometer.h"
@@ -32,18 +33,20 @@ class THcRFTime : public THaPhysicsModule {
 public:
   // Single arm required? Single arm name specified
   THcRFTime( const char* name, const char* description, const char* hadArmName="", 
-	       const char* elecArmName="", const char* coinname="");
+	       const char* elecArmName="", const char* RFname="");
 
   virtual ~THcRFTime();
 
   virtual EStatus Init( const TDatime& run_time );
-  virtual Int_t   Process( const THaEvData& );
-  virtual Int_t  Decode( const THaEvData& ); 
+  virtual Int_t  Process( const THaEvData& );
 
   void            Reset( Option_t* opt="" );
   void            Clear( Option_t* opt="" );
   
  protected:
+
+  // Event Information
+  Int_t fNhits;
 
   virtual Int_t ReadDatabase( const TDatime& date);
   virtual Int_t  DefineVariables( EMode mode = kDefine );
@@ -71,6 +74,7 @@ public:
   Double_t Bunch_Spacing_Override;
 
   Double_t Bunch_Spacing;
+  Double_t Bunch_Spacing_Epics;
   Double_t HMS_RFtime; // HMS RF time
   Double_t SHMS_RFtime; // SHMS RF time
   Double_t HMS_FPtime;   //HMS focal plane time  
@@ -152,16 +156,10 @@ public:
   //Double_t had_xfp;      //hadron x-focal plane
   //Double_t had_xpfp;     //hadron xp focal plane
   //Double_t had_ypfp;     //hadron yp focal plane
-  
-  // trigger times pTrig1 (SHMS 3/4 trig) and pTrig4 (HMS 3/4 trig)
-  //Double_t pTRIG1_TdcTime_ROC1;
-  //Double_t pTRIG4_TdcTime_ROC1;
-  //Double_t pTRIG1_TdcTime_ROC2;
-  //Double_t pTRIG4_TdcTime_ROC2;
 
   //--------------------------------------------------------------------
 
-  ClassDef(THcRFTime,0) 	// Coincidence Time Module
+  ClassDef(THcRFTime,0) 	// RF Time Module
 };
 
 #endif

--- a/src/THcRFTime.h
+++ b/src/THcRFTime.h
@@ -1,0 +1,167 @@
+#ifndef ROOT_THcRFTime
+#define ROOT_THcRFTime
+
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// THcRFTime Physics Module                                                  //
+// Author: Stephen JD Kay                                                    //
+// University of Regina                                                      //
+// Date: 12/04/21 (April 12th 2021)                                          //
+// Based on THcCoinTime class from C Yero                                    //
+///////////////////////////////////////////////////////////////////////////////
+
+#include "THaEvData.h"
+#include "THaCutList.h"
+#include "VarDef.h"
+#include "VarType.h"
+#include "TClonesArray.h"
+
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+
+#include "THaPhysicsModule.h"
+#include "THcTrigDet.h" 
+#include "THcHodoscope.h"
+#include "THcHallCSpectrometer.h"
+#include "THaTrack.h"
+#include "THaEpicsEvtHandler.h"
+
+class THcRFTime : public THaPhysicsModule {
+public:
+  // Single arm required? Single arm name specified
+  THcRFTime( const char* name, const char* description, const char* hadArmName="", 
+	       const char* elecArmName="", const char* coinname="");
+
+  virtual ~THcRFTime();
+
+  virtual EStatus Init( const TDatime& run_time );
+  virtual Int_t   Process( const THaEvData& );
+  virtual Int_t  Decode( const THaEvData& ); 
+
+  void            Reset( Option_t* opt="" );
+  void            Clear( Option_t* opt="" );
+  
+ protected:
+
+  virtual Int_t ReadDatabase( const TDatime& date);
+  virtual Int_t  DefineVariables( EMode mode = kDefine );
+
+  // Data needed for adding RF time dist as a Leaf Variable
+  // Need offset and bunch spacing too
+  TString     fHodName;		// Name of hodoscope
+  TString     fCoinDetName;     // Name of Coin Trigger
+  TString     fhadArmName;      // Name of hadron arm
+  TString     felecArmName;     // Name of electron arm
+  
+  // A bit misleading for these to be "hadron" and "electron" spectrometers
+  THcHallCSpectrometer* fhadSpectro;	// Hadron Spectrometer object
+  THcHallCSpectrometer* felecSpectro;	// Electron Spectrometer object
+  THcTrigDet* fCoinDet;                 // Coin Trigger detector object
+  THaEpicsEvtHandler* fEpicsHandler; // Not working, need another include?
+
+  THaTrack* theSHMSTrack;
+  THaTrack* theHMSTrack;
+
+  THcHodoscope* fHod;	                // Hodscope object
+
+  Double_t HMS_RF_Offset;
+  Double_t SHMS_RF_Offset;
+  Double_t Bunch_Spacing_Override;
+
+  Double_t Bunch_Spacing;
+  Double_t HMS_RFtime; // HMS RF time
+  Double_t SHMS_RFtime; // SHMS RF time
+  Double_t HMS_FPtime;   //HMS focal plane time  
+  Double_t SHMS_FPtime;   //SHMS focal plane time
+
+  Double_t fHMS_RFtimeDist; // These are the two quantities we actually want to try to determine and produce in the end
+  Double_t fSHMS_RFtimeDist;
+
+  // Variables and stuff used in the CoinTime path length correction calculations
+  // May want to re-use some of these in the future 
+  //-----Declare Variables used in HMS/SHMS RF. time correction-----
+  // This is just the coin timing stuff now, will need similar for RF
+  //  Double_t lightSpeed;
+  //Double_t elecMass;
+  //Double_t positronMass;
+
+  //hadron masses (the e- could be in coincidence with any of the hadrons)
+  //Double_t protonMass;
+  //Double_t kaonMass;
+  //Double_t pionMass;
+  
+  // These variables and calculations are probably still good
+  //Double_t SHMScentralPathLen;  
+  //Double_t HMScentralPathLen;   
+
+  //Double_t DeltaSHMSpathLength;
+  //Double_t DeltaHMSpathLength;
+
+  // Coin time values, not needed, delete soon
+  /*
+  Double_t fROC1_RAW_CoinTime;
+  Double_t fROC2_RAW_CoinTime;
+  Double_t fTRIG1_RAW_CoinTime;
+  Double_t fTRIG4_RAW_CoinTime;
+  
+  Double_t fROC1_epCoinTime;
+  Double_t fROC2_epCoinTime;
+  Double_t fTRIG1_epCoinTime;
+  Double_t fTRIG4_epCoinTime;
+
+  Double_t fROC1_eKCoinTime;
+  Double_t fROC2_eKCoinTime;
+  Double_t fTRIG1_eKCoinTime;
+  Double_t fTRIG4_eKCoinTime;
+
+  Double_t fROC1_ePiCoinTime;
+  Double_t fROC2_ePiCoinTime;
+  Double_t fTRIG1_ePiCoinTime;
+  Double_t fTRIG4_ePiCoinTime;
+ 
+  Double_t fROC1_ePosCoinTime;   //electron-positron coin time 
+  Double_t fROC2_ePosCoinTime;
+  Double_t fTRIG1_ePosCoinTime;   //electron-positron coin time 
+  Double_t fTRIG4_ePosCoinTime;
+  */
+
+  //Double_t elec_coinCorr;
+  //Double_t elecArm_BetaCalc;
+  //Double_t elec_hodFPtime;
+  
+  //Double_t had_coinCorr_proton;
+  // Double_t hadArm_BetaCalc_proton;
+  
+  //Double_t had_coinCorr_Kaon;
+  //Double_t hadArm_BetaCalc_Kaon;
+   
+  //Double_t had_coinCorr_Pion;
+  //Double_t hadArm_BetaCalc_Pion;
+  
+  //Double_t had_coinCorr_Positron;
+  //Double_t hadArm_BetaCalc_Positron;
+  
+  // Still needed as part of difference calculation? Keep? 
+  //Double_t elec_P;     //electron golden track momentum
+  //Double_t elec_dP;     //electron golden track delta-> (P-P0 / P0)
+  //Double_t elec_xptar;    //electron golden track theta (xptar, :) 
+
+  //Double_t had_P;     //hadron golden track momentum
+  //Double_t had_xfp;      //hadron x-focal plane
+  //Double_t had_xpfp;     //hadron xp focal plane
+  //Double_t had_ypfp;     //hadron yp focal plane
+  
+  // trigger times pTrig1 (SHMS 3/4 trig) and pTrig4 (HMS 3/4 trig)
+  //Double_t pTRIG1_TdcTime_ROC1;
+  //Double_t pTRIG4_TdcTime_ROC1;
+  //Double_t pTRIG1_TdcTime_ROC2;
+  //Double_t pTRIG4_TdcTime_ROC2;
+
+  //--------------------------------------------------------------------
+
+  ClassDef(THcRFTime,0) 	// Coincidence Time Module
+};
+
+#endif

--- a/src/THcSecondaryKine.cxx
+++ b/src/THcSecondaryKine.cxx
@@ -33,14 +33,12 @@ THcSecondaryKine::THcSecondaryKine( const char* name, const char* description,
   fPrimaryName(primary_kine), fPrimary(NULL)
 {
   // Constructor
-
 }
 
 //_____________________________________________________________________________
 THcSecondaryKine::~THcSecondaryKine()
 {
   // Destructor
-
   DefineVariables( kDelete );
 }
 
@@ -152,8 +150,6 @@ THaAnalysisObject::EStatus THcSecondaryKine::Init( const TDatime& run_time )
 Int_t THcSecondaryKine::Process( const THaEvData& )
 {
   // Calculate the kinematics.
-
-
   if( !IsOK() ) return -1;
 
   //Get secondary particle mass
@@ -241,9 +237,9 @@ Int_t THcSecondaryKine::Process( const THaEvData& )
   // Determination of the missing mass under various assumptions, utilises database read in to establish which
   // corrections to use to determine values
   // It might be easier/nicer to just manipulate the missing energy in the 4-vector fB to determine these quantities
-  
+  // Could also tie the calculation into the actual read in value a bit more too  
   // Hadron in standard.kinematics is a charged pion
-  if ( fMX > 0.12957018 && fMX < 0.14957018 ){ 
+  if ( fMX > 0.12957018 && fMX < 0.14957018 ){
     fMMpi = sqrt(abs((fEmiss*fEmiss)-(fPmiss*fPmiss)));
     fMMK = sqrt(abs((pow(fEmiss+(sqrt((fMass_pi*fMass_pi)+(pow((pvect.Mag()), 2))))-(sqrt((fMass_K*fMass_K)+(pow((pvect.Mag()), 2)))), 2)-(fPmiss*fPmiss))));
     fMMp = sqrt(abs((pow(fEmiss+(sqrt((fMass_pi*fMass_pi)+(pow((pvect.Mag()), 2))))-(sqrt((fMass_p*fMass_p)+(pow((pvect.Mag()), 2)))), 2)-(fPmiss*fPmiss))));
@@ -260,7 +256,14 @@ Int_t THcSecondaryKine::Process( const THaEvData& )
     fMMK = sqrt(abs((pow(fEmiss+(sqrt((fMass_p*fMass_p)+(pow((pvect.Mag()), 2))))-(sqrt((fMass_K*fMass_K)+(pow((pvect.Mag()), 2)))), 2)-(fPmiss*fPmiss))));
     fMMp = sqrt(abs((fEmiss*fEmiss)-(fPmiss*fPmiss)));
   }
-  // Any other condition
+  // Any other condition, try and determine something from whatever the hell the specified mass was
+  else if (fMX != 0 ){
+    fMMpi = sqrt(abs((pow(fEmiss+(sqrt((fMX*fMX)+(pow((pvect.Mag()), 2))))-(sqrt((fMass_pi*fMass_pi)+(pow((pvect.Mag()), 2)))), 2)-(fPmiss*fPmiss))));
+    fMMK = sqrt(abs((pow(fEmiss+(sqrt((fMX*fMX)+(pow((pvect.Mag()), 2))))-(sqrt((fMass_K*fMass_K)+(pow((pvect.Mag()), 2)))), 2)-(fPmiss*fPmiss))));
+    fMMp = sqrt(abs((pow(fEmiss+(sqrt((fMX*fMX)+(pow((pvect.Mag()), 2))))-(sqrt((fMass_p*fMass_p)+(pow((pvect.Mag()), 2)))), 2)-(fPmiss*fPmiss))));
+  }
+  // If the secondary mass was 0 or negative for some reason, this is just the "anything else" junk variable output basically
+  // Note, add an extra condition for the mass being 0 if it is relevant for you for some reason!
   else{
     fMMpi = -1000;
     fMMK = -1000;

--- a/src/THcSecondaryKine.h
+++ b/src/THcSecondaryKine.h
@@ -113,7 +113,7 @@ public:
   Double_t fMX;         // Mass of secondary particle (GeV)
   Double_t fOopCentralOffset; //Offset of central out-of-plane angle (rad)
   
-  Double_t fMass_pi; // Charged pion mass (GeV)
+  Double_t fMass_pi;// Charged pion mass (GeV)
   Double_t fMass_K; // Charged kaon mass (GeV)
   Double_t fMass_p; // Charged proton mass (GeV)
 

--- a/src/THcSecondaryKine.h
+++ b/src/THcSecondaryKine.h
@@ -38,6 +38,9 @@ public:
   Double_t          GetPmiss_z()    const { return fPmiss_z; }
   Double_t          GetEmiss()      const { return fEmiss; }
   Double_t          GetMrecoil()    const { return fMrecoil; }
+  Double_t          GetMMpi()       const { return fMMpi; }
+  Double_t          GetMMK()        const { return fMMK; }
+  Double_t          GetMMp()        const { return fMMp; }
   Double_t          GetErecoil()    const { return fErecoil; }
   Double_t          GetPrecoil_x()  const { return fB.X(); }
   Double_t          GetPrecoil_y()  const { return fB.Y(); }
@@ -82,9 +85,12 @@ public:
   Double_t fPmiss_x;    // x-component of p_miss wrt q (GeV)
   Double_t fPmiss_y;    // y-component of p_miss wrt q (GeV)
   Double_t fPmiss_z;    // z-component of p_miss, along q (GeV)
-  Double_t fEmiss_nuc;      // Missing energy (GeV), nuclear physics definition omega-Tx-Tb
-  Double_t fEmiss; // Missing energy (GeV), correct definition omega+Mt-Ex
+  Double_t fEmiss_nuc;  // Missing energy (GeV), nuclear physics definition omega-Tx-Tb
+  Double_t fEmiss;      // Missing energy (GeV), correct definition omega+Mt-Ex
   Double_t fMrecoil;    // Invariant mass of recoil system (GeV)
+  Double_t fMMpi;       // Missing mass under asssumption hadron is a pion
+  Double_t fMMK;        // Missing mass under asssumption hadron is a kaon
+  Double_t fMMp;        // Missing mass under asssumption hadron is a proton
   Double_t fErecoil;    // Total energy of recoil system (GeV)
   Double_t fTX;         // Kinetic energy of detected particle (GeV)
   Double_t fTB;         // Kinetic energy of recoil system (GeV)
@@ -106,6 +112,10 @@ public:
   // Parameters
   Double_t fMX;         // Mass of secondary particle (GeV)
   Double_t fOopCentralOffset; //Offset of central out-of-plane angle (rad)
+  
+  Double_t fMass_pi; // Charged pion mass (GeV)
+  Double_t fMass_K; // Charged kaon mass (GeV)
+  Double_t fMass_p; // Charged proton mass (GeV)
 
   TString            fSpectroName;  // Name of spectrometer for secondary particle
   THcHallCSpectrometer* fSpectro;   // Pointer to spectrometer object

--- a/src/THcTrigDet.cxx
+++ b/src/THcTrigDet.cxx
@@ -320,7 +320,7 @@ void THcTrigDet::Setup(const char* name, const char* description) {
 Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
   std::string adcNames, tdcNames;
   std::string trigNames="pTRIG1_ROC1 pTRIG4_ROC1 pTRIG1_ROC2 pTRIG4_ROC2";
-  // Double check names
+  // SJDK 12/04/21 - Added new RF names for use in getter
   std::string RFNames="pRF hRF";
   DBRequest list[] = {
     {"_numAdc", &fNumAdc, kInt},  // Number of ADC channels.
@@ -328,7 +328,7 @@ Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
     {"_adcNames", &adcNames, kString},  // Names of ADC channels.
     {"_tdcNames", &tdcNames, kString},  // Names of TDC channels.
     {"_trigNames", &trigNames, kString,0,1},  // Names of Triggers for coincidence time.
-    {"_RFNames", &RFNames, kString,0, 1}, // Names for RF time
+    {"_RFNames", &RFNames, kString,0, 1}, // SJDK 12/04/21 -  Names for RF time
     {"_tdcoffset", &fTdcOffset, kDouble,0,1},  // Offset of tdc channels
     {"_adc_tdc_offset", &fAdcTdcOffset, kDouble,0,1},  // Offset of Adc Pulse time (ns)
     {"_tdcchanperns", &fTdcChanperNS, kDouble,0,1},  // Convert channesl to ns
@@ -338,7 +338,7 @@ Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
   fTdcOffset=300.;
   fAdcTdcOffset=200.;
   gHcParms->LoadParmValues(list, fKwPrefix.c_str());
-  //
+  
   fAdcTimeWindowMin = new Double_t [fNumAdc];
   fAdcTimeWindowMax = new Double_t [fNumAdc];
   fTdcTimeWindowMin = new Double_t [fNumTdc];
@@ -367,7 +367,7 @@ Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
   fAdcNames = vsplit(adcNames);
   fTdcNames = vsplit(tdcNames);
   fTrigNames = vsplit(trigNames);
-  fRFNames = vsplit(RFNames);
+  fRFNames = vsplit(RFNames); // SJDK 12/04/21 - For RF getter
   //default index values
  
   //Assign an index to coincidence trigger times strings
@@ -385,6 +385,7 @@ Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
        cout << fTrigNames[j] << " " << fTrigId[j] << endl;
      }
  
+     // SJDK - 12/04/21 - For RF getter
   //Assign an index to RF times strings
      for (UInt_t j = 0; j <fRFNames.size(); j++) {
        fRFId[j]=-1;

--- a/src/THcTrigDet.cxx
+++ b/src/THcTrigDet.cxx
@@ -320,12 +320,15 @@ void THcTrigDet::Setup(const char* name, const char* description) {
 Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
   std::string adcNames, tdcNames;
   std::string trigNames="pTRIG1_ROC1 pTRIG4_ROC1 pTRIG1_ROC2 pTRIG4_ROC2";
+  // Double check names
+  std::string RFNames="pRF hRF";
   DBRequest list[] = {
     {"_numAdc", &fNumAdc, kInt},  // Number of ADC channels.
     {"_numTdc", &fNumTdc, kInt},  // Number of TDC channels.
     {"_adcNames", &adcNames, kString},  // Names of ADC channels.
     {"_tdcNames", &tdcNames, kString},  // Names of TDC channels.
     {"_trigNames", &trigNames, kString,0,1},  // Names of Triggers for coincidence time.
+    {"_RFNames", &RFNames, kString,0, 1}, // Names for RF time
     {"_tdcoffset", &fTdcOffset, kDouble,0,1},  // Offset of tdc channels
     {"_adc_tdc_offset", &fAdcTdcOffset, kDouble,0,1},  // Offset of Adc Pulse time (ns)
     {"_tdcchanperns", &fTdcChanperNS, kDouble,0,1},  // Convert channesl to ns
@@ -364,7 +367,7 @@ Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
   fAdcNames = vsplit(adcNames);
   fTdcNames = vsplit(tdcNames);
   fTrigNames = vsplit(trigNames);
-
+  fRFNames = vsplit(RFNames);
   //default index values
  
   //Assign an index to coincidence trigger times strings
@@ -381,11 +384,24 @@ Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
      for (UInt_t j = 0; j <fTrigNames.size(); j++) {
        cout << fTrigNames[j] << " " << fTrigId[j] << endl;
      }
-  
+ 
+  //Assign an index to RF times strings
+     for (UInt_t j = 0; j <fRFNames.size(); j++) {
+       fRFId[j]=-1;
+     }
+  for (int i = 0; i <fNumTdc; i++) {
+    for (UInt_t j = 0; j <fRFNames.size(); j++) {
+            if(fTdcNames.at(i)==fRFNames[j]) fRFId[j]=i;
+	  }
+  }
+ 
+  cout << " RF = " << fRFNames.size() << endl;
+     for (UInt_t j = 0; j <fRFNames.size(); j++) {
+       cout << fRFNames[j] << " " << fRFId[j] << endl;
+     }
 
   return kOK;
 }
-
 
 Int_t THcTrigDet::DefineVariables(THaAnalysisObject::EMode mode) {
 

--- a/src/THcTrigDet.cxx
+++ b/src/THcTrigDet.cxx
@@ -115,10 +115,10 @@ Use only with THcTrigApp class.
 #include "THcTrigApp.h"
 #include "THcTrigRawHit.h"
 
-
+//_____________________________________________________________________________
 THcTrigDet::THcTrigDet() {}
 
-
+//_____________________________________________________________________________
 THcTrigDet::THcTrigDet(
   const char* name, const char* description, THaApparatus* app
 ) :
@@ -135,7 +135,7 @@ THcTrigDet::THcTrigDet(
   fSpectName = name[0];
 }
 
-
+//_____________________________________________________________________________
 THcTrigDet::~THcTrigDet() {
   delete [] fAdcTimeWindowMin; fAdcTimeWindowMin = NULL;
   delete [] fAdcTimeWindowMax; fAdcTimeWindowMax = NULL;
@@ -144,7 +144,7 @@ THcTrigDet::~THcTrigDet() {
 
 }
 
-
+//_____________________________________________________________________________
 THaAnalysisObject::EStatus THcTrigDet::Init(const TDatime& date) {
   // Call `Setup` before everything else.
   Setup(GetName(), GetTitle());
@@ -191,7 +191,7 @@ THaAnalysisObject::EStatus THcTrigDet::Init(const TDatime& date) {
   fTDC_RefTimeCut = -1000;		// Minimum allowed reference times
   fADC_RefTimeCut = -1000;
   gHcParms->LoadParmValues((DBRequest*)&listextra,fKwPrefix.c_str());
- // Initialize hitlist part of the class.
+  // Initialize hitlist part of the class.
   // printf(" Init trig det hitlist\n");
   InitHitList(fDetMap, "THcTrigRawHit", 200,fTDC_RefTimeCut,fADC_RefTimeCut);
   CreateMissReportParms(fKwPrefix.c_str());
@@ -206,7 +206,7 @@ THaAnalysisObject::EStatus THcTrigDet::Init(const TDatime& date) {
   return fStatus;
 }
 
-
+//_____________________________________________________________________________
 void THcTrigDet::Clear(Option_t* opt) {
   THaAnalysisObject::Clear(opt);
 
@@ -230,7 +230,7 @@ void THcTrigDet::Clear(Option_t* opt) {
   };
 }
 
-
+//_____________________________________________________________________________
 Int_t THcTrigDet::Decode(const THaEvData& evData) {
     
   // Decode raw data for this event.
@@ -306,9 +306,7 @@ Int_t THcTrigDet::Decode(const THaEvData& evData) {
   return 0;
 }
 
-
-
-
+//_____________________________________________________________________________
 void THcTrigDet::Setup(const char* name, const char* description) {
   // Prefix for parameters in `param` file.
   string kwPrefix = string(GetApparatus()->GetName()) + "_" + name;
@@ -316,7 +314,7 @@ void THcTrigDet::Setup(const char* name, const char* description) {
   fKwPrefix = kwPrefix;
 }
 
-
+//_____________________________________________________________________________
 Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
   std::string adcNames, tdcNames;
   std::string trigNames="pTRIG1_ROC1 pTRIG4_ROC1 pTRIG1_ROC2 pTRIG4_ROC2";
@@ -332,7 +330,7 @@ Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
     {"_tdcoffset", &fTdcOffset, kDouble,0,1},  // Offset of tdc channels
     {"_adc_tdc_offset", &fAdcTdcOffset, kDouble,0,1},  // Offset of Adc Pulse time (ns)
     {"_tdcchanperns", &fTdcChanperNS, kDouble,0,1},  // Convert channesl to ns
-     {0}
+    {0}
   };
   fTdcChanperNS=0.09766;
   fTdcOffset=300.;
@@ -371,41 +369,39 @@ Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
   //default index values
  
   //Assign an index to coincidence trigger times strings
-     for (UInt_t j = 0; j <fTrigNames.size(); j++) {
-       fTrigId[j]=-1;
-     }
+  for (UInt_t j = 0; j <fTrigNames.size(); j++) {
+    fTrigId[j]=-1;
+  }
   for (int i = 0; i <fNumTdc; i++) {
     for (UInt_t j = 0; j <fTrigNames.size(); j++) {
-            if(fTdcNames.at(i)==fTrigNames[j]) fTrigId[j]=i;
-	  }
+      if(fTdcNames.at(i)==fTrigNames[j]) fTrigId[j]=i;
+    }
   }
  
   cout << " Trig = " << fTrigNames.size() << endl;
-     for (UInt_t j = 0; j <fTrigNames.size(); j++) {
-       cout << fTrigNames[j] << " " << fTrigId[j] << endl;
-     }
- 
-     // SJDK - 12/04/21 - For RF getter
-  //Assign an index to RF times strings
-     for (UInt_t j = 0; j <fRFNames.size(); j++) {
-       fRFId[j]=-1;
-     }
-  for (int i = 0; i <fNumTdc; i++) {
-    for (UInt_t j = 0; j <fRFNames.size(); j++) {
-            if(fTdcNames.at(i)==fRFNames[j]) fRFId[j]=i;
-	  }
+  for (UInt_t j = 0; j <fTrigNames.size(); j++) {
+    cout << fTrigNames[j] << " " << fTrigId[j] << endl;
   }
  
-  cout << " RF = " << fRFNames.size() << endl;
-     for (UInt_t j = 0; j <fRFNames.size(); j++) {
-       cout << fRFNames[j] << " " << fRFId[j] << endl;
-     }
+  // SJDK - 12/04/21 - For RF getter
+  // Assign an index to RF times strings
+  for (UInt_t j = 0; j <fRFNames.size(); j++) {
+    fRFId[j]=-1;
+  }
+  for (int i = 0; i <fNumTdc; i++) {
+    for (UInt_t j = 0; j <fRFNames.size(); j++) {
+      if(fTdcNames.at(i)==fRFNames[j]) fRFId[j]=i;
+    }
+  } 
+  for (UInt_t j = 0; j <fRFNames.size(); j++) {
+    cout << fRFNames[j] << " " << fRFId[j] << endl;
+  }
 
   return kOK;
 }
 
+//_____________________________________________________________________________
 Int_t THcTrigDet::DefineVariables(THaAnalysisObject::EMode mode) {
-
 
   if (mode == kDefine && fIsSetup) return kOK;
   fIsSetup = (mode == kDefine);
@@ -505,8 +501,6 @@ Int_t THcTrigDet::DefineVariables(THaAnalysisObject::EMode mode) {
     };
     vars.push_back(entry8);
   
- 
-
     adcPulseTimeTitle.at(i) = fAdcNames.at(i) + "_adcPulseTime";
     adcPulseTimeVar.at(i) = TString::Format("fAdcPulseTime[%d]", i);
     RVarDef entry9 {
@@ -524,8 +518,7 @@ Int_t THcTrigDet::DefineVariables(THaAnalysisObject::EMode mode) {
   for (int i=0; i<fNumTdc; ++i) {
     tdcTimeRawTitle.at(i) = fTdcNames.at(i) + "_tdcTimeRaw";
     tdcTimeRawVar.at(i) = TString::Format("fTdcTimeRaw[%d]", i);
-    
-
+   
     RVarDef entry1 {
       tdcTimeRawTitle.at(i).Data(),
       tdcTimeRawTitle.at(i).Data(),
@@ -571,6 +564,7 @@ void THcTrigDet::SetEvtType(int evtype) {
   AddEvtType(evtype);
 }
 
+//_____________________________________________________________________________
 Bool_t THcTrigDet::IsIgnoreType(Int_t evtype) const
 {
   for (UInt_t i=0; i < eventtypes.size(); i++) {
@@ -579,10 +573,12 @@ Bool_t THcTrigDet::IsIgnoreType(Int_t evtype) const
   return kFALSE; 
 }
 
+//_____________________________________________________________________________
 Bool_t THcTrigDet::HaveIgnoreList() const
 {
   return( (eventtypes.size()>0) ? kTRUE : kFALSE);
 }
+
 //_____________________________________________________________________________
 Int_t THcTrigDet::End(THaRunBase* run)
 {

--- a/src/THcTrigDet.h
+++ b/src/THcTrigDet.h
@@ -34,19 +34,20 @@ class THcTrigDet : public THaDetector, public THcHitList {
     Int_t          End(THaRunBase* run);
     //Funtions to get TDCtime for cointime module 
     Double_t Get_CT_Trigtime(Int_t ii) { return (fTrigId[ii]==-1 ? 0. : fTdcTime[fTrigId[ii]]) ;}
-
+    // Function to get RFTDC time for RF module
+    Double_t Get_RF_TrigTime(Int_t ii) { return (fRFId[ii]==-1 ? 0. : fTdcTime[fRFId[ii]]) ;}
+    
   protected:
     void Setup(const char* name, const char* description);
     virtual Int_t ReadDatabase(const TDatime& date);
     virtual Int_t DefineVariables(EMode mode=kDefine);
-    
-
 
     std::string fKwPrefix;
 
     Int_t fNumAdc;
     Int_t fNumTdc;
     Int_t fTrigId[4];
+    Int_t fRFId[2];
 
     Double_t fAdcTdcOffset;
     Double_t fTdcOffset;
@@ -55,6 +56,7 @@ class THcTrigDet : public THaDetector, public THcHitList {
     std::vector<std::string> fAdcNames;
     std::vector<std::string> fTdcNames;
     std::vector<std::string> fTrigNames;
+    std::vector<std::string> fRFNames;
 
     static const int fMaxAdcChannels = 200;
     static const int fMaxTdcChannels = 200;

--- a/src/THcTrigDet.h
+++ b/src/THcTrigDet.h
@@ -34,6 +34,7 @@ class THcTrigDet : public THaDetector, public THcHitList {
     Int_t          End(THaRunBase* run);
     //Funtions to get TDCtime for cointime module 
     Double_t Get_CT_Trigtime(Int_t ii) { return (fTrigId[ii]==-1 ? 0. : fTdcTime[fTrigId[ii]]) ;}
+    // SJDK 12/04/21 - New Getter for RF time info
     // Function to get RFTDC time for RF module
     Double_t Get_RF_TrigTime(Int_t ii) { return (fRFId[ii]==-1 ? 0. : fTdcTime[fRFId[ii]]) ;}
     
@@ -47,7 +48,7 @@ class THcTrigDet : public THaDetector, public THcHitList {
     Int_t fNumAdc;
     Int_t fNumTdc;
     Int_t fTrigId[4];
-    Int_t fRFId[2];
+    Int_t fRFId[2]; // SJDK 12/04/21 -  New RF ID for getter above
 
     Double_t fAdcTdcOffset;
     Double_t fTdcOffset;
@@ -70,7 +71,6 @@ class THcTrigDet : public THaDetector, public THcHitList {
     Double_t *fAdcTimeWindowMax;    
     Double_t *fTdcTimeWindowMin;    
     Double_t *fTdcTimeWindowMax;    
-
     
     Int_t fAdcPedRaw[fMaxAdcChannels];
     Int_t fAdcPulseIntRaw[fMaxAdcChannels];


### PR DESCRIPTION
New RFtime class to determine distributions for the HMS/SHMS that can be utilised for PID.

Currently fairly barebones (no corrections for particle type) but can still be used to separate different hadrons in the SHMS.

Adds three new dbase values that can be set (I set them in standard.kinematics) -

Bunch_Spacing_Override - A variable that can be used to forcibly set the bunch spacing to a specific value
HMS_RF_Offset - A value between -/+ Bunch spacing to centre the distribution as needed
SHMS_RF_Offset - A value between -/+ Bunch spacing to centre the distribution as needed

If the override is NOT set, the bunch spacing is determined from Epics read in in the class.

See attached pdf for some comparisons (page 6) -

The top row is the values plotted from the calculation in the analysis script, the bottom row is the same set of plots but using the output of the new hcana class. The final plot on each row shows the full distribution (magenta), the distribution with pion PID cuts applied (red) and with an RF cut applied (blue). In this case the cut is clearly wrong though so it isn't particularly helpful. This is just set in the analysis script so isn't an "error" or issue with the new class in any way.

This is utilised in a replay script in a VERY similar way to the CoinTime class -

  //Add RF physics module THcRFTime::THcRFTime (const char *name, const char* description, const char* hadArmName, 
  // const char* elecArmName, const char* RFname) :
  THcRFTime* RFTime = new THcRFTime("RFTime", "RF Time Determination", "P", "H", "T.coin");
  gHaPhysics->Add(RFTime);

[Pion_Histos_7873_120000.pdf](https://github.com/JeffersonLab/hcana/files/6321435/Pion_Histos_7873_120000.pdf)
