### PR TITLE
CMake: Set RPATH on installed executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ endif()
 set_compiler_flags("${ROOT_CXX_FLAGS}")
 set_diagnostic_flags(WALL WEXTRA)
 report_build_info()
+if(PODD_SET_RPATH)
+  set_install_rpath()
+endif()
 
 #----------------------------------------------------------------------------
 # Install in GNU-style directory layout


### PR DESCRIPTION
Add missing CMake command to enable RPATH on installed executables, like Podd does. RPATH makes it unnecessary to set LD_LIBRARY_PATH in most cases.

This feature can be disabled with CMake option -DPODD_SET_RPATH=OFF.
