### PR TITLE
Update TIBlobModule event decoding to support "word5" (trigger bits)

### DIFF
--- a/src/TIBlobModule.h
+++ b/src/TIBlobModule.h
@@ -27,30 +27,49 @@ public:
    virtual ~TIBlobModule();
 
    using Module::GetData;
-   using PipeliningModule::Init;
 
    virtual UInt_t GetData(UInt_t chan) const;
    virtual void Init();
+   virtual void Init( const char* configstr );
    virtual void Clear(const Option_t *opt="");
    virtual Int_t Decode(const UInt_t*) { return 0; }
    virtual UInt_t LoadSlot( THaSlotData *sldat, const UInt_t *evbuffer, const UInt_t *pstop );
    virtual UInt_t LoadSlot( THaSlotData *sldat, const UInt_t* evbuffer, UInt_t pos, UInt_t len);
    virtual UInt_t LoadBank( THaSlotData* sldat, const UInt_t* evbuffer, UInt_t pos, UInt_t len );
 
- protected:
+   // Index into fData[]. Usage: GetData(Decoder::TIBlobModule::kTimestamp)
+   enum EInfoType {
+     kTriggerType = 0, kTriggerNum, kTimestamp, kCounterBits, kTriggerBits,
+     kNTICHAN       /* indicates number of channels */
+   };
+
+   bool HasTriggerType() const { return TESTBIT(fDataAvail, kTriggerType); }
+   bool HasTriggerNum()  const { return TESTBIT(fDataAvail, kTriggerNum); }
+   bool HasTimestamp()   const { return TESTBIT(fDataAvail, kTimestamp); }
+   bool HasCounterBits() const { return TESTBIT(fDataAvail, kCounterBits); }
+   bool HasTriggerBits() const { return TESTBIT(fDataAvail, kTriggerBits); }
+
+   // Set type of 4th data word (3rd word if there is no timestamp).
+   // This only applies if the TI is configured to generate either the counter
+   // bits or the trigger bit pattern word, but not both. This case cannot
+   // be unambiguously decoded automatically.
+   // Values can be 0 = automatic, kCounterBits, or kTriggerBits.
+   void SetWord4Type( UInt_t type );
+
+protected:
   virtual UInt_t LoadNextEvBuffer( THaSlotData *sldat );
 
- private:
-
-   static const size_t NTICHAN = 4;  // maximum number of data words per event
+private:
    UInt_t fNfill;        // Number of filler words at end of current bank
+   UInt_t fDataAvail;    // Bitfield of data read (see EInfoType)
+   UInt_t fWord4Type;    // Which data contained in event data word4
    Bool_t fHasTimestamp; // Event data contain timestamp (default)
 
    std::string Here( const char* function );
+   void CheckWarnTrigBits( UInt_t word, UInt_t nopt, const char* here );
 
    static TypeIter_t fgThisType;
-   ClassDef(TIBlobModule,0)  //  TIBlob of a module;
-
+   ClassDef(TIBlobModule,0)        // Trigger Interface module
 };
 
 }


### PR DESCRIPTION
Update TI decoding to support the "trigger bits" word ("word5").

This also changes TIBlobModule to use a fixed number of channels again (5) instead of the variable number of channels that the previous version offered. To retrieve data, one should now do, for example,
```
if (module->HasTimestamp() ) {
   UInt_t timestamp = module->GetData(Decoder::TIBlobModule::kTimestamp);
   // do things with timestamp
}
```
The trigger type (`GetData(0)`) and trigger number (`GetData(1)`) should always be present, but timestamp, counter bits, and trigger bits are optional and depend on the DAQ configuration. `module->GetNumChan()` now always reports 5. Channels whose info is not present in the event are assigned a value of zero and should be tested with the `Has...()` functions.

If the counter bits are present, one should explicitly tell the module so through a configuration parameter in the crate map:
```
// Set parameters of this module via optional configuration string in
// db_cratemap.dat. Supported parameters:
//   debug:   debug level
//   word4:   type of word4 (0 = auto, 3 = counter bits, 4 = trigger bits)

==== Crate 30 type vme
# slot   model   bank   configuration string
   21       4       4    cfg: word4=3
```
(This is not necessary with the current Hall C DAQ.)