### PR TITLE
Helicity decoding fixes

### DIFF
--- a/src/THcHelicityReader.h
+++ b/src/THcHelicityReader.h
@@ -10,6 +10,8 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "Rtypes.h"
+#include "Decoder.h"
+#include "Fadc250Module.h"
 
 class THaEvData;
 class TDatime;
@@ -51,7 +53,11 @@ protected:
   Bool_t fIsHelm;
 
   Int_t fADCThreshold;		// Threshold for On/Off of helicity signals
+  Int_t fADCRawSamples;		// Use raw sample data if true
 
+  Decoder::Fadc250Module* fFADCModule; // Module object to get trigger time
+  Int_t fTTimeDiff;		       // Difference between TI and ADC times
+  
   ROCinfo  fROCinfo[kCount];
 
   Int_t    fQWEAKDebug;          // Debug level


### PR DESCRIPTION
Two fixes that repair the ability to extract helicity information.

1.  TIBlobModule was occasionally not getting the TI event time.  (See commit message).  The TI time is needed to help predict the helicity.

2.  A FADC firmware change removed pulse data for channels with DC inputs (such as the helicity inputs.)  Instead get the pedestal value from the first FADC sample.
