### PR TITLE
TIBlobModule: Use custom decoder for this module's data format

### DIFF
--- a/src/TIBlobModule.cxx
+++ b/src/TIBlobModule.cxx
@@ -11,118 +11,316 @@
 #include "THaSlotData.h"
 #include <cassert>
 #include <iostream>
+#include <sstream>
+#include <cstring>   // memcpy
 
 using namespace std;
 
 namespace Decoder {
 
-  Module::TypeIter_t TIBlobModule::fgThisType =
-    DoRegister( ModuleType( "Decoder::TIBlobModule" , 4 ));
+Module::TypeIter_t TIBlobModule::fgThisType =
+        DoRegister( ModuleType( "Decoder::TIBlobModule" , 4 ));
 
-  TIBlobModule::TIBlobModule()
-    : TIBlobModule(0,0) {}
+//_____________________________________________________________________________
+TIBlobModule::TIBlobModule()
+  : TIBlobModule(0,0) {}
 
-  TIBlobModule::TIBlobModule(UInt_t crate, UInt_t slot)
-    : PipeliningModule(crate, slot) { fNumChan = NTICHAN; }
+//_____________________________________________________________________________
+TIBlobModule::TIBlobModule(UInt_t crate, UInt_t slot)
+  : PipeliningModule(crate, slot)
+  , fNfill{0}
+  , fHasTimestamp{true}
+{}
 
-  TIBlobModule::~TIBlobModule() = default;
+//_____________________________________________________________________________
+TIBlobModule::~TIBlobModule() = default;
 
-  void TIBlobModule::Init() {
-    Module::Init();
-    fNumChan=NTICHAN;
+//_____________________________________________________________________________
+void TIBlobModule::Init()
+{
+  Module::Init();
 #if defined DEBUG && defined WITH_DEBUG
-    // This will make a HUGE output
-    delete fDebugFile; fDebugFile = 0;
-    fDebugFile = new ofstream;
-    fDebugFile->open(string("TIBlob_debug.txt"));
+  // This will make a HUGE output
+  delete fDebugFile; fDebugFile = 0;
+  fDebugFile = new ofstream;
+  fDebugFile->open(string("TIBlob_debug.txt"));
 #endif
-    //fDebugFile=0;
-    Clear();
-    IsInit = kTRUE;
+  //fDebugFile=0;
+  Clear();
+  IsInit = kTRUE;
 
-    fName = "TIBlob";
-  }
+  fName = "TIBlob";
+}
 
-  UInt_t TIBlobModule::LoadSlot( THaSlotData* sldat, const UInt_t* evbuffer,
+//_____________________________________________________________________________
+UInt_t TIBlobModule::LoadSlot( THaSlotData* sldat, const UInt_t* evbuffer,
                                  const UInt_t* pstop )
-  {
+{
     // Load from evbuffer between [evbuffer,pstop]
 
-    return LoadSlot(sldat, evbuffer, 0, pstop + 1 - evbuffer);
+  return LoadSlot(sldat, evbuffer, 0, pstop + 1 - evbuffer);
+}
+
+//_____________________________________________________________________________
+string TIBlobModule::Here( const char* function )
+{
+  ostringstream os;
+  os << "TIBlobModule::" << function << ": slot/crate "
+     << fSlot << "/" << fCrate << ": ";
+  return os.str();
+}
+
+//_____________________________________________________________________________
+UInt_t TIBlobModule::LoadSlot( THaSlotData* sldat, const UInt_t* evbuffer,
+                               UInt_t pos, UInt_t len ) {
+  // Load from bank data in evbuffer between [pos,pos+len)
+
+  // evbuffer+pos points to the event header, evbuffer+pos+len is one past
+  // the last word of the event, which is either the block trailer in single
+  // block mode or for the last event in multi-block mode, or the next event
+  // header in multi-block mode.
+
+  const char* const here = "LoadSlot";
+
+  // Clear event data and ensure there is enough space including optional data.
+  // Don't call Clear() here; it would wipe out the bank-level info.
+  fNumChan = 0;
+  fData.assign(NTICHAN,0);
+
+  if( len < 2 )
+    return 0;
+
+  // Event data:
+  //  event[0]:  header: trigger type, event length
+  //  event[1]:  trigger number lower 32 bits
+  //  event[2]:  trigger time lower 32 bits (optional)
+  //  event[3]:  maybe: tigger number/time upper 16 bits (optional, firmware-dependent)
+  const auto* event = evbuffer + pos;
+  UInt_t nwords = (event[0] & 0xFFFF) + 1;   // Number of words in this event
+  if( nwords > len || nwords > NTICHAN ) {
+    cerr << Here(here) << "Reported event length too long: hdr = "
+         << nwords << ", buf = " << len << ", need <= " << NTICHAN
+         << " and <= " << len << endl;
+    return 0;
+  }
+  if( nwords < 2 ) {
+    cerr << Here(here) << "Reported event length too short. Got "
+         << nwords << ", need >= 2" << endl;
+    return 0;
+  }
+  if( nwords == 2 && fHasTimestamp ) {
+    cerr << Here(here) << "Inconsistent event length = " << nwords
+         << " but timestamp present requires >= 3" << endl;
+    return 0;
+  }
+  fData[0] = (event[0] >> 24) & 0xFF;  // Trigger type
+  memcpy( fData.data()+1, event+1, (nwords-1)*sizeof(*event));
+  for( UInt_t i = 0; i < nwords; i++ ) {
+    sldat->loadData(i, fData[i], fData[i]);
+    //	cout << " " << fData[i];
+  }
+  //      cout << endl;
+
+  // Report actual number of valid data words, which is variable for this module
+  // although it should not change from event to event
+  fNumChan = nwords;
+  return nwords;
+}
+
+//_____________________________________________________________________________
+static inline
+Long64_t FindBlockHeaderForSlot( const UInt_t* buf, UInt_t start, UInt_t len,
+                                 UInt_t slot ) {
+  // Search 'buf' for data type identifier word encoding 'type', 'slot',
+  // and 'id'. The format is (T=type, S=slot, D=ID)
+  //    1TTT TSSS SSDD DDXX XXXX XXXX XXXX XXXX
+  // bit  28   24   20   16   12    8    4    0
+  //
+  // The buffer is searched between [start,start+len)
+  // Returns the offset into 'buf' containing the word, or -1 if not found.
+
+  const uint32_t ID = BIT(31) | (slot & 0x1F) << 22;
+  const auto* p = buf + start;
+  const auto* q = p + len;
+  while( p != q && (*p & 0xFFFC0000) != ID )
+    ++p;
+  return (p != q) ? p - buf : -1;
+}
+
+//_____________________________________________________________________________
+UInt_t TIBlobModule::LoadBank( Decoder::THaSlotData* sldat,
+                               const UInt_t* evbuffer,
+                               UInt_t pos, UInt_t len )
+{
+  // Load event block. If multi-block data, split the buffer into individual
+  // events. This routine is called for buffers with bank structure.
+
+  const char* const here = "LoadBank";
+
+  // Note: Clear() has been called at this point
+
+  if( len < 5 ) {
+    cerr << here << "Bank too short. Expected >= 5, got " << len << " words."
+         << endl;
+    // Caller has no provision for error codes and doesn't handle exceptions.
+    // Hopeless.
+    return 0;
+  }
+  // Find block header for this module's slot
+  // There should never be more than one TI module per bank per ROC, so this
+  // really ought to match the very first word.
+  auto ibeg = FindBlockHeaderForSlot(evbuffer, pos, len,
+                                     fSlot);
+  if( ibeg == -1 ) {
+    // Block header not present. Should not happen.
+    cerr << Here(here) << "No block header found in bank for slot " << fSlot
+         << "Call expert." << endl;
+    return 0;
+  }
+  if( ibeg != pos ) {
+    cerr << Here(here) << "Warning: " << ibeg-pos << " words of leading garbage"
+         << endl;
+  }
+  const UInt_t* p = evbuffer+ibeg;
+  // Block header lower 18 bits
+  fBlockHeader  = *p;
+  block_size    = (*p & 0x000000FF);      // Number of events in block
+  //fBlockNum     = (*p & 0x0003FF00) >> 8; // Block number
+
+  // Block header #2
+  UInt_t hdr2id = *++p & 0xFFFEFF00;
+  if( hdr2id != 0xFF102000 ) {
+    cerr << Here(here) << "Invalid block header #2 signature = "
+         << hex << *p << dec << ", expected 0xFF1020xx or 0xFF1120xx" << endl;
+    return 0;
+  }
+  fHasTimestamp = TESTBIT(*p, 16);
+  UInt_t block_size2 = (*p & 0x000000FF);
+  if( block_size != block_size2 ) {
+    cerr << Here(here) << "Warning: block sizes in block headers #1 and #2 "
+         << "disagree: " << block_size << ", " << block_size2 << endl;
   }
 
-  UInt_t TIBlobModule::LoadSlot( THaSlotData *sldat, const UInt_t* evbuffer,
-                                 UInt_t pos, UInt_t len)
-  {
-    // Load from bank data in evbuffer between [pos,pos+len)
+  // Find all the event headers (there should be block_size of them)
+  // between here and the block trailer, save their positions,
+  // then proceed with decoding the first block
+  evtblk.reserve(block_size + 1);
 
-    // Fill data structures of this class using the event buffer of one "event".
-    // An "event" is defined in the traditional way -- a scattering from a target, etc.
-
-    Clear();
-
-    // Only interpret data if fSlot agrees with the slot in the headers
-
-    const auto* bank = evbuffer + pos;
-    if( len > 0 ) {
-      // The first word might be a filler word
-      UInt_t ifill = (((bank[0] >> 27) & 0x1F) == 0x1F) ? 1 : 0;
-      if( len >= 5 + ifill ) {// Need at least two headers and the trailer and 2 data words
-        UInt_t header1 = bank[ifill];
-        UInt_t slot_blk_hdr = (header1 >> 22) & 0x1F;  // Slot number (set by VME64x backplane), mask 5 bits
-        if( fSlot != slot_blk_hdr ) {
-          return len;
-        }
-        assert(fData.size() >= 3 && NTICHAN >= 3);  // else error in constructor
-        fData[0] = (bank[2 + ifill] >> 24) & 0xFF;  // Trigger type
-        fData[1] = bank[3 + ifill];                 // Trigger number
-        //fData[2] = (len > 5 + ifill) ? bank[4 + ifill] : 0; // Trigger time
-
-	// PipeliningModule might supply a too short event length.
-	// This happens if the Trigger time looks like a block trailer
-	// We have two ways to check that the trigger time is really present
-	// 1.  Find the event length from event data word 1
-	// 2.  Look for the Timestamp present bit in block header 2
-
-	// Method 1
-	//      if((bank[2+ifill]&0xffff) >= 2) {
-	//	  fData[2] = bank[4+ifill];
-	//	} else {
-	//	  fData[2] = 0;
-	//	}
-	//	cout << "H: " << hex << bank[0+ifill] << " " << 
-	//	     bank[1+ifill] << " " << 
-	//	     bank[2+ifill] << " " << 
-	//	     bank[3+ifill] << " " << 
-	//	     bank[4+ifill] << dec << endl;
-	// Method 2
-	if((bank[1+ifill] & 0x10000) != 0) {
-	fData[2] = bank[4+ifill];
-	} else {
-		  fData[2] = 0;
-		}
-        for( UInt_t i = 0; i < NTICHAN; i++ ) {
-          sldat->loadData(i, fData[i], fData[i]);
-          //	cout << " " << fData[i];
-        }
-        //      cout << endl;
-      }
+  UInt_t blksz = block_size;
+  ++p;
+  while( blksz > 0 && p-evbuffer < pos+len) {
+    UInt_t sig = (*p & 0x00FF0000) >> 16;
+    if( sig != 0x01 ) {
+      cerr << Here(here) << "Invalid event header signature for iblock "
+           << block_size-blksz << ". Expected xx01xxxx, got "
+           << hex << *p << dec << endl;
+      return 0;
     }
-
-    return len;
+    UInt_t nwords = *p & 0xFFFF;   // Number of 32-bit words following
+    if( nwords < 1 ) {
+      cerr << Here(here) << "Event data too short, expected >= 2, got "
+           << nwords+1 << endl;
+      return 0;
+    }
+    evtblk.push_back(p - evbuffer);
+    p += nwords+1;
+    --blksz;
   }
 
+  if( evtblk.size() != block_size ) {
+    cerr << Here(here) << "Incorrect number of events found, expected "
+         << block_size << ", found " << evtblk.size() << endl;
+    return 0;
+  }
+  // evtblk must have exactly block_size elements now
+  evtblk.push_back(p-evbuffer); // include block trailer
+
+  // Verify block trailer
+  if( (*p & 0xFFC00000) != (BIT(31) | (1U << 27) | (fSlot & 0x1F) << 22) ) {
+    cerr << Here(here) << "Warning: Missing block trailer" << endl;
+  }
+  UInt_t nwords_inblock = *p & 0x3FFFFF;
+  Long64_t iend = p-evbuffer;   // Position of block trailer
+  if( nwords_inblock != iend+1-ibeg ) {
+    cerr << Here(here) << "Warning: block trailer word count mismatch, "
+         << "got " << nwords_inblock << ", expected " << iend+1-ibeg << endl;
+  }
+  assert( ibeg >= pos && iend > ibeg && iend < pos+len ); // trivially
+
+  // Consume filler words
+  while( ++p-evbuffer < pos+len
+         && (*p & 0xF7C00000) == (0xF0000000 | (fSlot & 0x1F) << 22) ) {
+    ++fNfill;
+  }
+  if( p-evbuffer != pos+len ) {
+    cerr << Here(here) << evbuffer+pos+len-p
+         << " trailing garbage words" << endl;
+  }
+
+  // Multi-block event?
+  fMultiBlockMode = ( block_size > 1 );
+
+  if( fMultiBlockMode ) {
+    // Multi-block: decode first event, using event positions from evtblk[]
+    index_buffer = 0;
+    return LoadNextEvBuffer(sldat)
+           + 2;  // 2 block header words
+
+  } else {
+    // Single block: decode, starting at event header
+    ibeg += 2;
+    return LoadSlot(sldat, evbuffer, ibeg, iend-ibeg)
+           + 3 // 2 block header words + 1 block trailer word
+           + fNfill;
+  }
+  // not reached
+}
+
+//_____________________________________________________________________________
+UInt_t TIBlobModule::LoadNextEvBuffer( Decoder::THaSlotData* sldat )
+{
+  // In multi-block mode, load the next event from the current block
+
+  UInt_t ii = index_buffer;
+  assert( ii+1 < evtblk.size() );
+
+  // ibeg = event header, iend = one past last word of this event ( = next
+  // event header if more events pending)
+  auto ibeg = evtblk[ii], iend = evtblk[ii+1];
+  assert(ibeg > 0 && iend > ibeg && static_cast<size_t>(iend) <= fBuffer.size());
+
+  // Load slot starting with event header at ibeg
+  ii = LoadSlot(sldat, fBuffer.data(), ibeg, iend-ibeg);
+
+  // Next cached buffer. Set flag if we've exhausted the cache.
+  ++index_buffer;
+  if( index_buffer+1 >= evtblk.size() )
+    fBlockIsDone = true;
+
+  if( fBlockIsDone )
+    ii += 1 + fNfill; // block trailer + filler words
+  return ii;
+}
+
+//_____________________________________________________________________________
   /* Does anything use this method */
-UInt_t TIBlobModule::GetData( UInt_t chan ) const {
+UInt_t TIBlobModule::GetData( UInt_t chan ) const
+{
   if (chan >= fNumChan) return 0;
   return fData[chan];
 }
 
-void TIBlobModule::Clear(const Option_t* opt) {
+//_____________________________________________________________________________
+// Clear module's data in preparation for new event/new bank
+void TIBlobModule::Clear(const Option_t* opt)
+{
   PipeliningModule::Clear(opt);
-  fData.assign(fNumChan,0);
+  fNumChan = 0;  // For this module: number of data words in current event
+  fData.assign(NTICHAN, 0);
+  fNfill = 0;
+  fHasTimestamp = true;
 }
 
-}
+} // namespace Decoder
 
 ClassImp(Decoder::TIBlobModule)

--- a/src/TIBlobModule.h
+++ b/src/TIBlobModule.h
@@ -14,6 +14,7 @@
 /////////////////////////////////////////////////////////////////////
 
 #include "PipeliningModule.h"
+#include <string>
 
 namespace Decoder {
 
@@ -34,12 +35,18 @@ public:
    virtual Int_t Decode(const UInt_t*) { return 0; }
    virtual UInt_t LoadSlot( THaSlotData *sldat, const UInt_t *evbuffer, const UInt_t *pstop );
    virtual UInt_t LoadSlot( THaSlotData *sldat, const UInt_t* evbuffer, UInt_t pos, UInt_t len);
+   virtual UInt_t LoadBank( THaSlotData* sldat, const UInt_t* evbuffer, UInt_t pos, UInt_t len );
 
  protected:
+  virtual UInt_t LoadNextEvBuffer( THaSlotData *sldat );
 
  private:
 
-   static const size_t NTICHAN = 3;
+   static const size_t NTICHAN = 4;  // maximum number of data words per event
+   UInt_t fNfill;        // Number of filler words at end of current bank
+   Bool_t fHasTimestamp; // Event data contain timestamp (default)
+
+   std::string Here( const char* function );
 
    static TypeIter_t fgThisType;
    ClassDef(TIBlobModule,0)  //  TIBlob of a module;


### PR DESCRIPTION
The original assumption that the TI module is a PipeliningModule is incorrect. The module's data format differs from that of PipeliningModules, which led to occasional decoding errors in single block mode and would have failed in multi-block mode.

This change supports both single and multi-block mode. Multi-block mode has not been tested yet due to lack of example data, but should work if the data format specs are accurate. The code assumes that the TI module's data are in a unique CODA bank for each ROC, and that there is only one TI module and no other modules in that bank. This is the case in the current Hall C DAQ setup.

Closes [Redmine issue 676](https://redmine.jlab.org/issues/676).