### PR TITLE
Podd 1.7 rc5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,10 @@ option(HCANA_BUILTIN_PODD "Use built-in Podd submodule (default: YES)" ON)
 #----------------------------------------------------------------------------
 # Set up Podd and ROOT dependencies
 if(HCANA_BUILTIN_PODD)
-  set(CMAKE_MODULE_PATH
-    ${PROJECT_SOURCE_DIR}/podd/cmake/Modules
-    ${CMAKE_MODULE_PATH}
-    )
+  list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/podd/cmake/Modules")
   include(PoddCMakeEnv)
-  find_package(ROOT 5.10 REQUIRED)
+  find_package(ROOT 6.00 REQUIRED)
+  config_add_dependency(ROOT 6.00)
 else()
   # Find Podd and register it as a dependency
   # This will also automatically set up ROOT
@@ -20,9 +18,6 @@ else()
   include(PoddCMakeEnv)
   config_add_dependency(Podd 1.6)
 endif()
-
-# Register ROOT dependency - it's in our public interface
-config_add_dependency(ROOT 5.10)
 
 #----------------------------------------------------------------------------
 # Set up the compiler flags

--- a/SConstruct
+++ b/SConstruct
@@ -25,6 +25,7 @@ baseenv.Append(HA_DIR= baseenv.subst('$HC_DIR')+'/podd')
 baseenv.Append(MAIN_DIR= baseenv.subst('$HEAD_DIR'))
 baseenv.Append(HA_Podd = os.path.join(baseenv.subst('$HA_DIR'),'Podd'))
 baseenv.Append(HA_DC = os.path.join(baseenv.subst('$HA_DIR'),'hana_decode'))
+baseenv.Append(HA_DB = os.path.join(baseenv.subst('$HA_DIR'),'Database'))
 baseenv.Append(MAJORVERSION = '0')
 baseenv.Append(MINORVERSION = '90')
 baseenv.Append(PATCH = '0')
@@ -38,7 +39,7 @@ print ("Hall A Main Directory = %s" % baseenv.subst('$HA_DIR'))
 print ("Software Version = %s" % baseenv.subst('$VERSION'))
 ivercode = 65536*int(float(baseenv.subst('$SOVERSION')))+ 256*int(10*(float(baseenv.subst('$SOVERSION'))-int(float(baseenv.subst('$SOVERSION')))))+ int(float(baseenv.subst('$PATCH')))
 baseenv.Append(VERCODE = ivercode)
-baseenv.Append(CPPPATH = ['$HC_SRC','$HA_Podd','$HA_DC'])
+baseenv.Append(CPPPATH = ['$HC_SRC','$HA_Podd','$HA_DC','$HA_DB'])
 
 sys.path.insert(1,baseenv.subst('$HA_DIR'+'/site_scons'))
 import configure
@@ -88,17 +89,21 @@ Export('baseenv')
 hallclib = 'HallC'
 poddlib = 'Podd'
 dclib = 'dc'
+dblib = 'PoddDB'
 
-baseenv.Append(LIBPATH=['$HC_DIR','$HC_SRC','$HA_Podd','$HA_DC'])
-baseenv.Append(RPATH=['$HC_DIR','$HA_Podd','$HA_DC'])
+baseenv.Append(LIBPATH=['$HC_DIR','$HC_SRC','$HA_Podd','$HA_DC','$HA_DB'])
+baseenv.Append(RPATH=['$HC_DIR','$HA_Podd','$HA_DC','$HA_DB'])
 baseenv.Replace(SHLIBSUFFIX = '.so')
 baseenv.Replace(SOSUFFIX = baseenv.subst('$SHLIBSUFFIX'))
 #baseenv.Replace(SHLIBSUFFIX = '.so')
 baseenv.Append(SHLIBSUFFIX = '.'+baseenv.subst('$VERSION'))
+# Scons 4.1.0 sets this to '-Wl,rpath=' which the Xcode 12 linker doesn't understand
+if baseenv['PLATFORM'] == 'darwin':
+    baseenv.Replace(RPATHPREFIX = '-Wl,-rpath,')
 
 pbaseenv=baseenv.Clone()
-pbaseenv.Prepend(LIBS=[hallclib,poddlib,dclib])
-baseenv.Prepend(LIBS=[poddlib,dclib])
+pbaseenv.Prepend(LIBS=[hallclib,poddlib,dclib,dblib])
+baseenv.Prepend(LIBS=[poddlib,dclib,dblib])
 Export('pbaseenv')
 
 if pbaseenv['CXX'] == 'g++':

--- a/src/THcDC.cxx
+++ b/src/THcDC.cxx
@@ -136,7 +136,7 @@ void THcDC::Setup(const char* name, const char* description)
   cout << "Plane Name List: " << planenamelist << endl;
   cout << "Drift Chambers: " <<  fNPlanes << " planes in " << fNChambers << " chambers" << endl;
 
-  vector<string> plane_names = vsplit(planenamelist);
+  vector<string> plane_names = Podd::vsplit(planenamelist);
 
   if(plane_names.size() != (UInt_t) fNPlanes) {
     cout << "ERROR: Number of planes " << fNPlanes << " doesn't agree with number of plane names " << plane_names.size() << endl;

--- a/src/THcHelicityScaler.cxx
+++ b/src/THcHelicityScaler.cxx
@@ -389,8 +389,8 @@ Int_t THcHelicityScaler::Analyze(THaEvData *evdata)
   
   UInt_t *rdata = (UInt_t*) evdata->GetRawDataBuffer();
   
-  if(evdata->GetEvType() == fDelayedType) { // Save this event for processing later
-    Int_t evlen = evdata->GetEvLength();
+  if((Int_t)evdata->GetEvType() == fDelayedType) { // Save this event for processing later
+    UInt_t evlen = evdata->GetEvLength();
     
     UInt_t *datacopy = new UInt_t[evlen];
     fDelayedEvents.push_back(datacopy);
@@ -421,12 +421,12 @@ Int_t THcHelicityScaler::AnalyzeBuffer(UInt_t* rdata)
 
   UInt_t *plast = p+*p;		// Index to last word in the bank
   Int_t roc = -1;
-  Int_t evlen = *p+1;
+  UInt_t evlen = *p+1;
   
   Int_t ifound=0;
   
   while(p<plast) {
-    Int_t banklen = *p;
+    UInt_t banklen = *p;
     p++;			  // point to header
     
     if (fDebugFile) {
@@ -466,7 +466,7 @@ Int_t THcHelicityScaler::AnalyzeBuffer(UInt_t* rdata)
       } else {
 	// This is a helicity scaler bank
 	if (roc == fROC) {
-	  Int_t nevents = (banklen-2)/fNScalerChannels;
+	  UInt_t nevents = (banklen-2)/fNScalerChannels;
 	  //cout << "# of helicity events in bank:" << " " << nevents << endl;
 	  if (nevents > 100) {
 	    cout << "Error! Beam off for too long" << endl;	
@@ -475,7 +475,7 @@ Int_t THcHelicityScaler::AnalyzeBuffer(UInt_t* rdata)
 	  fNTrigsInBuf = 0;
 
 	  // Save helcitiy and quad info for THcHelicity
-	  for (Int_t iev = 0; iev < nevents; iev++) {  // find number of helicity events in each bank
+	  for (UInt_t iev = 0; iev < nevents; iev++) {  // find number of helicity events in each bank
 	    Int_t index = fNScalerChannels*iev+1;
 
 	    //C.Y. 11/26/2020 This methods extracts the raw helicity information

--- a/src/THcHelicityScaler.cxx
+++ b/src/THcHelicityScaler.cxx
@@ -294,7 +294,7 @@ Int_t THcHelicityScaler::ReadDatabase(const TDatime& date )
       fBCM_SatQuadratic[i]=0.;
     }
     gHcParms->LoadParmValues((DBRequest*)&list2, prefix);
-    vector<string> bcm_names = vsplit(bcm_namelist);
+    vector<string> bcm_names = Podd::vsplit(bcm_namelist);
     for(Int_t i=0;i<fNumBCMs;i++) {
       fBCM_Name.push_back(bcm_names[i]+"_Hel.scal");
       fBCM_delta_charge[i]=0.;
@@ -1064,7 +1064,7 @@ THaAnalysisObject::EStatus THcHelicityScaler::Init(const TDatime& date)
   sname = "hel"+fName+sname0;   //This should be: 'helPScalevt' or 'helHScalevt'
 
   //Open helicity scaler .dat map file 
-  FILE *fi = OpenFile(sname.Data(), date);
+  FILE *fi = Podd::OpenDBFile(sname.Data(), date);
   if ( !fi ) {
     cout << "Cannot find db file for "<<fName<<" scaler event handler"<<endl;
     return kFileError;
@@ -1081,7 +1081,7 @@ THaAnalysisObject::EStatus THcHelicityScaler::Init(const TDatime& date)
     std::string sin(cbuf);
     std::string sinput(sin.substr(0,sin.find_first_of("#")));
     if (fDebugFile) *fDebugFile << "string input "<<sinput<<endl;
-    dbline = vsplit(sinput);
+    dbline = Podd::vsplit(sinput);
     if (dbline.size() > 0) {
       pos1 = FindNoCase(dbline[0],scomment);
       if (pos1 != minus1) continue;

--- a/src/THcHitList.cxx
+++ b/src/THcHitList.cxx
@@ -98,7 +98,7 @@ void THcHitList::InitHitList(THaDetMap* detmap,
   fNRefIndex = 0;
   fRefIndexMaps.clear();
   /* Find the biggest refindex */
-  for (Int_t i=0; i < fdMap->GetSize(); i++) {
+  for (UInt_t i=0; i < fdMap->GetSize(); i++) {
     THaDetMap::Module* d = fdMap->GetModule(i);
     if(d->plane >= 1000) {
       Int_t refindex = d->signal;
@@ -115,7 +115,7 @@ void THcHitList::InitHitList(THaDetMap* detmap,
     fRefIndexMaps.push_back(map);
   }
   // Put the refindex mapping information in the vector
-  for (Int_t i=0; i < fdMap->GetSize(); i++) {
+  for (UInt_t i=0; i < fdMap->GetSize(); i++) {
     THaDetMap::Module* d = fdMap->GetModule(i);
     if(d->plane >= 1000) {	// This is a reference time definition
       Int_t refindex = d->signal;
@@ -131,7 +131,7 @@ void THcHitList::InitHitList(THaDetMap* detmap,
   }
   // Loop to check that requested refindex's are defined
   // and that signal #'s are in range
-  for (Int_t i=0; i < fdMap->GetSize(); i++) {
+  for (UInt_t i=0; i < fdMap->GetSize(); i++) {
     THaDetMap::Module* d = fdMap->GetModule(i);
     Int_t refindex = d->refindex;
     if(d->plane < 1000) {
@@ -189,12 +189,12 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
     // Assumes that all FADCs are in the same crate
     cout << "Got the Crate map" << endl;
     fMap = evdata.GetCrateMap();
-    for (Int_t i=0; i < fdMap->GetSize(); i++) { // Look for a FADC250
+    for (UInt_t i=0; i < fdMap->GetSize(); i++) { // Look for a FADC250
       THaDetMap::Module* d = fdMap->GetModule(i);
       Decoder::Fadc250Module* isfadc = dynamic_cast<Decoder::Fadc250Module*>(evdata.GetModule(d->crate, d->slot));
       if(isfadc) {
 	// Scan this crate to find the TI.
-	for(Int_t slot=0;slot<Decoder::MAXSLOT;slot++) {
+	for(UInt_t slot=0;slot<Decoder::MAXSLOT;slot++) {
 	  if(fMap->getModel(d->crate, slot) == 4) {
 	    fTISlot = slot;
 	    fTICrate = d->crate;
@@ -204,7 +204,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
 	}
 	// Now make a map of all the FADCs in this crate
 	if(fTISlot>0) {
-	  for(Int_t slot=0;slot<Decoder::MAXSLOT;slot++) {
+	  for(UInt_t slot=0;slot<Decoder::MAXSLOT;slot++) {
 	    Decoder::Fadc250Module* fadc = dynamic_cast<Decoder::Fadc250Module*>
 	      (evdata.GetModule(d->crate, slot));
 	    if(fadc) {
@@ -241,10 +241,10 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
       if(evdata.IsMultifunction(fRefIndexMaps[i].crate,
 				fRefIndexMaps[i].slot)) { // Multifunction module (e.g. FADC)
 	// Make sure at least one pulse
-	Int_t nrefhits = evdata.GetNumEvents(Decoder::kPulseTime,
-					     fRefIndexMaps[i].crate,
-					     fRefIndexMaps[i].slot,
-					     fRefIndexMaps[i].channel);
+	UInt_t nrefhits = evdata.GetNumEvents(Decoder::kPulseTime,
+                                              fRefIndexMaps[i].crate,
+                                              fRefIndexMaps[i].slot,
+                                              fRefIndexMaps[i].channel);
 	Int_t timeshift=0;
 	if(fTISlot>0) {		// Get the trigger time for this module
 	  if(fTrigTimeShiftMap.find(fRefIndexMaps[i].slot)
@@ -261,7 +261,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
 	Int_t reftime = 0;
 	Int_t prevtime = 0;
 	Int_t difftime = 0;
-	for(Int_t ihit=0; ihit<nrefhits; ihit++) {
+	for(UInt_t ihit=0; ihit<nrefhits; ihit++) {
 	  reftime = evdata.GetData(Decoder::kPulseTime,fRefIndexMaps[i].crate,
 				   fRefIndexMaps[i].slot, fRefIndexMaps[i].channel,ihit);
 	  reftime += 64*timeshift;
@@ -306,7 +306,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
       }
     }
   }
-  for ( Int_t i=0; i < fdMap->GetSize(); i++ ) {
+  for ( UInt_t i=0; i < fdMap->GetSize(); i++ ) {
     THaDetMap::Module* d = fdMap->GetModule(i);
     
     // Loop over all channels that have a hit.
@@ -319,10 +319,10 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
     // Should probably get the Decoder::Module object and use it's
     // methods.  Saving a THaEvData::GetModule call every time
 
-    for ( Int_t j=0; j < evdata.GetNumChan( d->crate, d->slot); j++) {
+    for ( UInt_t j=0; j < evdata.GetNumChan( d->crate, d->slot); j++) {
       THcRawHit* rawhit=0;
 
-      Int_t chan = evdata.GetNextChan( d->crate, d->slot, j );
+      UInt_t chan = evdata.GetNextChan( d->crate, d->slot, j );
       if( chan < d->lo || chan > d->hi ) continue;     // Not one of my channels
 
       // Need to convert crate, slot, chan into plane, counter, signal
@@ -353,20 +353,20 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
       // Get the data from this channel
       // Allow for multiple hits
       if(signaltype == THcRawHit::kTDC || !multifunction) {
-	Int_t nMHits = evdata.GetNumHits(d->crate, d->slot, chan);
-	for (Int_t mhit = 0; mhit < nMHits; mhit++) {
-	  Int_t data = evdata.GetData( d->crate, d->slot, chan, mhit);
+	UInt_t nMHits = evdata.GetNumHits(d->crate, d->slot, chan);
+	for (UInt_t mhit = 0; mhit < nMHits; mhit++) {
+          UInt_t data = evdata.GetData( d->crate, d->slot, chan, mhit);
 	  // cout << "Signal " << signal << "=" << data << endl;
 	  rawhit->SetData(signal,data);
 	}
 	// Get the reference time.
 	if(d->refchan >= 0) {
-	  Int_t nrefhits = evdata.GetNumHits(d->crate,d->slot,d->refchan);
+	  UInt_t nrefhits = evdata.GetNumHits(d->crate,d->slot,d->refchan);
 	  Bool_t goodreftime=kFALSE;
 	  Int_t reftime=0;
 	  Int_t prevtime=0;
 	  Int_t difftime=0;
-	  for(Int_t ihit=0; ihit<nrefhits; ihit++) {
+	  for(UInt_t ihit=0; ihit<nrefhits; ihit++) {
 	    reftime = evdata.GetData(d->crate, d->slot, d->refchan, ihit);
 	    if (ihit != 0 ) difftime=reftime-prevtime;
               prevtime = reftime;
@@ -418,16 +418,16 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
         }
 	
 	// Copy the samples
-	Int_t nsamples=evdata.GetNumEvents(Decoder::kSampleADC, d->crate, d->slot, chan);
+	UInt_t nsamples=evdata.GetNumEvents(Decoder::kSampleADC, d->crate, d->slot, chan);
 
 	// If nsamples comes back zero, may want to suppress further attempts to
 	// get sample data for this or all modules
-	for (Int_t isamp=0;isamp<nsamples;isamp++) {
+	for (UInt_t isamp=0;isamp<nsamples;isamp++) {
 	  rawhit->SetSample(signal,evdata.GetData(Decoder::kSampleADC, d->crate, d->slot, chan, isamp));
 	}
 	// Now get the pulse mode data
 	// Pulse area will go into regular SetData, others will use special hit methods
-	Int_t npulses=evdata.GetNumEvents(Decoder::kPulseIntegral, d->crate, d->slot, chan);
+	UInt_t npulses=evdata.GetNumEvents(Decoder::kPulseIntegral, d->crate, d->slot, chan);
 	// Assume that the # of pulses for kPulseTime, kPulsePeak and kPulsePedestal are same;
 	Int_t timeshift=0;
 	if(fTISlot>0) {		// Get the trigger time for this module
@@ -440,7 +440,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
 	  }
 	  timeshift = fTrigTimeShiftMap[d->slot];
 	}
-	for (Int_t ipulse=0;ipulse<npulses;ipulse++) {
+	for (UInt_t ipulse=0;ipulse<npulses;ipulse++) {
 	  rawhit->SetDataTimePedestalPeak(signal,
 					  evdata.GetData(Decoder::kPulseIntegral, d->crate, d->slot, chan, ipulse),
 					  evdata.GetData(Decoder::kPulseTime, d->crate, d->slot, chan, ipulse)+64*timeshift,
@@ -449,8 +449,8 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
 	}
 	// Get the reference time for the FADC pulse time
 	if(d->refchan >= 0) {	// Reference time for the slot
-	  Int_t nrefhits = evdata.GetNumEvents(Decoder::kPulseIntegral,
-					       d->crate, d->slot, d->refchan);
+	  UInt_t nrefhits = evdata.GetNumEvents(Decoder::kPulseIntegral,
+                                                d->crate, d->slot, d->refchan);
 	  Bool_t goodreftime=kFALSE;
 	  Int_t reftime = 0;
 	  Int_t prevtime = 0;
@@ -466,7 +466,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
 	    }
 	    timeshift = fTrigTimeShiftMap[d->slot];
 	  }
-	  for(Int_t ihit=0; ihit<nrefhits; ihit++) {
+	  for(UInt_t ihit=0; ihit<nrefhits; ihit++) {
 	    reftime = evdata.GetData(Decoder::kPulseTime, d->crate, d->slot, d->refchan, ihit);
 	    reftime += 64*timeshift;
 	    if (ihit != 0) difftime=reftime-prevtime;

--- a/src/THcHodoscope.cxx
+++ b/src/THcHodoscope.cxx
@@ -111,7 +111,7 @@ void THcHodoscope::Setup(const char* name, const char* description)
 
   cout << "Plane Name List : " << planenamelist << endl;
 
-  vector<string> plane_names = vsplit(planenamelist);
+  vector<string> plane_names = Podd::vsplit(planenamelist);
   // Plane names
   if(plane_names.size() != (UInt_t) fNPlanes) {
     cout << "ERROR: Number of planes " << fNPlanes << " doesn't agree with number of plane names " << plane_names.size() << endl;

--- a/src/THcParmList.cxx
+++ b/src/THcParmList.cxx
@@ -16,7 +16,7 @@ This class is built on THaVarList, adding a method to load the list of
 parameters from Hall C ENGINE style CTP parameter files and a method
 to retrieve a set of parameters from the list.
 
-An instance of THaTextvars is created to hold the string parameters.
+An instance of Podd::Textvars is created to hold the string parameters.
 
 \fn THcParmList::Load( const char* fname, Int_t RunNumber )
 \brief Load the parameter cache by reading a CTP style parameter file.
@@ -72,7 +72,7 @@ ClassImp(THcParmList)
 /// Create empty numerical and string parameter lists
 THcParmList::THcParmList() : THaVarList()
 {
-  TextList = new THaTextvars;
+  TextList = new Podd::Textvars;
 }
 
 inline static bool IsComment( const string& s, string::size_type pos )

--- a/src/THcParmList.h
+++ b/src/THcParmList.h
@@ -8,7 +8,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "THaVarList.h"
-#include "THaTextvars.h"
+#include "Textvars.h"
 
 #ifdef WITH_CCDB
 #ifdef __CINT__
@@ -61,7 +61,7 @@ public:
 
 private:
 
-  THaTextvars* TextList;  //! Dictionary of string parameters
+  Podd::Textvars* TextList;  //! Dictionary of string parameters
 
 #ifdef WITH_CCDB
   SQLiteCalibration* CCDB_obj;

--- a/src/THcScalerEvtHandler.cxx
+++ b/src/THcScalerEvtHandler.cxx
@@ -254,8 +254,8 @@ Int_t THcScalerEvtHandler::Analyze(THaEvData *evdata)
 
   UInt_t *rdata = (UInt_t*) evdata->GetRawDataBuffer();
 
-  if( evdata->GetEvType() == fDelayedType) { // Save this event for processing later
-    Int_t evlen = evdata->GetEvLength();
+  if( (Int_t)evdata->GetEvType() == fDelayedType) { // Save this event for processing later
+    UInt_t evlen = evdata->GetEvLength();
     
     UInt_t *datacopy = new UInt_t[evlen];
     fDelayedEvents.push_back(datacopy);

--- a/src/THcScalerEvtHandler.cxx
+++ b/src/THcScalerEvtHandler.cxx
@@ -176,7 +176,7 @@ Int_t THcScalerEvtHandler::ReadDatabase(const TDatime& date )
       fBCM_SatQuadratic[i]=0.;
     }
     gHcParms->LoadParmValues((DBRequest*)&list2, prefix);
-    vector<string> bcm_names = vsplit(bcm_namelist);
+    vector<string> bcm_names = Podd::vsplit(bcm_namelist);
     for(Int_t i=0;i<fNumBCMs;i++) {
       fBCM_Name.push_back(bcm_names[i]+".scal");
       fBCM_delta_charge[i]=0.;
@@ -660,7 +660,7 @@ THaAnalysisObject::EStatus THcScalerEvtHandler::Init(const TDatime& date)
   TString sname;
   sname = fName+sname0;
 
-  FILE *fi = OpenFile(sname.Data(), date);
+  FILE *fi = Podd::OpenDBFile(sname.Data(), date);
   if ( !fi ) {
     cout << "Cannot find db file for "<<fName<<" scaler event handler"<<endl;
     return kFileError;
@@ -677,7 +677,7 @@ THaAnalysisObject::EStatus THcScalerEvtHandler::Init(const TDatime& date)
     std::string sin(cbuf);
     std::string sinput(sin.substr(0,sin.find_first_of("#")));
     if (fDebugFile) *fDebugFile << "string input "<<sinput<<endl;
-    dbline = vsplit(sinput);
+    dbline = Podd::vsplit(sinput);
     if (dbline.size() > 0) {
       pos1 = FindNoCase(dbline[0],scomment);
       if (pos1 != minus1) continue;

--- a/src/THcShower.cxx
+++ b/src/THcShower.cxx
@@ -84,7 +84,7 @@ void THcShower::Setup(const char* name, const char* description)
   fADC_RefTimeCut = 0;
   gHcParms->LoadParmValues((DBRequest*)&list,prefix);
   fNTotLayers = (fNLayers+(fHasArray!=0?1:0));
-  vector<string> layer_names = vsplit(layernamelist);
+  vector<string> layer_names = Podd::vsplit(layernamelist);
 
   if(layer_names.size() != fNTotLayers) {
     cout << "THcShower::Setup ERROR: Number of layers " << fNTotLayers

--- a/src/THcTrigDet.cxx
+++ b/src/THcTrigDet.cxx
@@ -362,10 +362,10 @@ Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
     //    cout << ip << " " << fTdcNames.at(ip) << " " << fTdcTimeWindowMin[ip] << " " << fTdcTimeWindowMax[ip] << endl;
   }
   // Split the names to std::vector<std::string>.
-  fAdcNames = vsplit(adcNames);
-  fTdcNames = vsplit(tdcNames);
-  fTrigNames = vsplit(trigNames);
-  fRFNames = vsplit(RFNames); // SJDK 12/04/21 - For RF getter
+  fAdcNames = Podd::vsplit(adcNames);
+  fTdcNames = Podd::vsplit(tdcNames);
+  fTrigNames = Podd::vsplit(trigNames);
+  fRFNames = Podd::vsplit(RFNames); // SJDK 12/04/21 - For RF getter
   //default index values
  
   //Assign an index to coincidence trigger times strings

--- a/src/TIBlobModule.h
+++ b/src/TIBlobModule.h
@@ -22,23 +22,22 @@ class TIBlobModule : public PipeliningModule {
 public:
 
    TIBlobModule() : PipeliningModule() {}
-   TIBlobModule(Int_t crate, Int_t slot);
+   TIBlobModule(UInt_t crate, UInt_t slot);
    virtual ~TIBlobModule();
 
    using Module::GetData;
-   using Module::LoadSlot;
 
-   virtual UInt_t GetData(Int_t chan) const;
+   virtual UInt_t GetData(UInt_t chan) const;
    virtual void Init();
    virtual void Clear(const Option_t *opt="");
    virtual Int_t Decode(const UInt_t*) { return 0; }
-   virtual Int_t LoadSlot(THaSlotData *sldat,  const UInt_t *evbuffer, const UInt_t *pstop );
-   virtual Int_t LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, Int_t pos, Int_t len);
-   Int_t LoadNextEvBuffer(THaSlotData *sldat);
-   Int_t LoadThisBlock(THaSlotData *sldat, std::vector<UInt_t > evb);
+   virtual UInt_t LoadSlot( THaSlotData *sldat, const UInt_t *evbuffer, const UInt_t *pstop );
+   virtual UInt_t LoadSlot( THaSlotData *sldat, const UInt_t* evbuffer, UInt_t pos, UInt_t len);
+   virtual UInt_t LoadNextEvBuffer(THaSlotData *sldat);
+   virtual UInt_t LoadThisBlock( THaSlotData *sldat, const std::vector<UInt_t>& evbuffer);
  
  protected:
-   Int_t SplitBuffer(std::vector< UInt_t > bigbuffer);
+   virtual Int_t SplitBuffer( const std::vector<UInt_t>& bigbuffer);
 
  private:
 


### PR DESCRIPTION
Update to Podd 1.7.0-rc5

Version rc5 includes:
- Refactored database API (can now be used independently of Podd, e.g. by standalone Decoder)
- Ability to pass arbitrary configuration parameters to decoder modules through the crate map file
- Dynamic resizing of the decoder event buffer dependent on input event size, which can now be unlimited in principle. (There is a hardcoded 1 GiB sanity limit.)
    
Because of API changes, the following 1-to-1 replacements were necessary in the hcana sources:
    
```
#include "THaTextvars.h" -> #include "Textvars.h"
THaTextvars -> Podd::Textvars
vsplit -> Podd::vsplit
OpenFile -> Podd::OpenDBFile
```
This PR also includes all the changes from my previous PR #469.