### PR TITLE
Update to Podd 1.7.0 Release. Adapt TIBlobModule to new block data API

### DIFF
--- a/src/TIBlobModule.cxx
+++ b/src/TIBlobModule.cxx
@@ -19,12 +19,11 @@ namespace Decoder {
     DoRegister( ModuleType( "Decoder::TIBlobModule" , 4 ));
 
   TIBlobModule::TIBlobModule(UInt_t crate, UInt_t slot) : PipeliningModule(crate, slot) {
-    fDebugFile=0;
-    Init();
+    fDebugFile=nullptr;
+    TIBlobModule::Init();
   }
 
-  TIBlobModule::~TIBlobModule() {
-  }
+  TIBlobModule::~TIBlobModule() = default;
 
   void TIBlobModule::Init() {
     Module::Init();
@@ -43,120 +42,50 @@ namespace Decoder {
     fName = "TIBlob";
   }
 
-  UInt_t TIBlobModule::LoadSlot( THaSlotData *sldat, const UInt_t* evbuffer, const UInt_t *pstop) {
-    // the 3-arg verison of LoadSlot
+  UInt_t TIBlobModule::LoadSlot( THaSlotData* sldat, const UInt_t* evbuffer,
+                                 const UInt_t* pstop )
+  {
+    // Load from evbuffer between [evbuffer,pstop]
 
-    std::vector< UInt_t > evb;
-    while(evbuffer < pstop) evb.push_back(*evbuffer++);
-
-    // Note, methods SplitBuffer, GetNextBlock are defined in PipeliningModule
-    // SplitBuffer needs to be modified a bit for the TI
-
-    SplitBuffer(evb);
-    return LoadThisBlock(sldat, GetNextBlock());
+    return LoadSlot(sldat, evbuffer, 0, pstop + 1 - evbuffer);
   }
 
-  UInt_t TIBlobModule::LoadSlot( THaSlotData *sldat, const UInt_t *evbuffer, UInt_t pos, UInt_t len) {
-    // the 4-arg verison of LoadSlot.  Let it call the 3-arg version.
-    // Do we need this or is it historical?
-
-    return LoadSlot(sldat, evbuffer+pos, evbuffer+pos+len);
-  }
-
-  UInt_t TIBlobModule::LoadNextEvBuffer( THaSlotData *sldat) {
-    // Note, GetNextBlock belongs to PipeliningModule
-    return LoadThisBlock(sldat, GetNextBlock());
-  }
-
-  UInt_t TIBlobModule::LoadThisBlock( THaSlotData *sldat, const vector<UInt_t>& evbuffer) {
+  UInt_t TIBlobModule::LoadSlot( THaSlotData *sldat, const UInt_t* evbuffer,
+                                 UInt_t pos, UInt_t len)
+  {
+    // Load from bank data in evbuffer between [pos,pos+len)
 
     // Fill data structures of this class using the event buffer of one "event".
     // An "event" is defined in the traditional way -- a scattering from a target, etc.
-    
+
     Clear();
 
     // Only interpret data if fSlot agrees with the slot in the headers
-    
-    UInt_t evlen = evbuffer.size();
-    if(evlen>0) {
+
+    const auto* bank = evbuffer + pos;
+    if( len > 0 ) {
       // The first word might be a filler word
-      UInt_t ifill = (((evbuffer[0] >> 27) & 0x1F) == 0x1F) ? 1 : 0;
-      if (evlen>=5+ifill) {// Need at least two headers and the trailer and 2 data words
-	UInt_t header1=evbuffer[ifill];
-	UInt_t slot_blk_hdr=(header1 >> 22) & 0x1F;  // Slot number (set by VME64x backplane), mask 5 bits
-	if(fSlot != slot_blk_hdr) {
-	  return evlen;
-	}
-	fData[0] = (evbuffer[2 + ifill] >> 24) & 0xFF; // Trigger type
-	fData[1] = evbuffer[3 + ifill];		 // Trigger number
-	fData[2] = (evlen>5+ifill) ? evbuffer[4 + ifill] : 0; // Trigger time
-	//      cout << "TIBlob Slot " << fSlot << ": ";
-	for(UInt_t i=0;i<3;i++) {
-	  sldat->loadData(i, fData[i], fData[i]);
-	  //	cout << " " << fData[i];
-	}
-	//      cout << endl;
+      UInt_t ifill = (((bank[0] >> 27) & 0x1F) == 0x1F) ? 1 : 0;
+      if( len >= 5 + ifill ) {// Need at least two headers and the trailer and 2 data words
+        UInt_t header1 = bank[ifill];
+        UInt_t slot_blk_hdr = (header1 >> 22) & 0x1F;  // Slot number (set by VME64x backplane), mask 5 bits
+        if( fSlot != slot_blk_hdr ) {
+          return len;
+        }
+        fData[0] = (bank[2 + ifill] >> 24) & 0xFF; // Trigger type
+        fData[1] = bank[3 + ifill];                 // Trigger number
+        fData[2] = (len > 5 + ifill) ? evbuffer[4 + ifill] : 0; // Trigger time
+        //      cout << "TIBlob Slot " << fSlot << ": ";
+        for( UInt_t i = 0; i < 3; i++ ) {
+          sldat->loadData(i, fData[i], fData[i]);
+          //	cout << " " << fData[i];
+        }
+        //      cout << endl;
       }
     }
-      
-    return evlen;
 
+    return len;
   }
-
-  Int_t TIBlobModule::SplitBuffer( const vector<UInt_t>& bigbuffer ) {
-
-    // Split a CODA buffer into blocks.   A block is data from a traditional physics event.
-    // In MultiBlock Mode, a pipelining module can have several events in each CODA buffer.
-    // If block level is 1, then the buffer is a traditional physics event.
-    // If finding >1 block, this will set fMultiBlockMode = kTRUE
-
-    // Copied from PipeliningModule and customized for TI
-
-    std::vector<UInt_t > oneEventBuffer;
-    eventblock.clear();
-    fBlockIsDone = kFALSE;
-    //    Int_t eventnum = 1;
-    //    Int_t evt_num_modblock;
-
-    //    if ((fFirstTime == kFALSE) && (IsMultiBlockMode() == kFALSE)) {
-      eventblock.push_back(bigbuffer);
-      index_buffer=1;
-      return 1;
-      //    }
-      //    return 0;
-    // The rest of this is only use if we are in multiblock mode
-    // It still needs to be developed.
-#if 0
-    int debug=1;
-
-    Int_t slot_blk_hdr, slot_evt_hdr, slot_blk_trl;
-    Int_t iblock_num, nblock_events, nwords_inblock, evt_num;
-    Int_t BlockStart=0;
-
-    slot_blk_hdr = 0;
-    slot_evt_hdr = 0;
-    slot_blk_trl = 0;
-    nblock_events = 0;
-
-    if(codabuffer.size() > 2) {	// Need at least the two headers and the trailer
-      UInt_t header1=codabuffer[0];
-      UInt_t header2=codabuffer[1];
-
-      if((header1&0xF8000000)==0x80000000 &&
-	 (header1&0xF8000000)==0xF8000000) {	// Header words
-	slot_blk_hdr = (header1 >> 22) & 0x1F;  // Slot number (set by VME64x backplane), mask 5 bits
-	// iblock_num = (data >> 8) & 0x3FF;
-	nblock_events = header1 & 0xFF;
-	if(nblock_events > 1) fMultiBlockMode = kTRUE;
-	UInt_t i=2;
-	while(i+1 < codabuffer.size()) {
-	  // This should be event header
-	  
-      
-...
-#endif
-}
-
 
   /* Does anything use this method */
 UInt_t TIBlobModule::GetData( UInt_t chan ) const {
@@ -165,7 +94,7 @@ UInt_t TIBlobModule::GetData( UInt_t chan ) const {
 }
 
 void TIBlobModule::Clear(const Option_t* opt) {
-  VmeModule::Clear(opt);
+  PipeliningModule::Clear(opt);
   fData.assign(fNumChan,0);
 }
 

--- a/src/TIBlobModule.h
+++ b/src/TIBlobModule.h
@@ -26,6 +26,7 @@ public:
    virtual ~TIBlobModule();
 
    using Module::GetData;
+   using PipeliningModule::Init;
 
    virtual UInt_t GetData(UInt_t chan) const;
    virtual void Init();
@@ -33,11 +34,8 @@ public:
    virtual Int_t Decode(const UInt_t*) { return 0; }
    virtual UInt_t LoadSlot( THaSlotData *sldat, const UInt_t *evbuffer, const UInt_t *pstop );
    virtual UInt_t LoadSlot( THaSlotData *sldat, const UInt_t* evbuffer, UInt_t pos, UInt_t len);
-   virtual UInt_t LoadNextEvBuffer(THaSlotData *sldat);
-   virtual UInt_t LoadThisBlock( THaSlotData *sldat, const std::vector<UInt_t>& evbuffer);
- 
+
  protected:
-   virtual Int_t SplitBuffer( const std::vector<UInt_t>& bigbuffer);
 
  private:
 


### PR DESCRIPTION
Update to official Podd 1.7.0 Release.

TIBlobModule needed to be adapted to the new, streamlined block data API that was put in place for SBS. While that module previously did not support block data at all (comments said "still needs to be developed") , it should now do so since it inherits the block data decoding from PipeliningModule.
