### PR TITLE
RFTime Class Updates

### DIFF
--- a/src/THcCoinTime.cxx
+++ b/src/THcCoinTime.cxx
@@ -143,7 +143,8 @@ Int_t THcCoinTime::ReadDatabase( const TDatime& date )
   
   //Default values if not read from param file
   eHad_CT_Offset = 0.0;
-
+  
+  // SJDK 16/11/22 - This must be to a specific point? Where? The first hodo plane?
   HMScentralPathLen = 22.0*100.;
   SHMScentralPathLen = 18.1*100.;
   
@@ -271,7 +272,9 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
       pHMS_TdcTime_ROC2 = fCoinDet->Get_CT_Trigtime(3);//HMS pTrig3
       	  
       DeltaSHMSpathLength = .11*shms_xptar*1000 +0.057*shms_dP/100.;
-      DeltaHMSpathLength = -1.0*(12.462*hms_xpfp + 0.1138*hms_xpfp*hms_xfp - 0.0154*hms_xfp - 72.292*hms_xpfp*hms_xpfp - 0.0000544*hms_xfp*had_xfp - 116.52*hms_ypfp*hms_ypfp);
+      // 16/11/22 - SJDK - The calculation below seems to be "correct" in the sense this it is accounting for the beam on target angle etc. However, it is only defined this was for the HMS. Also, it is is redefined on the next line
+      // I've commented it out for now since it seems pointless to define it twice.
+      //DeltaHMSpathLength = -1.0*(12.462*hms_xpfp + 0.1138*hms_xpfp*hms_xfp - 0.0154*hms_xfp - 72.292*hms_xpfp*hms_xpfp - 0.0000544*hms_xfp*had_xfp - 116.52*hms_ypfp*hms_ypfp);
       DeltaHMSpathLength = (.12*hms_xptar*1000 +0.17*hms_dP/100.);
 
           // default assume SHMS is electron arm

--- a/src/THcCoinTime.cxx
+++ b/src/THcCoinTime.cxx
@@ -334,9 +334,9 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
 	  fHMS_ePiCoinTime = fHMS_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Pion) - eHad_CT_Offset;
 
 	  //POSITRON
-	  fROC1_ePosCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset ;	  
+	  fROC1_ePosCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
 	  fROC2_ePosCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
-	  fSHMS_ePosCoinTime = fSHMS_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset ;	  
+	  fSHMS_ePosCoinTime = fSHMS_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
 	  fHMS_ePosCoinTime = fHMS_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
          
   return 0;

--- a/src/THcCoinTime.cxx
+++ b/src/THcCoinTime.cxx
@@ -74,6 +74,15 @@ void THcCoinTime::Clear( Option_t* opt )
   fHMS_eKCoinTime=kBig;
   fSHMS_epCoinTime=kBig;
   fHMS_epCoinTime=kBig;
+
+  /*
+  // 31/01/23 - SJDK - Commented out for now
+  // 18/11/22 - SJDK - Added RF time distributions with a CoinTime correction
+  fSHMS_eRFtimeDist_CT=kBig;
+  fSHMS_piRFtimeDist_CT=kBig;
+  fSHMS_KRFtimeDist_CT=kBig;
+  fSHMS_pRFtimeDist_CT=kBig;  
+  */
 }
 
 //_____________________________________________________________________________
@@ -135,9 +144,18 @@ Int_t THcCoinTime::ReadDatabase( const TDatime& date )
   // Read database. Gets variable needed for CoinTime calculation
   DBRequest list[]={
     {"eHadCoinTime_Offset",  &eHad_CT_Offset, kDouble, 0, 1},   //coin time offset for ep coincidences
-
     {"HMS_CentralPathLen",  &HMScentralPathLen, kDouble, 0, 1},
     {"SHMS_CentralPathLen", &SHMScentralPathLen, kDouble, 0, 1},
+    /*
+    // 31/01/23 - SJDK - Commented out for now, this is for testing the CT corrected RF times
+    // 18/11/22 - SJDK - New variables read in for the RF calculations included here
+    {"SHMS_RF_Offset",  &SHMS_RF_Offset, kDouble, 0, 1}, // RF offset for SHMS
+    {"SHMS_eRF_Offset",  &SHMS_eRF_Offset, kDouble, 0, 1},   // Electron/Positron RF offset for SHMS
+    {"SHMS_piRF_Offset",  &SHMS_piRF_Offset, kDouble, 0, 1},   // Pion RF offset for SHMS
+    {"SHMS_KRF_Offset",  &SHMS_KRF_Offset, kDouble, 0, 1},   //  Kaon RF offset for SHMS
+    {"SHMS_pRF_Offset",  &SHMS_pRF_Offset, kDouble, 0, 1},   // Proton RF offset for SHMS
+    {"Bunch_Spacing_Override",  &Bunch_Spacing_Override, kDouble, 0, 1}, // Bunch spacing value, can be manually set to override the Epics read in,
+    */
     {0}
   };
   
@@ -147,9 +165,42 @@ Int_t THcCoinTime::ReadDatabase( const TDatime& date )
   // SJDK 16/11/22 - This must be to a specific point? Where? The first hodo plane?
   HMScentralPathLen = 22.0*100.;
   SHMScentralPathLen = 18.1*100.;
+ 
+  /*
+  // 31/01/23 - Again, just for testing the CT corrected RF time, commented out for now
+  // SJDK 18/11/22 - New variables associated with RFTime calculations
+  // Default values if not read from param file
+  Bunch_Spacing_Override = 1.5556; // Strangely specific value so we can check if it's set or not
+  SHMS_RF_Offset = 0.0;
   
-  gHcParms->LoadParmValues((DBRequest*)&list, "");
+  // Particle specific RF offset values, set to a default value. The default doesn't really make sense as a choice, check after read in if it was set
+  SHMS_eRF_Offset = -5.1114;
+  SHMS_piRF_Offset = -5.1114;
+  SHMS_KRF_Offset = -5.1114;
+  SHMS_pRF_Offset = -5.1114;
 
+  gHcParms->LoadParmValues((DBRequest*)&list, "");
+  // If the override value has been set (i.e. it is NOT the default value), set it to whatever the read in is
+  if ( Bunch_Spacing_Override != 1.5556){
+  Bunch_Spacing = Bunch_Spacing_Override;
+  }
+  // If override wasn't set, assume the bunch spacing has some default value (will be overriden by Epics if it looks OK)
+  else if (Bunch_Spacing_Override == 1.5556){
+  Bunch_Spacing = 4.008;
+  }
+  if (SHMS_eRF_Offset == -5.1114){
+  SHMS_eRF_Offset = SHMS_RF_Offset; // If electron SHMS offset wasn't explicitly set, set it to the same value as the generic spectrometer offset
+  }
+  if (SHMS_piRF_Offset == -5.1114){
+  SHMS_piRF_Offset = SHMS_RF_Offset; // If pion SHMS offset wasn't explicitly set, set it to the same value as the generic spectrometer offset
+  }
+  if (SHMS_KRF_Offset == -5.1114){
+  SHMS_KRF_Offset = SHMS_RF_Offset; // If kaon SHMS offset wasn't explicitly set, set it to the same value as the generic spectrometer offset
+  }
+  if (SHMS_pRF_Offset == -5.1114){
+  SHMS_pRF_Offset = SHMS_RF_Offset; // If proton SHMS offset wasn't explicitly set, set it to the same value as the generic spectrometer offset
+  }
+  */
   return kOK;
 }
 
@@ -194,7 +245,14 @@ Int_t THcCoinTime::DefineVariables( EMode mode )
     {"had_coinCorr_Positron",    "",  "had_coinCorr_Positron"},
     {"elec_coinCorr",    "",  "elec_coinCorr"},
 
-    { 0 }
+    // 31/01/23 - SJDK - Defined here just in case someone wants to take a closer look at these in the future
+    /*
+    {"SHMS_eRFtimeDist_CT", "SHMS Corrected RF time Distribution for PID (e)", "fSHMS_eRFtimeDist_CT"},
+    {"SHMS_piRFtimeDist_CT", "SHMS Corrected RF time Distribution for PID (pi)", "fSHMS_piRFtimeDist_CT"},
+    {"SHMS_KRFtimeDist_CT", "SHMS Corrected RF time Distribution for PID (K)", "fSHMS_KRFtimeDist_CT"},
+    {"SHMS_pRFtimeDist_CT", "SHMS Corrected RF time Distribution for PID (p)", "fSHMS_pRFtimeDist_CT"},
+    */
+    {0}
   };
 
   return DefineVarsFromList( vars, mode );
@@ -341,7 +399,24 @@ Int_t THcCoinTime::Process( const THaEvData& evdata )
 	  fROC2_ePosCoinTime = fROC2_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
 	  fSHMS_ePosCoinTime = fSHMS_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
 	  fHMS_ePosCoinTime = fHMS_RAW_CoinTime + sign*( elec_coinCorr - had_coinCorr_Positron) - eHad_CT_Offset;
-         
+
+	  /*
+	  // SJDK - 31/01/23 - Tested a few different methods to correct the RF time for the Coin time based upon different particle types. Didn't have much luck with this. Shelving it for now
+	  // SJDK - 18/11/22 - Note, this is just for testing, RF time calculations should be made more "generic" as the CT ones already are
+	  // RF Time calculations - Testing
+	  // 21/11/22 - From testing, adding fROC1_ePosCoinTime as a correction doesn't have the desired effect. It is not a sign issue. Adding/subtracting fails to flatten CT vs RFTime
+	  // Will try using RAW times instead
+	  // Adding it didn't quite work, trying subtraction, didn't work either
+	  // Add coin time WITHOTUT adding correction? Being applied twice. Didn't work either
+	  // Raw Untracked variable? fROC1_RAW_CoinTime_NoTrack
+	  SHMS_RFtime = fCoinDet->Get_RF_TrigTime(0); // SHMS is ID 0
+
+	  fSHMS_eRFtimeDist_CT = fmod((fmod((SHMS_RFtime - SHMS_FPtime + SHMS_eRF_Offset + had_coinCorr_Positron + fROC1_RAW_CoinTime_NoTrack), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
+	  fSHMS_piRFtimeDist_CT = fmod((fmod((SHMS_RFtime - SHMS_FPtime + SHMS_piRF_Offset + had_coinCorr_Pion + fROC1_RAW_CoinTime_NoTrack), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
+	  fSHMS_KRFtimeDist_CT = fmod((fmod((SHMS_RFtime - SHMS_FPtime + SHMS_KRF_Offset + had_coinCorr_Kaon + fROC1_RAW_CoinTime_NoTrack), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
+	  fSHMS_pRFtimeDist_CT = fmod((fmod((SHMS_RFtime - SHMS_FPtime + SHMS_pRF_Offset + had_coinCorr_proton + fROC1_RAW_CoinTime_NoTrack), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
+	  */
+
   return 0;
 }
 

--- a/src/THcCoinTime.h
+++ b/src/THcCoinTime.h
@@ -107,7 +107,24 @@ public:
   Double_t fROC2_ePosCoinTime;
   Double_t fSHMS_ePosCoinTime;   //electron-positron coin time 
   Double_t fHMS_ePosCoinTime;
+  /*
+  // SJDK - 18/11/22 - Variables for RF testing
+  // SJDK 31/01/23 - No luck in getting this working, commented out again for now
+  Double_t SHMS_RF_Offset;
+  Double_t SHMS_eRF_Offset;
+  Double_t SHMS_piRF_Offset;
+  Double_t SHMS_KRF_Offset;
+  Double_t SHMS_pRF_Offset;
+  Double_t Bunch_Spacing;
+  Double_t Bunch_Spacing_Override;
+  Double_t SHMS_RFtime; // SHMS RF time
   
+  Double_t fSHMS_eRFtimeDist_CT;
+  Double_t fSHMS_piRFtimeDist_CT;
+  Double_t fSHMS_KRFtimeDist_CT;
+  Double_t fSHMS_pRFtimeDist_CT;  
+  */
+
   Double_t elec_coinCorr;
   Double_t elecArm_BetaCalc;
   Double_t elec_hodFPtime;

--- a/src/THcRFTime.cxx
+++ b/src/THcRFTime.cxx
@@ -126,8 +126,18 @@ Int_t THcRFTime::ReadDatabase( const TDatime& date )
 
   DBRequest list[]={
     {"HMS_RF_Offset",  &HMS_RF_Offset, kDouble, 0, 1},   // RF offset for HMS
+    {"HMS_eRF_Offset",  &HMS_eRF_Offset, kDouble, 0, 1},   // Electron/Positron RF offset for HMS
+    {"HMS_piRF_Offset",  &HMS_piRF_Offset, kDouble, 0, 1},   // Pion RF offset for HMS
+    {"HMS_KRF_Offset",  &HMS_KRF_Offset, kDouble, 0, 1},   //  Kaon RF offset for HMS
+    {"HMS_pRF_Offset",  &HMS_pRF_Offset, kDouble, 0, 1},   // Proton RF offset for HMS
     {"SHMS_RF_Offset",  &SHMS_RF_Offset, kDouble, 0, 1}, // RF offset for SHMS
-    {"Bunch_Spacing_Override",  &Bunch_Spacing_Override, kDouble, 0, 1}, // Bunch spacing value, can be manually set to override the Epics read in
+    {"SHMS_eRF_Offset",  &SHMS_eRF_Offset, kDouble, 0, 1},   // Electron/Positron RF offset for SHMS
+    {"SHMS_piRF_Offset",  &SHMS_piRF_Offset, kDouble, 0, 1},   // Pion RF offset for SHMS
+    {"SHMS_KRF_Offset",  &SHMS_KRF_Offset, kDouble, 0, 1},   //  Kaon RF offset for SHMS
+    {"SHMS_pRF_Offset",  &SHMS_pRF_Offset, kDouble, 0, 1},   // Proton RF offset for SHMS
+    {"Bunch_Spacing_Override",  &Bunch_Spacing_Override, kDouble, 0, 1}, // Bunch spacing value, can be manually set to override the Epics read in,
+    {"HMS_CentralPathLen",  &HMS_CentralPathLen, kDouble, 0, 1},
+    {"SHMS_CentralPathLen", &SHMS_CentralPathLen, kDouble, 0, 1},
     {0}
   };
 
@@ -135,6 +145,17 @@ Int_t THcRFTime::ReadDatabase( const TDatime& date )
   Bunch_Spacing_Override = 1.5556; // Strangely specific value so we can check if it's set or not
   HMS_RF_Offset = 0.0;
   SHMS_RF_Offset = 0.0;
+  
+  // Particle specific RF offset values, set to a default value. The default doesn't really make sense as a choice, check after read in if it was set
+  HMS_eRF_Offset = -5.1114;
+  HMS_piRF_Offset = -5.1114;
+  HMS_KRF_Offset = -5.1114;
+  HMS_pRF_Offset = -5.1114;
+  SHMS_eRF_Offset = -5.1114;
+  SHMS_piRF_Offset = -5.1114;
+  SHMS_KRF_Offset = -5.1114;
+  SHMS_pRF_Offset = -5.1114; 
+
   gHcParms->LoadParmValues((DBRequest*)&list, "");
   // If the override value has been set (i.e. it is NOT the default value), set it to whatever the read in is
   if ( Bunch_Spacing_Override != 1.5556){
@@ -144,6 +165,49 @@ Int_t THcRFTime::ReadDatabase( const TDatime& date )
   else if (Bunch_Spacing_Override == 1.5556){
     Bunch_Spacing = 4.008;
   }
+
+  // Slightly tedious way to do this, almost certainly a better/nicer way to check if it was defined in a param file
+  if (HMS_eRF_Offset == -5.1114){
+    HMS_eRF_Offset = HMS_RF_Offset; // If electron HMS offset wasn't explicitly set, set it to the same value as the generic spectrometer offset
+  }
+  if (HMS_piRF_Offset == -5.1114){
+    HMS_piRF_Offset = HMS_RF_Offset; // If pion HMS offset wasn't explicitly set, set it to the same value as the generic spectrometer offset
+  }
+  if (HMS_KRF_Offset == -5.1114){
+    HMS_KRF_Offset = HMS_RF_Offset; // If kaon HMS offset wasn't explicitly set, set it to the same value as the generic spectrometer offset
+  }
+  if (HMS_pRF_Offset == -5.1114){
+    HMS_pRF_Offset = HMS_RF_Offset; // If proton HMS offset wasn't explicitly set, set it to the same value as the generic spectrometer offset
+  }
+  if (SHMS_eRF_Offset == -5.1114){
+    SHMS_eRF_Offset = SHMS_RF_Offset; // If electron SHMS offset wasn't explicitly set, set it to the same value as the generic spectrometer offset
+  }
+  if (SHMS_piRF_Offset == -5.1114){
+    SHMS_piRF_Offset = SHMS_RF_Offset; // If pion SHMS offset wasn't explicitly set, set it to the same value as the generic spectrometer offset
+  }
+  if (SHMS_KRF_Offset == -5.1114){
+    SHMS_KRF_Offset = SHMS_RF_Offset; // If kaon SHMS offset wasn't explicitly set, set it to the same value as the generic spectrometer offset
+  }
+  if (SHMS_pRF_Offset == -5.1114){
+    SHMS_pRF_Offset = SHMS_RF_Offset; // If proton SHMS offset wasn't explicitly set, set it to the same value as the generic spectrometer offset
+  }
+  
+  // Add warning if strange offset value specified
+  if(abs(HMS_RF_Offset) > Bunch_Spacing || abs(SHMS_RF_Offset) > Bunch_Spacing){
+    cout << endl;
+    cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << endl;
+    cout << "NOTICE : One (or both) RF offsets are set to a value which is larger than the bunch spacing for the run -" << endl;
+    cout << "Bunch Spacing = " << Bunch_Spacing << " (ns)" << endl;
+    cout << "HMS RF Offset = " << HMS_RF_Offset << " (ns)" << endl;
+    cout << "SHMS RF Offset = " << SHMS_RF_Offset << " (ns)" << endl;
+    cout << "This doesn't actually make much sense, the RFDistribution takes the modulo of the bunch spacing." << endl;
+    cout << "Any value larger than the bunch spacing is effectively pointless, consider choosing the appropriate value within the range 0 to " << Bunch_Spacing << " instead." << endl;
+    cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << endl;
+    cout << endl;
+  }
+
+  HMS_CentralPathLen = 22.0*100.; // Path length in cm
+  SHMS_CentralPathLen = 18.1*100.; // Path legnth in cm
 
   THcAnalyzer *analyzer = dynamic_cast<THcAnalyzer*>(THcAnalyzer::GetInstance());
   fEpicsHandler = analyzer->GetEpicsEvtHandler();
@@ -158,9 +222,17 @@ Int_t THcRFTime::DefineVariables( EMode mode )
   if( mode == kDefine && fIsSetup ) return kOK;
   fIsSetup = ( mode == kDefine );
   const RVarDef vars[] = {
-    {"HMS_RFtimeDist",    "HMS RF Time Disttribution for PID",  "fHMS_RFtimeDist"},
-    {"SHMS_RFtimeDist",    "SHMS RF Time Disttribution for PID",  "fSHMS_RFtimeDist"},
-    { 0 }
+    {"HMS_RFtimeDist", "HMS RF Time Distribution for PID", "fHMS_RFtimeDist"},
+    {"HMS_eRFtimeDist", "HMS Corrected RF time Distribution for PID (e)", "fHMS_eRFtimeDist"},
+    {"HMS_piRFtimeDist", "HMS Corrected RF time Distribution for PID (pi)", "fHMS_piRFtimeDist"},
+    {"HMS_KRFtimeDist", "HMS Corrected RF time Distribution for PID (K)", "fHMS_KRFtimeDist"},
+    {"HMS_pRFtimeDist", "HMS Corrected RF time Distribution for PID (p)", "fHMS_pRFtimeDist"},
+    {"SHMS_RFtimeDist", "SHMS RF time Distribution for PID", "fSHMS_RFtimeDist"},
+    {"SHMS_eRFtimeDist", "SHMS Corrected RF time Distribution for PID (e)", "fSHMS_eRFtimeDist"},
+    {"SHMS_piRFtimeDist", "SHMS Corrected RF time Distribution for PID (pi)", "fSHMS_piRFtimeDist"},
+    {"SHMS_KRFtimeDist", "SHMS Corrected RF time Distribution for PID (K)", "fSHMS_KRFtimeDist"},
+    {"SHMS_pRFtimeDist", "SHMS Corrected RF time Distribution for PID (p)", "fSHMS_pRFtimeDist"},
+    {0}
   };
 
   return DefineVarsFromList( vars, mode );
@@ -203,17 +275,63 @@ Int_t THcRFTime::Process( const THaEvData& evdata )
     theHMSTrack = (fhadSpectro->GetGoldenTrack());
   }
 
+  lightSpeed = 29.9792; // in cm/ns
+  //Particle Masses (HardCoded)
+  elecMass =  0.510998/1000.0; // electron mass in GeV/c^2
+  pionMass = 139.570/1000.0;    //charged pion mass in GeV/c^2
+  kaonMass = 493.677/1000.0;    //charged kaon mass in GeV/c^2
+  protonMass = 938.27208/1000.0; // proton mass in GeV/c^2	
+
   //Check if Database is reading the correct elec-arm particle mass
   // if (felecSpectro->GetParticleMass() > 0.00052) return 1;
-
-  Double_t SHMS_FPtime = theSHMSTrack->GetFPTime();// SHMS arm
-  Double_t HMS_FPtime = theHMSTrack->GetFPTime();  // HMS arm
+  // HMS Arm
+  Double_t HMS_xptar = theHMSTrack->GetTTheta();
+  Double_t HMS_P = theHMSTrack->GetP();
+  Double_t HMS_dP = theHMSTrack->GetDp();     
+  Double_t HMS_FPtime = theHMSTrack->GetFPTime();
+  // SHMS Arm
+  Double_t SHMS_xptar = theSHMSTrack->GetTTheta();
+  Double_t SHMS_P = theSHMSTrack->GetP();
+  Double_t SHMS_dP = theSHMSTrack->GetDp();
+  Double_t SHMS_FPtime = theSHMSTrack->GetFPTime();
 
   if (SHMS_FPtime==-2000 || HMS_FPtime==-2000)  return 1;
   if (SHMS_FPtime==-1000 || HMS_FPtime==-1000)  return 1;
 
-  SHMS_RFtime = fCoinDet->Get_RF_TrigTime(0); // SHMS is ID 0
   HMS_RFtime = fCoinDet->Get_RF_TrigTime(1); // HMS is ID 1
+  SHMS_RFtime = fCoinDet->Get_RF_TrigTime(0); // SHMS is ID 0
+
+  HMS_DeltaPathLen = HMS_CentralPathLen + (.12*HMS_xptar*1000) + (0.17*(HMS_dP/100.)); // Path length in cm
+  SHMS_DeltaPathLen = SHMS_CentralPathLen + (.11*SHMS_xptar*1000) + (0.057*(SHMS_dP/100.));
+
+  //beta calculations beta = v/c = p/E
+  HMS_Beta_Calc_e = HMS_P / sqrt((HMS_P*HMS_P)+(elecMass*elecMass));
+  HMS_Beta_Calc_pi = HMS_P / sqrt((HMS_P*HMS_P)+(pionMass*pionMass));
+  HMS_Beta_Calc_K = HMS_P / sqrt((HMS_P*HMS_P)+(kaonMass*kaonMass));
+  HMS_Beta_Calc_p = HMS_P / sqrt((HMS_P*HMS_P)+(protonMass*protonMass));
+  SHMS_Beta_Calc_e = SHMS_P / sqrt((SHMS_P*SHMS_P)+(elecMass*elecMass));
+  SHMS_Beta_Calc_pi = SHMS_P / sqrt((SHMS_P*SHMS_P)+(pionMass*pionMass));
+  SHMS_Beta_Calc_K = SHMS_P / sqrt((SHMS_P*SHMS_P)+(kaonMass*kaonMass));
+  SHMS_Beta_Calc_p = SHMS_P / sqrt((SHMS_P*SHMS_P)+(protonMass*protonMass));
+
+  // ToF for central path by particle species - Not needed? Shuo calculates, but doesn't actually seem useful
+  HMS_RFCentralTime_e = (HMS_CentralPathLen)/(lightSpeed*HMS_Beta_Calc_e);
+  HMS_RFCentralTime_pi = (HMS_CentralPathLen)/(lightSpeed*HMS_Beta_Calc_pi);
+  HMS_RFCentralTime_K = (HMS_CentralPathLen)/(lightSpeed*HMS_Beta_Calc_K);
+  HMS_RFCentralTime_p = (HMS_CentralPathLen)/(lightSpeed*HMS_Beta_Calc_p);
+  SHMS_RFCentralTime_e = (SHMS_CentralPathLen)/(lightSpeed*SHMS_Beta_Calc_e);
+  SHMS_RFCentralTime_pi = (SHMS_CentralPathLen)/(lightSpeed*SHMS_Beta_Calc_pi);
+  SHMS_RFCentralTime_K = (SHMS_CentralPathLen)/(lightSpeed*SHMS_Beta_Calc_K);
+  SHMS_RFCentralTime_p = (SHMS_CentralPathLen)/(lightSpeed*SHMS_Beta_Calc_p);
+  // ToF for delta path by particle species
+  HMS_RFDeltaTime_e = (HMS_DeltaPathLen)/(lightSpeed*HMS_Beta_Calc_e);
+  HMS_RFDeltaTime_pi = (HMS_DeltaPathLen)/(lightSpeed*HMS_Beta_Calc_pi);
+  HMS_RFDeltaTime_K = (HMS_DeltaPathLen)/(lightSpeed*HMS_Beta_Calc_K);
+  HMS_RFDeltaTime_p = (HMS_DeltaPathLen)/(lightSpeed*HMS_Beta_Calc_p);
+  SHMS_RFDeltaTime_e = (SHMS_DeltaPathLen)/(lightSpeed*SHMS_Beta_Calc_e);
+  SHMS_RFDeltaTime_pi = (SHMS_DeltaPathLen)/(lightSpeed*SHMS_Beta_Calc_pi);
+  SHMS_RFDeltaTime_K = (SHMS_DeltaPathLen)/(lightSpeed*SHMS_Beta_Calc_K);
+  SHMS_RFDeltaTime_p = (SHMS_DeltaPathLen)/(lightSpeed*SHMS_Beta_Calc_p);
 
   // RF Time dist can be utilised for PID, offsets should be set in Standard.kinematics, these are just used to "center" the distribution at a desired point
   // Typically, other PID info needs to be utilised to establish where the relevant peaks for each particle species are in the distribution
@@ -223,6 +341,19 @@ Int_t THcRFTime::Process( const THaEvData& evdata )
   fHMS_RFtimeDist = fmod((fmod((HMS_RFtime - HMS_FPtime + HMS_RF_Offset), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
   fSHMS_RFtimeDist = fmod((fmod((SHMS_RFtime - SHMS_FPtime + SHMS_RF_Offset), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
 
+  // 21/10/22 - Determine a corrected RFtime based upon the path length/velocity for different particle species.
+  // Based upon the CTime correction by C. Yero and work by S. Jia
+  // Beta is calculated for each particle species and the path length is determined from delta and xptar. From this, a ToF for each particle species is calculated and added in the modulo. This produces a flat distribution across delta when appropriate PID is applied
+  // An offset can be applied for each particle type if desired to centre their distributions arbitrarily
+  fHMS_eRFtimeDist = fmod((fmod((HMS_RFtime - HMS_FPtime + HMS_eRF_Offset + HMS_RFDeltaTime_e), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
+  fHMS_piRFtimeDist = fmod((fmod((HMS_RFtime - HMS_FPtime + HMS_piRF_Offset + HMS_RFDeltaTime_pi), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
+  fHMS_KRFtimeDist = fmod((fmod((HMS_RFtime - HMS_FPtime + HMS_KRF_Offset + HMS_RFDeltaTime_K), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
+  fHMS_pRFtimeDist = fmod((fmod((HMS_RFtime - HMS_FPtime + HMS_pRF_Offset + HMS_RFDeltaTime_p), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
+  fSHMS_eRFtimeDist = fmod((fmod((SHMS_RFtime - SHMS_FPtime + SHMS_eRF_Offset + SHMS_RFDeltaTime_e), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
+  fSHMS_piRFtimeDist = fmod((fmod((SHMS_RFtime - SHMS_FPtime + SHMS_piRF_Offset + SHMS_RFDeltaTime_pi), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
+  fSHMS_KRFtimeDist = fmod((fmod((SHMS_RFtime - SHMS_FPtime + SHMS_KRF_Offset + SHMS_RFDeltaTime_K), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
+  fSHMS_pRFtimeDist = fmod((fmod((SHMS_RFtime - SHMS_FPtime + SHMS_pRF_Offset + SHMS_RFDeltaTime_p), Bunch_Spacing) + Bunch_Spacing), Bunch_Spacing);
+  
   return 0;
 }
 

--- a/src/THcRFTime.cxx
+++ b/src/THcRFTime.cxx
@@ -64,7 +64,16 @@ void THcRFTime::Clear( Option_t* opt )
   // Only need to clear variables that are actually used, will need to re-tweak this when the rest is set up
   //  THaPhysicsModule::Clear(opt);
   fHMS_RFtimeDist=kBig;
+  fHMS_eRFtimeDist=kBig;
+  fHMS_piRFtimeDist=kBig;
+  fHMS_KRFtimeDist=kBig;
+  fHMS_pRFtimeDist=kBig;
   fSHMS_RFtimeDist=kBig;
+  fSHMS_eRFtimeDist=kBig;
+  fSHMS_piRFtimeDist=kBig;
+  fSHMS_KRFtimeDist=kBig;
+  fSHMS_pRFtimeDist=kBig;
+  
 }
 
 //_____________________________________________________________________________
@@ -73,7 +82,6 @@ void THcRFTime::Reset( Option_t* opt)
 {
   Clear(opt);
 }
-
 
 //_____________________________________________________________________________
 THaAnalysisObject::EStatus THcRFTime::Init( const TDatime& run_time )

--- a/src/THcRFTime.cxx
+++ b/src/THcRFTime.cxx
@@ -72,8 +72,7 @@ void THcRFTime::Clear( Option_t* opt )
   fSHMS_eRFtimeDist=kBig;
   fSHMS_piRFtimeDist=kBig;
   fSHMS_KRFtimeDist=kBig;
-  fSHMS_pRFtimeDist=kBig;
-  
+  fSHMS_pRFtimeDist=kBig;  
 }
 
 //_____________________________________________________________________________
@@ -286,7 +285,7 @@ Int_t THcRFTime::Process( const THaEvData& evdata )
   }
 
   lightSpeed = 29.9792; // in cm/ns
-  //Particle Masses (Hardcoded - should be able to grab from elsewhere?)
+  // Particle Masses (Hardcoded - should be able to grab from elsewhere?)
   elecMass =  0.510998/1000.0; // electron mass in GeV/c^2
   pionMass = 139.570/1000.0;    //charged pion mass in GeV/c^2
   kaonMass = 493.677/1000.0;    //charged kaon mass in GeV/c^2

--- a/src/THcRFTime.h
+++ b/src/THcRFTime.h
@@ -49,7 +49,7 @@ public:
   Int_t fNhits;
 
   virtual Int_t ReadDatabase( const TDatime& date);
-  virtual Int_t  DefineVariables( EMode mode = kDefine );
+  virtual Int_t DefineVariables( EMode mode = kDefine );
 
   // Data needed for adding RF time dist as a Leaf Variable
   // Need offset and bunch spacing too
@@ -70,95 +70,75 @@ public:
   THcHodoscope* fHod;	                // Hodscope object
 
   Double_t HMS_RF_Offset;
+  Double_t HMS_eRF_Offset;
+  Double_t HMS_piRF_Offset;
+  Double_t HMS_KRF_Offset;
+  Double_t HMS_pRF_Offset;
   Double_t SHMS_RF_Offset;
+  Double_t SHMS_eRF_Offset;
+  Double_t SHMS_piRF_Offset;
+  Double_t SHMS_KRF_Offset;
+  Double_t SHMS_pRF_Offset;
   Double_t Bunch_Spacing_Override;
 
   Double_t Bunch_Spacing;
   Double_t Bunch_Spacing_Epics;
   Double_t HMS_RFtime; // HMS RF time
   Double_t SHMS_RFtime; // SHMS RF time
-  Double_t HMS_FPtime;   //HMS focal plane time  
-  Double_t SHMS_FPtime;   //SHMS focal plane time
 
   Double_t fHMS_RFtimeDist; // These are the two quantities we actually want to try to determine and produce in the end
   Double_t fSHMS_RFtimeDist;
 
-  // Variables and stuff used in the CoinTime path length correction calculations
-  // May want to re-use some of these in the future 
-  //-----Declare Variables used in HMS/SHMS RF. time correction-----
-  // This is just the coin timing stuff now, will need similar for RF
-  //  Double_t lightSpeed;
-  //Double_t elecMass;
-  //Double_t positronMass;
+  // SJDK 21/10/22 - Adding in mass corrected RF times for HMS/SHMS. 4 particle species, e/pi/K/p
+  Double_t fHMS_eRFtimeDist;
+  Double_t fHMS_piRFtimeDist;
+  Double_t fHMS_KRFtimeDist;
+  Double_t fHMS_pRFtimeDist;
 
-  //hadron masses (the e- could be in coincidence with any of the hadrons)
-  //Double_t protonMass;
-  //Double_t kaonMass;
-  //Double_t pionMass;
+  Double_t fSHMS_eRFtimeDist;
+  Double_t fSHMS_piRFtimeDist;
+  Double_t fSHMS_KRFtimeDist;
+  Double_t fSHMS_pRFtimeDist;
+
+  //-----Declare Variables used in HMS/SHMS RF time correction-----
+  Double_t lightSpeed;
+  Double_t elecMass;
+  Double_t protonMass;
+  Double_t kaonMass;
+  Double_t pionMass;
+
+  Double_t HMS_CentralPathLen;  
+  Double_t HMS_DeltaPathLen;
+  Double_t SHMS_CentralPathLen;  
+  Double_t SHMS_DeltaPathLen;
+
+  Double_t HMS_Beta_Calc_e;
+  Double_t HMS_Beta_Calc_pi;
+  Double_t HMS_Beta_Calc_K;
+  Double_t HMS_Beta_Calc_p;
+  Double_t SHMS_Beta_Calc_e;
+  Double_t SHMS_Beta_Calc_pi;
+  Double_t SHMS_Beta_Calc_K;
+  Double_t SHMS_Beta_Calc_p;
+
+  Double_t HMS_RFCentralTime_e;
+  Double_t HMS_RFCentralTime_pi;
+  Double_t HMS_RFCentralTime_K;
+  Double_t HMS_RFCentralTime_p;
+  Double_t SHMS_RFCentralTime_e;
+  Double_t SHMS_RFCentralTime_pi;
+  Double_t SHMS_RFCentralTime_K;
+  Double_t SHMS_RFCentralTime_p;
+
+  Double_t HMS_RFDeltaTime_e;
+  Double_t HMS_RFDeltaTime_pi;
+  Double_t HMS_RFDeltaTime_K;
+  Double_t HMS_RFDeltaTime_p;
+  Double_t SHMS_RFDeltaTime_e;
+  Double_t SHMS_RFDeltaTime_pi;
+  Double_t SHMS_RFDeltaTime_K;
+  Double_t SHMS_RFDeltaTime_p;
   
-  // These variables and calculations are probably still good
-  //Double_t SHMScentralPathLen;  
-  //Double_t HMScentralPathLen;   
-
-  //Double_t DeltaSHMSpathLength;
-  //Double_t DeltaHMSpathLength;
-
-  // Coin time values, not needed, delete soon
-  /*
-  Double_t fROC1_RAW_CoinTime;
-  Double_t fROC2_RAW_CoinTime;
-  Double_t fTRIG1_RAW_CoinTime;
-  Double_t fTRIG4_RAW_CoinTime;
-  
-  Double_t fROC1_epCoinTime;
-  Double_t fROC2_epCoinTime;
-  Double_t fTRIG1_epCoinTime;
-  Double_t fTRIG4_epCoinTime;
-
-  Double_t fROC1_eKCoinTime;
-  Double_t fROC2_eKCoinTime;
-  Double_t fTRIG1_eKCoinTime;
-  Double_t fTRIG4_eKCoinTime;
-
-  Double_t fROC1_ePiCoinTime;
-  Double_t fROC2_ePiCoinTime;
-  Double_t fTRIG1_ePiCoinTime;
-  Double_t fTRIG4_ePiCoinTime;
- 
-  Double_t fROC1_ePosCoinTime;   //electron-positron coin time 
-  Double_t fROC2_ePosCoinTime;
-  Double_t fTRIG1_ePosCoinTime;   //electron-positron coin time 
-  Double_t fTRIG4_ePosCoinTime;
-  */
-
-  //Double_t elec_coinCorr;
-  //Double_t elecArm_BetaCalc;
-  //Double_t elec_hodFPtime;
-  
-  //Double_t had_coinCorr_proton;
-  // Double_t hadArm_BetaCalc_proton;
-  
-  //Double_t had_coinCorr_Kaon;
-  //Double_t hadArm_BetaCalc_Kaon;
-   
-  //Double_t had_coinCorr_Pion;
-  //Double_t hadArm_BetaCalc_Pion;
-  
-  //Double_t had_coinCorr_Positron;
-  //Double_t hadArm_BetaCalc_Positron;
-  
-  // Still needed as part of difference calculation? Keep? 
-  //Double_t elec_P;     //electron golden track momentum
-  //Double_t elec_dP;     //electron golden track delta-> (P-P0 / P0)
-  //Double_t elec_xptar;    //electron golden track theta (xptar, :) 
-
-  //Double_t had_P;     //hadron golden track momentum
-  //Double_t had_xfp;      //hadron x-focal plane
-  //Double_t had_xpfp;     //hadron xp focal plane
-  //Double_t had_ypfp;     //hadron yp focal plane
-
-  //--------------------------------------------------------------------
-
   ClassDef(THcRFTime,0) 	// RF Time Module
 };
 


### PR DESCRIPTION
I've updated the RFTime class with some new additions.

I added in particle dependent corrections for each spectrometer. An offset for each particle species can also be defined an applied separately if desired too.

Attached is a series of plots showing that the RFTime, corrected by particle species, is now flat across delta. 1D distributions of the uncorrected RF time plotted against the particle specific RF time are show on page 3. The distributions after the correction all appear sharper and are shifted (hence the need for a per particle offset). Pages 4 and 6 show the particle dependent RF vs delta and MM respectively. 

[Q2_3p0_W2p32_loweps_15_11_22.pdf](https://github.com/JeffersonLab/hcana/files/10024602/Q2_3p0_W2p32_loweps_15_11_22.pdf)

Note, for these plots the cuts applied were as follows -

General Cuts - H.gtr.dp > -8 && H.gtr.dp < 8 && P.gtr.dp > -10 && P.gtr.dp <20 && H.cal.etottracknorm > 0.7 && H.cal.etottracknorm < 1.4 && H.cer.npeSum > 1 && abs(H.gtr.beta-1) < 0.3
PID -
Positron - P.cal.etottracknorm > 0.7 && P.cal.etottracknorm < 1.4 && P.aero.npeSum > 1 && P.hgcer.npeSum > 1
Pion - P.cal.etottracknorm < 0.7 && P.aero.npeSum > 1.5 && P.hgcer.npeSum > 1
Kaon - P.cal.etottracknorm < 0.7 && P.aero.npeSum > 1.5 && P.hgcer.npeSum < 3
Proton - P.cal.etottracknorm < 0.7 && P.aero.npeSum < 3 && P.hgcer.npeSum < 5

Appropriate CT cuts (determined from pages 1 and 2) were also applied as needed.

The correction applied is simply the ToF for the particle type. This is done by determining the path length (from delta and xptar, see lines 304 and 305 - this is lifted from the CTime class by CYero), this is then simply divided by Beta * c, where Beta here has been determined for each particle type from the momentum and mass (lines 308-317). Note that this is the _track_ momentum and _not_ the spectrometer momentum. 

The ToF is calculated in lines 319-327. This is then applied as a correction when determing the new particle RFDistributions (lines 337-349). 

As mentioned, the offsets can be set individually as refelected in these calculations. By default, they will be set to the offset for the spectrometer if they are _not_ specfied in a database file. The way this was implemented isn't great and could definitely be improved upon (I'd rather just check if the variable is specified in a database file or not, but couldn't find a nice example of this)

In addition to this, I also added in some warnings regarding the choice of the RF offset value specified. 

There are still a few things I want to add, so please don't merge this in just yet (hence why it's a draft for now). This is more of a preview of what's planned. In particular, I also want to investigate the possibility of adding a set of CT corrected RFTime variables (to flatten the distributions on page 5 of the pdf earlier and remove the CT/RF correlation). 

I also want to further test this across other settings before a merge.