### PR TITLE
Updated THcNPSArray to have flag to output raw waveform sample

### DIFF
--- a/src/THcNPSArray.cxx
+++ b/src/THcNPSArray.cxx
@@ -331,6 +331,7 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
     {"_cal_arr_SampNSAT",     &fSampNSAT,       kInt,0,1},
     {"_cal_arr_SampNSB",     &fSampNSB,       kInt,0,1},
     {"_cal_arr_OutputSampWaveform",     &fOutputSampWaveform,       kInt,0,1},
+    {"_cal_arr_OutputSampRawWaveform",     &fOutputSampRawWaveform,       kInt,0,1},
     {"_cal_arr_UseSampWaveform",     &fUseSampWaveform,       kInt,0,1},
     {0}
   };
@@ -350,6 +351,7 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
    fSampNSAT = 2; // default value in THcRawHit::SetF250Params
    cout << " fSampThreshold 1 = " << fSampThreshold << endl;
    fOutputSampWaveform = 1; // 0= no output , 1 = output Sample Waveform
+   fOutputSampRawWaveform = 0; // 0= output pedestal subtracted (mV) , 1 = output Sample Raw Waveform (ADC chan)
    fUseSampWaveform = 1; // 0= do not use , 1 = use Sample Waveform
    
    gHcParms->LoadParmValues((DBRequest*)&list1, fKwPrefix.c_str());
@@ -1104,7 +1106,11 @@ Int_t THcNPSArray::AccumulateHits(TClonesArray* rawhits, Int_t nexthit, Int_t tr
     fSampWaveform.push_back(float(rawAdcHit.GetNSamples()));
 
     for (UInt_t thit = 0; thit < rawAdcHit.GetNSamples(); thit++) {
-      fSampWaveform.push_back(rawAdcHit.GetSample(thit)); // ped subtracted sample (mV)
+      if (fOutputSampRawWaveform == 1) {
+          fSampWaveform.push_back(rawAdcHit.GetSampleRaw(thit)); // raw sample (Adc chan)
+       } else {
+         fSampWaveform.push_back(rawAdcHit.GetSample(thit)); // ped subtracted sample (mV)
+       }
     }
     
     for (UInt_t thit = 0; thit < rawAdcHit.GetNSampPulses(); thit++) {

--- a/src/THcNPSArray.h
+++ b/src/THcNPSArray.h
@@ -207,6 +207,7 @@ protected:
   Int_t fLayerNum;		// 2 for SHMS
 
   Int_t  fOutputSampWaveform;
+  Int_t  fOutputSampRawWaveform;
   Int_t  fUseSampWaveform;
   Double_t  fSampThreshold;
   Int_t  fSampNSA;


### PR DESCRIPTION
Added parameter nps_cal_arr_OutputSampRawWaveform
; If nps_cal_arr_OutputSampRawWaveform = 1
   then output raw (Adc Chan) 4ns samples in the waveform
; If nps_cal_arr_OutputSampRawWaveform = 0
  then output pedestal subtracted (converted to mV) 4ns samples in the waveform
; Default is nps_cal_arr_OutputSampRawWaveform=0
  if  nps_cal_arr_OutputSampRawWaveform is not set in parameter file

Modified THcNPSArray to fill fOutputSampRawWaveform with new parameter 1) fSampWaveform in loaded with raw ADC chan values if nps_cal_arr_OutputSampRawWaveform = 1 2) fSampWaveform in loaded with pedsubtracted ADC values converted to mV
   if nps_cal_arr_OutputSampRawWaveform = 0