### PR TITLE
Firmware update

### DIFF
--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -520,7 +520,7 @@ Int_t THcCherenkov::CoarseProcess( TClonesArray&  )
               fAdcPulseAmpTest[npmt] = pulseAmp;
 	  }
         } else {
-	  fAdcGoodElem[npmt]=ielem;
+	  if (pulseTimeCut) fAdcGoodElem[npmt]=ielem;
         }
   }
   // Loop over the npmt

--- a/src/THcCherenkov.cxx
+++ b/src/THcCherenkov.cxx
@@ -592,7 +592,7 @@ Int_t THcCherenkov::CoarseProcess( TClonesArray&  )
               fAdcPulseAmpTest[npmt] = pulseAmp;
 	  }
         } else {
-	  if (pulseTimeCut) fAdcGoodElem[npmt]=ielem;
+	  fAdcGoodElem[npmt]=ielem;
         }
   }
   // Loop over the npmt

--- a/src/THcCoinTime.cxx
+++ b/src/THcCoinTime.cxx
@@ -66,13 +66,13 @@ void THcCoinTime::Clear( Option_t* opt )
   fROC1_RAW_CoinTime=kBig;
   fROC2_RAW_CoinTime=kBig;
   fTRIG1_ePosCoinTime=kBig;
-  fTRIG4_ePosCoinTime=kBig;
+  fTRIG3_ePosCoinTime=kBig;
   fTRIG1_ePiCoinTime=kBig;
-  fTRIG4_ePiCoinTime=kBig;
+  fTRIG3_ePiCoinTime=kBig;
   fTRIG1_eKCoinTime=kBig;
-  fTRIG4_eKCoinTime=kBig;
+  fTRIG3_eKCoinTime=kBig;
   fTRIG1_epCoinTime=kBig;
-  fTRIG4_epCoinTime=kBig;
+  fTRIG3_epCoinTime=kBig;
 }
 
 //_____________________________________________________________________________
@@ -167,31 +167,33 @@ Int_t THcCoinTime::DefineVariables( EMode mode )
     {"epCoinTime_ROC1",    "ROC1 Corrected ep Coincidence Time",  "fROC1_epCoinTime"},
     {"epCoinTime_ROC2",    "ROC2 Corrected ep Coincidence Time",  "fROC2_epCoinTime"},
     {"epCoinTime_TRIG1",    "TRIG1 Corrected ep Coincidence Time",  "fTRIG1_epCoinTime"},
-    {"epCoinTime_TRIG4",    "TRIG4 Corrected ep Coincidence Time",  "fTRIG4_epCoinTime"},
+    {"epCoinTime_TRIG3",    "TRIG3 Corrected ep Coincidence Time",  "fTRIG3_epCoinTime"},
   
     {"eKCoinTime_ROC1",    "ROC1 Corrected eK Coincidence Time",  "fROC1_eKCoinTime"},
     {"eKCoinTime_ROC2",    "ROC2 Corrected eK Coincidence Time",  "fROC2_eKCoinTime"},
     {"eKCoinTime_TRIG1",    "TRIG1 Corrected eK Coincidence Time",  "fTRIG1_eKCoinTime"},
-    {"eKCoinTime_TRIG4",    "TRIG4 Corrected eK Coincidence Time",  "fTRIG4_eKCoinTime"},
+    {"eKCoinTime_TRIG3",    "TRIG3 Corrected eK Coincidence Time",  "fTRIG3_eKCoinTime"},
     
     {"ePiCoinTime_ROC1",    "ROC1 Corrected ePi Coincidence Time",  "fROC1_ePiCoinTime"},
     {"ePiCoinTime_ROC2",    "ROC2 Corrected ePi Coincidence Time",  "fROC2_ePiCoinTime"},
     {"ePiCoinTime_TRIG1",    "TRIG1 Corrected ePi Coincidence Time",  "fTRIG1_ePiCoinTime"},
-    {"ePiCoinTime_TRIG4",    "TRIG4 Corrected ePi Coincidence Time",  "fTRIG4_ePiCoinTime"},
+    {"ePiCoinTime_TRIG3",    "TRIG3 Corrected ePi Coincidence Time",  "fTRIG3_ePiCoinTime"},
       
     {"ePositronCoinTime_ROC1",    "ROC1 Corrected e-Positorn Coincidence Time",  "fROC1_ePosCoinTime"},
     {"ePositronCoinTime_ROC2",    "ROC2 Corrected e-Positron Coincidence Time",  "fROC2_ePosCoinTime"},
     {"ePositronCoinTime_TRIG1",    "TRIG1 Corrected e-Positorn Coincidence Time",  "fTRIG1_ePosCoinTime"},
-    {"ePositronCoinTime_TRIG4",    "TRIG4 Corrected e-Positron Coincidence Time",  "fTRIG4_ePosCoinTime"},
+    {"ePositronCoinTime_TRIG3",    "TRIG3 Corrected e-Positron Coincidence Time",  "fTRIG3_ePosCoinTime"},
     
     {"CoinTime_RAW_ROC1",    "ROC1 RAW Coincidence Time",  "fROC1_RAW_CoinTime"},
     {"CoinTime_RAW_ROC2",    "ROC2 RAW Coincidence Time",  "fROC2_RAW_CoinTime"},
     {"CoinTime_RAW_TRIG1",    "TRIG1 RAW Coincidence Time",  "fTRIG1_RAW_CoinTime"},
-    {"CoinTime_RAW_TRIG4",    "TRIG4 RAW Coincidence Time",  "fTRIG4_RAW_CoinTime"},
+    {"CoinTime_RAW_TRIG3",    "TRIG3 RAW Coincidence Time",  "fTRIG3_RAW_CoinTime"},
     {"DeltaSHMSPathLength","DeltaSHMSpathLength (cm)","DeltaSHMSpathLength"},
     {"DeltaHMSPathLength", "DeltaHMSpathLength (cm)","DeltaHMSpathLength"},
     {"had_coinCorr_Positron",    "",  "had_coinCorr_Positron"},
     {"elec_coinCorr",    "",  "elec_coinCorr"},
+
+
     { 0 }
   };
 
@@ -237,16 +239,20 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
   kaonMass = 493.677/1000.0;    //charged kaon mass in GeV/c^2
   pionMass = 139.570/1000.0;    //charged pion mass in GeV/c^2
 
- 
+
   //Check if there was a golden track in both arms
   if (!theSHMSTrack || !theHMSTrack)
     {
       return 1;
     }
 
+
   //Check if Database is reading the correct elec-arm particle mass
-  if (felecSpectro->GetParticleMass() > 0.00052) return 1;
-        
+  if (felecSpectro->GetParticleMass() > 0.00052) {
+    cout << "ERROR CHECK PARTICLE MASS IN STANDARD.KINEMATICS ! ! !" << endl;
+    return 1;
+  }
+
       //SHMS arm
       Double_t shms_xptar = theSHMSTrack->GetTTheta();     
       Double_t shms_dP = theSHMSTrack->GetDp();            
@@ -265,10 +271,10 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
       
       //Get raw TDC Times for HMS/SHMS (3/4 trigger)
       pTRIG1_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(0);  //SHMS
-      pTRIG4_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(1);  //HMS
+      pTRIG3_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(1);  //HMS
       pTRIG1_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(2);//SHMS
-      pTRIG4_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(3);//HMS
-
+      pTRIG3_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(3);//HMS
+      	  
       DeltaSHMSpathLength = .11*shms_xptar*1000 +0.057*shms_dP/100.;
       DeltaHMSpathLength = -1.0*(12.462*hms_xpfp + 0.1138*hms_xpfp*hms_xfp - 0.0154*hms_xfp - 72.292*hms_xpfp*hms_xpfp - 0.0000544*hms_xfp*had_xfp - 116.52*hms_ypfp*hms_ypfp);
       DeltaHMSpathLength = (.12*hms_xptar*1000 +0.17*hms_dP/100.);
@@ -293,7 +299,6 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
 	  hadArm_BetaCalc_Pion = had_P / sqrt(had_P*had_P + pionMass*pionMass);	
 	  hadArm_BetaCalc_Positron = had_P / sqrt(had_P*had_P + positronMass*positronMass);
 
-
 	  //Coincidence Corrections
 	  elec_coinCorr = (ElecPathLength) / (lightSpeed * elecArm_BetaCalc );
 	  had_coinCorr_proton = (HadPathLength) / (lightSpeed * hadArm_BetaCalc_proton );
@@ -302,36 +307,35 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
 	  had_coinCorr_Positron = (HadPathLength) / (lightSpeed * hadArm_BetaCalc_Positron );
 
 	  //Raw, Uncorrected Coincidence Time
-	  fROC1_RAW_CoinTime =  (pTRIG1_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG4_TdcTime_ROC1 + HMS_FPtime);
-	  fROC2_RAW_CoinTime =  (pTRIG1_TdcTime_ROC2 + SHMS_FPtime) - (pTRIG4_TdcTime_ROC2 + HMS_FPtime);
+	  fROC1_RAW_CoinTime =  (pTRIG1_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG3_TdcTime_ROC1 + HMS_FPtime);
+	  fROC2_RAW_CoinTime =  (pTRIG1_TdcTime_ROC2 + SHMS_FPtime) - (pTRIG3_TdcTime_ROC2 + HMS_FPtime);
 	  fTRIG1_RAW_CoinTime =  (pTRIG1_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG1_TdcTime_ROC2 + HMS_FPtime);
-	  fTRIG4_RAW_CoinTime =  (pTRIG4_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG4_TdcTime_ROC2 + HMS_FPtime);
-	   
+	  fTRIG3_RAW_CoinTime =  (pTRIG3_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG3_TdcTime_ROC2 + HMS_FPtime);
 	  //Corrected Coincidence Time for ROC1/ROC2 (ROC1 Should be identical to ROC2)
           // 
 	  //PROTON
 	  fROC1_epCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
 	  fROC2_epCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
 	  fTRIG1_epCoinTime = fTRIG1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
-	  fTRIG4_epCoinTime = fTRIG4_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
+	  fTRIG3_epCoinTime = fTRIG3_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
 
 	  //KAON
 	  fROC1_eKCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
 	  fROC2_eKCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
 	  fTRIG1_eKCoinTime = fTRIG1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
-	  fTRIG4_eKCoinTime = fTRIG4_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
+	  fTRIG3_eKCoinTime = fTRIG3_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
 	
 	  //PION
 	  fROC1_ePiCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;	  
 	  fROC2_ePiCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;
 	  fTRIG1_ePiCoinTime = fTRIG1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;	  
-	  fTRIG4_ePiCoinTime = fTRIG4_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;
+	  fTRIG3_ePiCoinTime = fTRIG3_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;
 
 	  //POSITRON
 	  fROC1_ePosCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset ;	  
 	  fROC2_ePosCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
 	  fTRIG1_ePosCoinTime = fTRIG1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset ;	  
-	  fTRIG4_ePosCoinTime = fTRIG4_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
+	  fTRIG3_ePosCoinTime = fTRIG3_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
          
   return 0;
 }

--- a/src/THcCoinTime.cxx
+++ b/src/THcCoinTime.cxx
@@ -66,14 +66,14 @@ void THcCoinTime::Clear( Option_t* opt )
   fROC2_ePosCoinTime=kBig;
   fROC1_RAW_CoinTime=kBig;
   fROC2_RAW_CoinTime=kBig;
-  fTRIG1_ePosCoinTime=kBig;
-  fTRIG3_ePosCoinTime=kBig;
-  fTRIG1_ePiCoinTime=kBig;
-  fTRIG3_ePiCoinTime=kBig;
-  fTRIG1_eKCoinTime=kBig;
-  fTRIG3_eKCoinTime=kBig;
-  fTRIG1_epCoinTime=kBig;
-  fTRIG3_epCoinTime=kBig;
+  fSHMS_ePosCoinTime=kBig;
+  fHMS_ePosCoinTime=kBig;
+  fSHMS_ePiCoinTime=kBig;
+  fHMS_ePiCoinTime=kBig;
+  fSHMS_eKCoinTime=kBig;
+  fHMS_eKCoinTime=kBig;
+  fSHMS_epCoinTime=kBig;
+  fHMS_epCoinTime=kBig;
 }
 
 //_____________________________________________________________________________
@@ -121,9 +121,7 @@ THaAnalysisObject::EStatus THcCoinTime::Init( const TDatime& run_time )
     fStatus = kInitError;
     return fStatus;
   }
-  
-
-  
+    
   if( (fStatus=THaPhysicsModule::Init( run_time )) != kOK ) {
     return fStatus;
   }
@@ -148,7 +146,6 @@ Int_t THcCoinTime::ReadDatabase( const TDatime& date )
 
   HMScentralPathLen = 22.0*100.;
   SHMScentralPathLen = 18.1*100.;
-
   
   gHcParms->LoadParmValues((DBRequest*)&list, "");
 
@@ -165,28 +162,28 @@ Int_t THcCoinTime::DefineVariables( EMode mode )
   const RVarDef vars[] = {
     {"epCoinTime_ROC1",    "ROC1 Corrected ep Coincidence Time",  "fROC1_epCoinTime"},
     {"epCoinTime_ROC2",    "ROC2 Corrected ep Coincidence Time",  "fROC2_epCoinTime"},
-    {"epCoinTime_TRIG1",    "TRIG1 Corrected ep Coincidence Time",  "fTRIG1_epCoinTime"},
-    {"epCoinTime_TRIG3",    "TRIG3 Corrected ep Coincidence Time",  "fTRIG3_epCoinTime"},
+    {"epCoinTime_SHMS",    "SHMS Corrected ep Coincidence Time",  "fSHMS_epCoinTime"},
+    {"epCoinTime_TRIG3",    "TRIG3 Corrected ep Coincidence Time",  "fHMS_epCoinTime"},
   
     {"eKCoinTime_ROC1",    "ROC1 Corrected eK Coincidence Time",  "fROC1_eKCoinTime"},
     {"eKCoinTime_ROC2",    "ROC2 Corrected eK Coincidence Time",  "fROC2_eKCoinTime"},
-    {"eKCoinTime_TRIG1",    "TRIG1 Corrected eK Coincidence Time",  "fTRIG1_eKCoinTime"},
-    {"eKCoinTime_TRIG3",    "TRIG3 Corrected eK Coincidence Time",  "fTRIG3_eKCoinTime"},
+    {"eKCoinTime_SHMS",    "SHMS Corrected eK Coincidence Time",  "fSHMS_eKCoinTime"},
+    {"eKCoinTime_TRIG3",    "TRIG3 Corrected eK Coincidence Time",  "fHMS_eKCoinTime"},
     
     {"ePiCoinTime_ROC1",    "ROC1 Corrected ePi Coincidence Time",  "fROC1_ePiCoinTime"},
     {"ePiCoinTime_ROC2",    "ROC2 Corrected ePi Coincidence Time",  "fROC2_ePiCoinTime"},
-    {"ePiCoinTime_TRIG1",    "TRIG1 Corrected ePi Coincidence Time",  "fTRIG1_ePiCoinTime"},
-    {"ePiCoinTime_TRIG3",    "TRIG3 Corrected ePi Coincidence Time",  "fTRIG3_ePiCoinTime"},
+    {"ePiCoinTime_SHMS",    "SHMS Corrected ePi Coincidence Time",  "fSHMS_ePiCoinTime"},
+    {"ePiCoinTime_TRIG3",    "TRIG3 Corrected ePi Coincidence Time",  "fHMS_ePiCoinTime"},
       
     {"ePositronCoinTime_ROC1",    "ROC1 Corrected e-Positorn Coincidence Time",  "fROC1_ePosCoinTime"},
     {"ePositronCoinTime_ROC2",    "ROC2 Corrected e-Positron Coincidence Time",  "fROC2_ePosCoinTime"},
-    {"ePositronCoinTime_TRIG1",    "TRIG1 Corrected e-Positorn Coincidence Time",  "fTRIG1_ePosCoinTime"},
-    {"ePositronCoinTime_TRIG3",    "TRIG3 Corrected e-Positron Coincidence Time",  "fTRIG3_ePosCoinTime"},
+    {"ePositronCoinTime_SHMS",    "SHMS Corrected e-Positorn Coincidence Time",  "fSHMS_ePosCoinTime"},
+    {"ePositronCoinTime_TRIG3",    "TRIG3 Corrected e-Positron Coincidence Time",  "fHMS_ePosCoinTime"},
     
     {"CoinTime_RAW_ROC1",    "ROC1 RAW Coincidence Time",  "fROC1_RAW_CoinTime"},
     {"CoinTime_RAW_ROC2",    "ROC2 RAW Coincidence Time",  "fROC2_RAW_CoinTime"},
-    {"CoinTime_RAW_TRIG1",    "TRIG1 RAW Coincidence Time",  "fTRIG1_RAW_CoinTime"},
-    {"CoinTime_RAW_TRIG3",    "TRIG3 RAW Coincidence Time",  "fTRIG3_RAW_CoinTime"},
+    {"CoinTime_RAW_SHMS",    "SHMS RAW Coincidence Time",  "fSHMS_RAW_CoinTime"},
+    {"CoinTime_RAW_TRIG3",    "TRIG3 RAW Coincidence Time",  "fHMS_RAW_CoinTime"},
     {"DeltaSHMSPathLength","DeltaSHMSpathLength (cm)","DeltaSHMSpathLength"},
     {"DeltaHMSPathLength", "DeltaHMSpathLength (cm)","DeltaHMSpathLength"},
     {"had_coinCorr_Positron",    "",  "had_coinCorr_Positron"},
@@ -198,8 +195,6 @@ Int_t THcCoinTime::DefineVariables( EMode mode )
   return DefineVarsFromList( vars, mode );
 
 }
-
-
 
 //_____________________________________________________________________________
 Int_t THcCoinTime::Process( const THaEvData& evdata )
@@ -266,10 +261,10 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
       if (SHMS_FPtime==-1000 || HMS_FPtime==-1000)  return 1;
       
       //Get raw TDC Times for HMS/SHMS (3/4 trigger)
-      pTRIG1_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(0);  //SHMS
-      pTRIG3_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(1);  //HMS
-      pTRIG1_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(2);//SHMS
-      pTRIG3_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(3);//HMS
+      pSHMS_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(0);  //SHMS
+      pHMS_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(1);  //HMS
+      pSHMS_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(2);//SHMS pTRIG1
+      pHMS_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(3);//HMS pTRIG3
       	  
       DeltaSHMSpathLength = .11*shms_xptar*1000 +0.057*shms_dP/100.;
       DeltaHMSpathLength = -1.0*(12.462*hms_xpfp + 0.1138*hms_xpfp*hms_xfp - 0.0154*hms_xfp - 72.292*hms_xpfp*hms_xpfp - 0.0000544*hms_xfp*had_xfp - 116.52*hms_ypfp*hms_ypfp);
@@ -288,6 +283,7 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
              had_P = theSHMSTrack->GetP();              //hadron golden track arm momentum
              sign=1;
 	  }
+
 	  //beta calculations beta = v/c = p/E
 	  elecArm_BetaCalc = elec_P / sqrt(elec_P*elec_P + elecMass*elecMass);
 	  hadArm_BetaCalc_proton = had_P / sqrt(had_P*had_P + protonMass*protonMass);
@@ -303,35 +299,35 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
 	  had_coinCorr_Positron = (HadPathLength) / (lightSpeed * hadArm_BetaCalc_Positron );
 
 	  //Raw, Uncorrected Coincidence Time
-	  fROC1_RAW_CoinTime =  (pTRIG1_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG3_TdcTime_ROC1 + HMS_FPtime);
-	  fROC2_RAW_CoinTime =  (pTRIG1_TdcTime_ROC2 + SHMS_FPtime) - (pTRIG3_TdcTime_ROC2 + HMS_FPtime);
-	  fTRIG1_RAW_CoinTime =  (pTRIG1_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG1_TdcTime_ROC2 + HMS_FPtime);
-	  fTRIG3_RAW_CoinTime =  (pTRIG3_TdcTime_ROC1 + SHMS_FPtime) - (pTRIG3_TdcTime_ROC2 + HMS_FPtime);
+	  fROC1_RAW_CoinTime =  (pSHMS_TdcTime_ROC1 + SHMS_FPtime) - (pHMS_TdcTime_ROC1 + HMS_FPtime);
+	  fROC2_RAW_CoinTime =  (pSHMS_TdcTime_ROC2 + SHMS_FPtime) - (pHMS_TdcTime_ROC2 + HMS_FPtime);
+	  fSHMS_RAW_CoinTime =  (pSHMS_TdcTime_ROC1 + SHMS_FPtime) - (pSHMS_TdcTime_ROC2 + HMS_FPtime);
+	  fHMS_RAW_CoinTime =  (pHMS_TdcTime_ROC1 + SHMS_FPtime) - (pHMS_TdcTime_ROC2 + HMS_FPtime);
 	  //Corrected Coincidence Time for ROC1/ROC2 (ROC1 Should be identical to ROC2)
           // 
 	  //PROTON
 	  fROC1_epCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
 	  fROC2_epCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
-	  fTRIG1_epCoinTime = fTRIG1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
-	  fTRIG3_epCoinTime = fTRIG3_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
+	  fSHMS_epCoinTime = fSHMS_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
+	  fHMS_epCoinTime = fHMS_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - eHad_CT_Offset; 
 
 	  //KAON
 	  fROC1_eKCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
 	  fROC2_eKCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
-	  fTRIG1_eKCoinTime = fTRIG1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
-	  fTRIG3_eKCoinTime = fTRIG3_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
+	  fSHMS_eKCoinTime = fSHMS_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
+	  fHMS_eKCoinTime = fHMS_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_Kaon) - eHad_CT_Offset;
 	
 	  //PION
 	  fROC1_ePiCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;	  
 	  fROC2_ePiCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;
-	  fTRIG1_ePiCoinTime = fTRIG1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;	  
-	  fTRIG3_ePiCoinTime = fTRIG3_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;
+	  fSHMS_ePiCoinTime = fSHMS_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;	  
+	  fHMS_ePiCoinTime = fHMS_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;
 
 	  //POSITRON
 	  fROC1_ePosCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset ;	  
 	  fROC2_ePosCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
-	  fTRIG1_ePosCoinTime = fTRIG1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset ;	  
-	  fTRIG3_ePosCoinTime = fTRIG3_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
+	  fSHMS_ePosCoinTime = fSHMS_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset ;	  
+	  fHMS_ePosCoinTime = fHMS_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
          
   return 0;
 }

--- a/src/THcCoinTime.cxx
+++ b/src/THcCoinTime.cxx
@@ -2,6 +2,7 @@
     \ingroup PhysMods
 
 \brief Class for calculating and adding the Coincidence Time in the Tree.
+// SJDK - 08/09/21 - Switched Trig4 to Trig3 due to hardware changes
 
 //Author: Carlos Yero
 //Date: April 27, 2018
@@ -134,8 +135,6 @@ THaAnalysisObject::EStatus THcCoinTime::Init( const TDatime& run_time )
 Int_t THcCoinTime::ReadDatabase( const TDatime& date )
 {
   // Read database. Gets variable needed for CoinTime calculation
-
-
   DBRequest list[]={
     {"eHadCoinTime_Offset",  &eHad_CT_Offset, kDouble, 0, 1},   //coin time offset for ep coincidences
 
@@ -193,7 +192,6 @@ Int_t THcCoinTime::DefineVariables( EMode mode )
     {"had_coinCorr_Positron",    "",  "had_coinCorr_Positron"},
     {"elec_coinCorr",    "",  "elec_coinCorr"},
 
-
     { 0 }
   };
 
@@ -239,13 +237,11 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
   kaonMass = 493.677/1000.0;    //charged kaon mass in GeV/c^2
   pionMass = 139.570/1000.0;    //charged pion mass in GeV/c^2
 
-
   //Check if there was a golden track in both arms
   if (!theSHMSTrack || !theHMSTrack)
     {
       return 1;
     }
-
 
   //Check if Database is reading the correct elec-arm particle mass
   if (felecSpectro->GetParticleMass() > 0.00052) {

--- a/src/THcCoinTime.cxx
+++ b/src/THcCoinTime.cxx
@@ -163,27 +163,31 @@ Int_t THcCoinTime::DefineVariables( EMode mode )
     {"epCoinTime_ROC1",    "ROC1 Corrected ep Coincidence Time",  "fROC1_epCoinTime"},
     {"epCoinTime_ROC2",    "ROC2 Corrected ep Coincidence Time",  "fROC2_epCoinTime"},
     {"epCoinTime_SHMS",    "SHMS Corrected ep Coincidence Time",  "fSHMS_epCoinTime"},
-    {"epCoinTime_TRIG3",    "TRIG3 Corrected ep Coincidence Time",  "fHMS_epCoinTime"},
+    {"epCoinTime_HMS",    "HMS Corrected ep Coincidence Time",  "fHMS_epCoinTime"},
   
     {"eKCoinTime_ROC1",    "ROC1 Corrected eK Coincidence Time",  "fROC1_eKCoinTime"},
     {"eKCoinTime_ROC2",    "ROC2 Corrected eK Coincidence Time",  "fROC2_eKCoinTime"},
     {"eKCoinTime_SHMS",    "SHMS Corrected eK Coincidence Time",  "fSHMS_eKCoinTime"},
-    {"eKCoinTime_TRIG3",    "TRIG3 Corrected eK Coincidence Time",  "fHMS_eKCoinTime"},
+    {"eKCoinTime_HMS",    "HMS Corrected eK Coincidence Time",  "fHMS_eKCoinTime"},
     
     {"ePiCoinTime_ROC1",    "ROC1 Corrected ePi Coincidence Time",  "fROC1_ePiCoinTime"},
     {"ePiCoinTime_ROC2",    "ROC2 Corrected ePi Coincidence Time",  "fROC2_ePiCoinTime"},
     {"ePiCoinTime_SHMS",    "SHMS Corrected ePi Coincidence Time",  "fSHMS_ePiCoinTime"},
-    {"ePiCoinTime_TRIG3",    "TRIG3 Corrected ePi Coincidence Time",  "fHMS_ePiCoinTime"},
+    {"ePiCoinTime_HMS",    "HMS Corrected ePi Coincidence Time",  "fHMS_ePiCoinTime"},
       
     {"ePositronCoinTime_ROC1",    "ROC1 Corrected e-Positorn Coincidence Time",  "fROC1_ePosCoinTime"},
     {"ePositronCoinTime_ROC2",    "ROC2 Corrected e-Positron Coincidence Time",  "fROC2_ePosCoinTime"},
     {"ePositronCoinTime_SHMS",    "SHMS Corrected e-Positorn Coincidence Time",  "fSHMS_ePosCoinTime"},
-    {"ePositronCoinTime_TRIG3",    "TRIG3 Corrected e-Positron Coincidence Time",  "fHMS_ePosCoinTime"},
+    {"ePositronCoinTime_HMS",    "HMS Corrected e-Positron Coincidence Time",  "fHMS_ePosCoinTime"},
     
     {"CoinTime_RAW_ROC1",    "ROC1 RAW Coincidence Time",  "fROC1_RAW_CoinTime"},
     {"CoinTime_RAW_ROC2",    "ROC2 RAW Coincidence Time",  "fROC2_RAW_CoinTime"},
     {"CoinTime_RAW_SHMS",    "SHMS RAW Coincidence Time",  "fSHMS_RAW_CoinTime"},
-    {"CoinTime_RAW_TRIG3",    "TRIG3 RAW Coincidence Time",  "fHMS_RAW_CoinTime"},
+    {"CoinTime_RAW_HMS",    "HMS RAW Coincidence Time",  "fHMS_RAW_CoinTime"},
+    {"CoinTime_RAW_ROC1_NoTrack",    "ROC1 RAW Coincidence Time w/o Tracked Param",  "fROC1_RAW_CoinTime_NoTrack"},
+    {"CoinTime_RAW_ROC2_NoTrack",    "ROC2 RAW Coincidence Time w/o Tracked Param",  "fROC2_RAW_CoinTime_NoTrack"},
+    {"CoinTime_RAW_SHMS_NoTrack",    "SHMS RAW Coincidence Time w/o Tracked Param",  "fSHMS_RAW_CoinTime_NoTrack"},
+    {"CoinTime_RAW_HMS_NoTrack",    "HMS RAW Coincidence Time w/o Tracked Param",  "fHMS_RAW_CoinTime_NoTrack"},
     {"DeltaSHMSPathLength","DeltaSHMSpathLength (cm)","DeltaSHMSpathLength"},
     {"DeltaHMSPathLength", "DeltaHMSpathLength (cm)","DeltaHMSpathLength"},
     {"had_coinCorr_Positron",    "",  "had_coinCorr_Positron"},
@@ -263,8 +267,8 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
       //Get raw TDC Times for HMS/SHMS (3/4 trigger)
       pSHMS_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(0);  //SHMS
       pHMS_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(1);  //HMS
-      pSHMS_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(2);//SHMS pTRIG1
-      pHMS_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(3);//HMS pTRIG3
+      pSHMS_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(2);//SHMS pTrig1
+      pHMS_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(3);//HMS pTrig3
       	  
       DeltaSHMSpathLength = .11*shms_xptar*1000 +0.057*shms_dP/100.;
       DeltaHMSpathLength = -1.0*(12.462*hms_xpfp + 0.1138*hms_xpfp*hms_xfp - 0.0154*hms_xfp - 72.292*hms_xpfp*hms_xpfp - 0.0000544*hms_xfp*had_xfp - 116.52*hms_ypfp*hms_ypfp);
@@ -303,6 +307,12 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
 	  fROC2_RAW_CoinTime =  (pSHMS_TdcTime_ROC2 + SHMS_FPtime) - (pHMS_TdcTime_ROC2 + HMS_FPtime);
 	  fSHMS_RAW_CoinTime =  (pSHMS_TdcTime_ROC1 + SHMS_FPtime) - (pSHMS_TdcTime_ROC2 + HMS_FPtime);
 	  fHMS_RAW_CoinTime =  (pHMS_TdcTime_ROC1 + SHMS_FPtime) - (pHMS_TdcTime_ROC2 + HMS_FPtime);
+	  // 04/05/21 - SJDK - Added for use in Report files for tracking efficiency calculations
+	  //Raw, Uncorrected Coincidence Time WITHOUT any tracked quantities
+	  fROC1_RAW_CoinTime_NoTrack =  (pSHMS_TdcTime_ROC1) - (pTRIG4_TdcTime_ROC1);
+	  fROC2_RAW_CoinTime_NoTrack =  (pSHMS_TdcTime_ROC2) - (pTRIG4_TdcTime_ROC2);
+	  fSHMS_RAW_CoinTime_NoTrack =  (pSHMS_TdcTime_ROC1) - (pSHMS_TdcTime_ROC2);
+	  fHMS_RAW_CoinTime_NoTrack =  (pHMS_TdcTime_ROC1) - (pHMS_TdcTime_ROC2);
 	  //Corrected Coincidence Time for ROC1/ROC2 (ROC1 Should be identical to ROC2)
           // 
 	  //PROTON

--- a/src/THcCoinTime.h
+++ b/src/THcCoinTime.h
@@ -82,6 +82,11 @@ public:
   Double_t fROC2_RAW_CoinTime;
   Double_t fSHMS_RAW_CoinTime;
   Double_t fHMS_RAW_CoinTime;  
+
+  Double_t fROC1_RAW_CoinTime_NoTrack;
+  Double_t fROC2_RAW_CoinTime_NoTrack;
+  Double_t fSHMS_RAW_CoinTime_NoTrack;
+  Double_t fHMS_RAW_CoinTime_NoTrack;  
   
   Double_t fROC1_epCoinTime;
   Double_t fROC2_epCoinTime;

--- a/src/THcCoinTime.h
+++ b/src/THcCoinTime.h
@@ -33,14 +33,12 @@ public:
 
   virtual ~THcCoinTime();
 
-
   virtual EStatus Init( const TDatime& run_time );
   virtual Int_t   Process( const THaEvData& );
 
   void            Reset( Option_t* opt="" );
   void            Clear( Option_t* opt="" );
   
-
  protected:
 
   virtual Int_t ReadDatabase( const TDatime& date);
@@ -52,7 +50,6 @@ public:
   TString     fCoinDetName;         // Name of Coin Trigger
   TString     fhadArmName;       //name of hadron arm
   TString     felecArmName;     // name of electron arm
-
 
   THcHallCSpectrometer* fhadSpectro;	// hadron Spectrometer object
   THcHallCSpectrometer* felecSpectro;	// electron Spectrometer object
@@ -83,28 +80,28 @@ public:
 
   Double_t fROC1_RAW_CoinTime;
   Double_t fROC2_RAW_CoinTime;
-  Double_t fTRIG1_RAW_CoinTime;
-  Double_t fTRIG3_RAW_CoinTime;  
+  Double_t fSHMS_RAW_CoinTime;
+  Double_t fHMS_RAW_CoinTime;  
   
   Double_t fROC1_epCoinTime;
   Double_t fROC2_epCoinTime;
-  Double_t fTRIG1_epCoinTime;
-  Double_t fTRIG3_epCoinTime;
+  Double_t fSHMS_epCoinTime;
+  Double_t fHMS_epCoinTime;
 
   Double_t fROC1_eKCoinTime;
   Double_t fROC2_eKCoinTime;
-  Double_t fTRIG1_eKCoinTime;
-  Double_t fTRIG3_eKCoinTime;
+  Double_t fSHMS_eKCoinTime;
+  Double_t fHMS_eKCoinTime;
 
   Double_t fROC1_ePiCoinTime;
   Double_t fROC2_ePiCoinTime;
-  Double_t fTRIG1_ePiCoinTime;
-  Double_t fTRIG3_ePiCoinTime;
+  Double_t fSHMS_ePiCoinTime;
+  Double_t fHMS_ePiCoinTime;
  
   Double_t fROC1_ePosCoinTime;   //electron-positron coin time 
   Double_t fROC2_ePosCoinTime;
-  Double_t fTRIG1_ePosCoinTime;   //electron-positron coin time 
-  Double_t fTRIG3_ePosCoinTime;
+  Double_t fSHMS_ePosCoinTime;   //electron-positron coin time 
+  Double_t fHMS_ePosCoinTime;
   
   Double_t elec_coinCorr;
   Double_t elecArm_BetaCalc;
@@ -122,7 +119,6 @@ public:
   Double_t had_coinCorr_Positron;
   Double_t hadArm_BetaCalc_Positron;
   
-
   Double_t elec_P;     //electron golden track momentum
   Double_t elec_dP;     //electron golden track delta-> (P-P0 / P0)
   Double_t elec_xptar;    //electron golden track theta (xptar, :) 
@@ -134,11 +130,11 @@ public:
   Double_t had_ypfp;     //hadron yp focal plane
   Double_t had_FPtime;   //hadron focal plane time
 
-  // trigger times pTrig1 (SHMS 3/4 trig) and pTrig4 (HMS 3/4 trig)
-  Double_t pTRIG1_TdcTime_ROC1;
-  Double_t pTRIG3_TdcTime_ROC1;
-  Double_t pTRIG1_TdcTime_ROC2;
-  Double_t pTRIG3_TdcTime_ROC2;
+  // trigger times pTrig1 (SHMS 3/4 trig) and pTrig3 (HMS 3/4 trig)
+  Double_t pSHMS_TdcTime_ROC1;
+  Double_t pHMS_TdcTime_ROC1;
+  Double_t pSHMS_TdcTime_ROC2;
+  Double_t pHMS_TdcTime_ROC2;
 
   //--------------------------------------------------------------------
 

--- a/src/THcCoinTime.h
+++ b/src/THcCoinTime.h
@@ -84,28 +84,27 @@ public:
   Double_t fROC1_RAW_CoinTime;
   Double_t fROC2_RAW_CoinTime;
   Double_t fTRIG1_RAW_CoinTime;
-  Double_t fTRIG4_RAW_CoinTime;
-  
+  Double_t fTRIG3_RAW_CoinTime;  
   
   Double_t fROC1_epCoinTime;
   Double_t fROC2_epCoinTime;
   Double_t fTRIG1_epCoinTime;
-  Double_t fTRIG4_epCoinTime;
+  Double_t fTRIG3_epCoinTime;
 
   Double_t fROC1_eKCoinTime;
   Double_t fROC2_eKCoinTime;
   Double_t fTRIG1_eKCoinTime;
-  Double_t fTRIG4_eKCoinTime;
+  Double_t fTRIG3_eKCoinTime;
 
   Double_t fROC1_ePiCoinTime;
   Double_t fROC2_ePiCoinTime;
   Double_t fTRIG1_ePiCoinTime;
-  Double_t fTRIG4_ePiCoinTime;
+  Double_t fTRIG3_ePiCoinTime;
  
   Double_t fROC1_ePosCoinTime;   //electron-positron coin time 
   Double_t fROC2_ePosCoinTime;
   Double_t fTRIG1_ePosCoinTime;   //electron-positron coin time 
-  Double_t fTRIG4_ePosCoinTime;
+  Double_t fTRIG3_ePosCoinTime;
   
   Double_t elec_coinCorr;
   Double_t elecArm_BetaCalc;
@@ -137,9 +136,9 @@ public:
 
   // trigger times pTrig1 (SHMS 3/4 trig) and pTrig4 (HMS 3/4 trig)
   Double_t pTRIG1_TdcTime_ROC1;
-  Double_t pTRIG4_TdcTime_ROC1;
+  Double_t pTRIG3_TdcTime_ROC1;
   Double_t pTRIG1_TdcTime_ROC2;
-  Double_t pTRIG4_TdcTime_ROC2;
+  Double_t pTRIG3_TdcTime_ROC2;
 
   //--------------------------------------------------------------------
 

--- a/src/THcTrigDet.cxx
+++ b/src/THcTrigDet.cxx
@@ -334,7 +334,12 @@ void THcTrigDet::Setup(const char* name, const char* description) {
 //_____________________________________________________________________________
 Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
   std::string adcNames, tdcNames;
-  std::string trigNames="pTRIG1_ROC1 pTRIG4_ROC1 pTRIG1_ROC2 pTRIG4_ROC2";
+  
+  //std::string trigNames="pTRIG1_ROC1 pTRIG4_ROC1 pTRIG1_ROC2 pTRIG4_ROC2";
+  
+  //C.Y. Sep 08, 2021 | changed pTRIG4 to pTRIG3 (Since in hardware, pTRIG3 -> h3/4 trigger)
+  std::string trigNames="pTRIG1_ROC1 pTRIG3_ROC1 pTRIG1_ROC2 pTRIG3_ROC2";
+
   // SJDK 12/04/21 - Added new RF names for use in getter
   std::string RFNames="pRF hRF";
   DBRequest list[] = {
@@ -398,6 +403,7 @@ Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
   cout << " Trig = " << fTrigNames.size() << endl;
   for (UInt_t j = 0; j <fTrigNames.size(); j++) {
     cout << fTrigNames[j] << " " << fTrigId[j] << endl;
+
   }
  
   // SJDK - 12/04/21 - For RF getter

--- a/src/THcTrigDet.cxx
+++ b/src/THcTrigDet.cxx
@@ -335,10 +335,11 @@ void THcTrigDet::Setup(const char* name, const char* description) {
 Int_t THcTrigDet::ReadDatabase(const TDatime& date) {
   std::string adcNames, tdcNames;
   
-  //std::string trigNames="pTRIG1_ROC1 pTRIG4_ROC1 pTRIG1_ROC2 pTRIG4_ROC2";
+  std::string trigNames="pTRIG1_ROC1 pTRIG4_ROC1 pTRIG1_ROC2 pTRIG4_ROC2";
   
   //C.Y. Sep 08, 2021 | changed pTRIG4 to pTRIG3 (Since in hardware, pTRIG3 -> h3/4 trigger)
-  std::string trigNames="pTRIG1_ROC1 pTRIG3_ROC1 pTRIG1_ROC2 pTRIG3_ROC2";
+  // SJDK - 22/02/22 - Switched back, keep names here as is, can set in param files later
+  //std::string trigNames="pTRIG1_ROC1 pTRIG3_ROC1 pTRIG1_ROC2 pTRIG3_ROC2";
 
   // SJDK 12/04/21 - Added new RF names for use in getter
   std::string RFNames="pRF hRF";

--- a/src/THcTrigDet.h
+++ b/src/THcTrigDet.h
@@ -34,6 +34,7 @@ class THcTrigDet : public THaDetector, public THcHitList {
     Int_t          End(THaRunBase* run);
     //Funtions to get TDCtime for cointime module 
     Double_t Get_CT_Trigtime(Int_t ii) { return (fTrigId[ii]==-1 ? 0. : fTdcTime[fTrigId[ii]]) ;}
+
     // SJDK 12/04/21 - New Getter for RF time info
     // Function to get RFTDC time for RF module
     Double_t Get_RF_TrigTime(Int_t ii) { return (fRFId[ii]==-1 ? 0. : fTdcTime[fRFId[ii]]) ;}


### PR DESCRIPTION
Changes from the 2021/2022 PionLT run - Triggers were switched due to hardware changes. This is needed for coin time determination for the 2021 data onwards.