### PR TITLE
Hodtest fixup

### DIFF
--- a/examples/PARAM/hcana.param
+++ b/examples/PARAM/hcana.param
@@ -152,8 +152,8 @@ hcer_enorm_max = 1.5
 hcer_dp_min = -20.0
 hcer_dp_max = 25.0
 
-hcer_adcTimeWindowMin = 1500.
-hcer_adcTimeWindowMax = 3500.
+hcer_adcTimeWindowMin = 1500., 1500.
+hcer_adcTimeWindowMax = 3500., 3500.
 
 ; Threshold for good hit (for measureing effic.)
 hcer_npe_thresh = 0.5

--- a/src/THcParmList.cxx
+++ b/src/THcParmList.cxx
@@ -660,6 +660,8 @@ Int_t THcParmList::ReadArray(const char* attrC, T* array, Int_t size)
   if(size > sz) {
     cout << "*** ERROR: requested " << size << " elements of " << attrC <<
       " which has only " << sz << " elements" << endl;
+    cout << "Cannot continue. Must fix database. Terminating program." << endl;
+    //FIXME: probably should make this an exception to be caught in LoadParmValues
     exit(EXIT_FAILURE);
   } else if(size < sz) {
     cout << "*** WARNING: requested " << size << " elements of " << attrC <<


### PR DESCRIPTION
examples/hodtest.C crashed on me when running it with the current version of hcana. The error was not particularly clear. I traced it to two apparently incorrect entries in examples/PARAM/hcana.param, which are corrected here. hodtest.C now works for me, and the histograms more or less match what's in the wiki.

I also added a clarifying message to be printed in case the program exits because of bad parameters. Perhaps instead of calling exit(), throwing an exception would be a little cleaner, especially if such fatal errors may occur in several different places, but I'll leave it as it is for now.