### PR TITLE
Per-block AdcTdcOffset for NPS calorimeter

### DIFF
--- a/src/THcNPSArray.cxx
+++ b/src/THcNPSArray.cxx
@@ -189,7 +189,6 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
     {"_cal_using_fadc", &fUsingFADC, kInt, 0, 1},
     {"_cal_clustering", &fClustMethod, kInt, 0, 1},
     //    {"_cal_arr_ADCMode", &fADCMode, kInt, 0, 1},
-    //    {"_cal_arr_adc_tdc_offset", &fAdcTdcOffset, kDouble, 0, 1},
     {"_cal_arr_AdcThreshold", &fAdcThreshold, kDouble, 0, 1},
     {"_cal_arr_adc_samp_threshold", &fAdcSampThreshold, kDouble, 0, 1},
     {"_cal_arr_adc_peak_samp_width", &fDataSampWidth, kDouble, 0, 1},
@@ -205,9 +204,8 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
   };
 
   fClustMethod = 0;  //Set default clusterin method to HMS/SHMS original 
-  fDebugAdc = 1;  // Set ADC debug parameter to false unless set in parameter file
+  fDebugAdc = 0;  // Set ADC debug parameter to false unless set in parameter file
   //  fADCMode=kADCDynamicPedestal;
-  //  fAdcTdcOffset=0.0;
   fAdcThreshold=0.;
   fAdcSampThreshold=30;		// Peak found if this amount above pedestal
   fDataSampWidth=15;		// Integrate this # of samples to get peak area
@@ -310,7 +308,7 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
   Double_t cal_arr_cal_const[fNelem];
   Double_t cal_arr_gain_cor[fNelem];
 
-  cal_arr_AdcTdcOffset = new Double_t [fNelem];
+  fAdcTdcOffset = new Double_t [fNelem];
 
   fAdcTimeWindowMin = new Double_t [fNelem];
   fAdcTimeWindowMax = new Double_t [fNelem];
@@ -321,9 +319,9 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
   
   DBRequest list1[]={
     {"_cal_arr_ped_limit", fPedLimit, kInt, static_cast<UInt_t>(fNelem),1},
-    {"_cal_arr_AdcTdcOffset", cal_arr_AdcTdcOffset, kDouble, static_cast<UInt_t>(fNelem),1},
     {"_cal_arr_cal_const", cal_arr_cal_const, kDouble, static_cast<UInt_t>(fNelem)},
     {"_cal_arr_gain_cor",  cal_arr_gain_cor,  kDouble, static_cast<UInt_t>(fNelem)},
+    {"_cal_arr_adc_tdc_offset", fAdcTdcOffset, kDouble, static_cast<UInt_t>(fNelem),1},
     {"_cal_arr_AdcTimeWindowMin", fAdcTimeWindowMin, kDouble, static_cast<UInt_t>(fNelem),1},
     {"_cal_arr_AdcTimeWindowMax", fAdcTimeWindowMax, kDouble, static_cast<UInt_t>(fNelem),1},
     {"_cal_arr_AdcPulseTimeMin", fAdcPulseTimeMin, kDouble, static_cast<UInt_t>(fNelem),1},
@@ -373,12 +371,12 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
       cout <<  endl;
     };
 
-    cout << "  cal_arr_AdcTdcOffset:" << endl;
+    cout << "  cal_arr_adc_tdc_offset:" << endl;
     el=0;
     for (UInt_t j=0; j<fNColumns; j++) {
       cout << "    ";
       for (UInt_t i=0; i<fNRows; i++) {
-	cout << cal_arr_AdcTdcOffset[el++] << " ";
+	cout << fAdcTdcOffset[el++] << " ";
       };
       cout << endl;
     };
@@ -1079,7 +1077,7 @@ Int_t THcNPSArray::AccumulateHits(TClonesArray* rawhits, Int_t nexthit, Int_t tr
 	((THcSignalHit*) frAdcPulseAmp->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPulseAmp(thit));
 	
 	((THcSignalHit*) frAdcPulseTimeRaw->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPulseTimeRaw(thit));
-	((THcSignalHit*) frAdcPulseTime->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPulseTime(thit)+cal_arr_AdcTdcOffset[padnum]);
+	((THcSignalHit*) frAdcPulseTime->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPulseTime(thit)+fAdcTdcOffset[padnum]);
 
 	if (rawAdcHit.GetPulseAmpRaw(thit) > 0)  ((THcSignalHit*) frAdcErrorFlag->ConstructedAt(nrAdcHits))->Set(padnum, 0);
 	if (rawAdcHit.GetPulseAmpRaw(thit) <= 0) ((THcSignalHit*) frAdcErrorFlag->ConstructedAt(nrAdcHits))->Set(padnum, 1);
@@ -1134,7 +1132,7 @@ Int_t THcNPSArray::AccumulateHits(TClonesArray* rawhits, Int_t nexthit, Int_t tr
       ((THcSignalHit*) frAdcSampPulseAmpRaw->ConstructedAt(nrSampAdcHits))->Set(padnum, rawAdcHit.GetSampPulseAmpRaw(thit));
       ((THcSignalHit*) frAdcSampPulseAmp->ConstructedAt(nrSampAdcHits))->Set(padnum, rawAdcHit.GetSampPulseAmp(thit));
       ((THcSignalHit*) frAdcSampPulseTimeRaw->ConstructedAt(nrSampAdcHits))->Set(padnum, rawAdcHit.GetSampPulseTimeRaw(thit));
-      ((THcSignalHit*) frAdcSampPulseTime->ConstructedAt(nrSampAdcHits))->Set(padnum, rawAdcHit.GetSampPulseTime(thit)+cal_arr_AdcTdcOffset[padnum]);
+      ((THcSignalHit*) frAdcSampPulseTime->ConstructedAt(nrSampAdcHits))->Set(padnum, rawAdcHit.GetSampPulseTime(thit)+fAdcTdcOffset[padnum]);
       //
       if ( rawAdcHit.GetNPulses() == 0 || fUseSampWaveform ==1 ) {
 	((THcSignalHit*) frAdcPedRaw->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetSampPedRaw());
@@ -1147,7 +1145,7 @@ Int_t THcNPSArray::AccumulateHits(TClonesArray* rawhits, Int_t nexthit, Int_t tr
 	((THcSignalHit*) frAdcPulseAmp->ConstructedAt(nrAdcHits))->Set(padnum,rawAdcHit.GetSampPulseAmp(thit) );
 	
 	((THcSignalHit*) frAdcPulseTimeRaw->ConstructedAt(nrAdcHits))->Set(padnum,rawAdcHit.GetSampPulseTimeRaw(thit) );
-	((THcSignalHit*) frAdcPulseTime->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetSampPulseTime(thit)+cal_arr_AdcTdcOffset[padnum]);
+	((THcSignalHit*) frAdcPulseTime->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetSampPulseTime(thit)+fAdcTdcOffset[padnum]);
 
 	((THcSignalHit*) frAdcErrorFlag->ConstructedAt(nrAdcHits))->Set(padnum, 3);  
 	if (fUseSampWaveform ==1) ((THcSignalHit*) frAdcErrorFlag->ConstructedAt(nrAdcHits))->Set(padnum, 0);  
@@ -1218,9 +1216,9 @@ Int_t THcNPSArray::AccumulateHits(TClonesArray* rawhits, Int_t nexthit, Int_t tr
 // 	    ((THcSignalHit*) frAdcPulseAmpRaw->ConstructedAt(nrAdcHits))->Set(padnum, sampmax);
 // 	    ((THcSignalHit*) frAdcPulseAmp->ConstructedAt(nrAdcHits))->Set(padnum, (sampmax-pedestal)*rawAdcHit.GetAdcTomV());
 // 	    ((THcSignalHit*) frAdcPulseTimeRaw->ConstructedAt(nrAdcHits))->Set(padnum, rawtime);
-// 	    Double_t time = (rawtime - rawAdcHit.GetRefTime())*rawAdcHit.GetAdcTons()+fAdcTdcOffset;
+// 	    Double_t time = (rawtime - rawAdcHit.GetRefTime())*rawAdcHit.GetAdcTons()+fAdcTdcOffset[padnum];
 // 	    //	    ((THcSignalHit*) frAdcPulseTime->ConstructedAt(nrAdcHits))->
-// 	    //	      Set(padnum, (rawtime - rawAdcHit.GetRefTime())*rawAdcHit.GetAdcTons()+fAdcTdcOffset);
+// 	    //	      Set(padnum, (rawtime - rawAdcHit.GetRefTime())*rawAdcHit.GetAdcTons()+fAdcTdcOffset[padnum]);
 // 	    ((THcSignalHit*) frAdcPulseTime->ConstructedAt(nrAdcHits))->
 // 	      Set(padnum, time);
 // 	    if (sampmax-pedestal>0&&integralraw>0) {
@@ -1250,8 +1248,8 @@ Int_t THcNPSArray::AccumulateHits(TClonesArray* rawhits, Int_t nexthit, Int_t tr
 //     if(padnum == 112) {
 //       for (UInt_t thit=0; thit<rawAdcHit.GetNPulses(); ++thit) {
 // 	Double_t rawtime = rawAdcHit.GetPulseTimeRaw(thit);
-// 	Double_t time = rawAdcHit.GetPulseTime(thit)+fAdcTdcOffset;
-// 	cout << "Pulse: " << thit << " " << time << " " << rawtime << " " << fAdcTdcOffset <<
+// 	Double_t time = rawAdcHit.GetPulseTime(thit)+fAdcTdcOffset[padnum];
+// 	cout << "Pulse: " << thit << " " << time << " " << rawtime << " " << fAdcTdcOffset[padnum] <<
 // 	  " R" << rawAdcHit.GetRefTime() << endl;
 //       }
 //     }
@@ -1277,7 +1275,7 @@ Int_t THcNPSArray::AccumulateHits(TClonesArray* rawhits, Int_t nexthit, Int_t tr
 // 	((THcSignalHit*) frAdcPulseAmp->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPulseAmp(thit));
 	
 // 	((THcSignalHit*) frAdcPulseTimeRaw->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPulseTimeRaw(thit));
-// 	((THcSignalHit*) frAdcPulseTime->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPulseTime(thit)+fAdcTdcOffset);
+// 	((THcSignalHit*) frAdcPulseTime->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPulseTime(thit)+fAdcTdcOffset[padnum]);
 
 // 	if (rawAdcHit.GetPulseAmp(thit)>0&&rawAdcHit.GetPulseIntRaw(thit)>0) {
 // 	  ((THcSignalHit*) frAdcErrorFlag->ConstructedAt(nrAdcHits))->Set(padnum,0);

--- a/src/THcNPSArray.cxx
+++ b/src/THcNPSArray.cxx
@@ -189,7 +189,7 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
     {"_cal_using_fadc", &fUsingFADC, kInt, 0, 1},
     {"_cal_clustering", &fClustMethod, kInt, 0, 1},
     //    {"_cal_arr_ADCMode", &fADCMode, kInt, 0, 1},
-    {"_cal_arr_adc_tdc_offset", &fAdcTdcOffset, kDouble, 0, 1},
+    //    {"_cal_arr_adc_tdc_offset", &fAdcTdcOffset, kDouble, 0, 1},
     {"_cal_arr_AdcThreshold", &fAdcThreshold, kDouble, 0, 1},
     {"_cal_arr_adc_samp_threshold", &fAdcSampThreshold, kDouble, 0, 1},
     {"_cal_arr_adc_peak_samp_width", &fDataSampWidth, kDouble, 0, 1},
@@ -207,7 +207,7 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
   fClustMethod = 0;  //Set default clusterin method to HMS/SHMS original 
   fDebugAdc = 0;  // Set ADC debug parameter to false unless set in parameter file
   //  fADCMode=kADCDynamicPedestal;
-  fAdcTdcOffset=0.0;
+  //  fAdcTdcOffset=0.0;
   fAdcThreshold=0.;
   fAdcSampThreshold=30;		// Peak found if this amount above pedestal
   fDataSampWidth=15;		// Integrate this # of samples to get peak area
@@ -306,6 +306,7 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
   // Pedestal limits per channel.
   fPedLimit = new Int_t [fNelem];
 
+  Double_t cal_arr_AdcTdcOffset[fNelem];
   Double_t cal_arr_cal_const[fNelem];
   Double_t cal_arr_gain_cor[fNelem];
 
@@ -318,6 +319,7 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
   
   DBRequest list1[]={
     {"_cal_arr_ped_limit", fPedLimit, kInt, static_cast<UInt_t>(fNelem),1},
+    {"_cal_arr_AdcTdcOffset", cal_arr_AdcTdcOffset, kDouble, static_cast<UInt_t>(fNelem)},
     {"_cal_arr_cal_const", cal_arr_cal_const, kDouble, static_cast<UInt_t>(fNelem)},
     {"_cal_arr_gain_cor",  cal_arr_gain_cor,  kDouble, static_cast<UInt_t>(fNelem)},
     {"_cal_arr_AdcTimeWindowMin", fAdcTimeWindowMin, kDouble, static_cast<UInt_t>(fNelem),1},
@@ -367,6 +369,16 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
 	cout << fPedLimit[el++] << " ";
       };
       cout <<  endl;
+    };
+
+    cout << "  cal_arr_AdcTdcOffset:" << endl;
+    el=0;
+    for (UInt_t j=0; j<fNColumns; j++) {
+      cout << "    ";
+      for (UInt_t i=0; i<fNRows; i++) {
+	cout << cal_arr_AdcTdcOffset[el++] << " ";
+      };
+      cout << endl;
     };
 
     cout << "  cal_arr_cal_const:" << endl;

--- a/src/THcNPSArray.cxx
+++ b/src/THcNPSArray.cxx
@@ -205,7 +205,7 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
   };
 
   fClustMethod = 0;  //Set default clusterin method to HMS/SHMS original 
-  fDebugAdc = 0;  // Set ADC debug parameter to false unless set in parameter file
+  fDebugAdc = 1;  // Set ADC debug parameter to false unless set in parameter file
   //  fADCMode=kADCDynamicPedestal;
   //  fAdcTdcOffset=0.0;
   fAdcThreshold=0.;
@@ -1077,7 +1077,7 @@ Int_t THcNPSArray::AccumulateHits(TClonesArray* rawhits, Int_t nexthit, Int_t tr
 	((THcSignalHit*) frAdcPulseAmp->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPulseAmp(thit));
 	
 	((THcSignalHit*) frAdcPulseTimeRaw->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPulseTimeRaw(thit));
-	((THcSignalHit*) frAdcPulseTime->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPulseTime(thit)+fAdcTdcOffset);
+	((THcSignalHit*) frAdcPulseTime->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetPulseTime(thit)+cal_arr_AdcTdcOffset[padnum]);
 
 	if (rawAdcHit.GetPulseAmpRaw(thit) > 0)  ((THcSignalHit*) frAdcErrorFlag->ConstructedAt(nrAdcHits))->Set(padnum, 0);
 	if (rawAdcHit.GetPulseAmpRaw(thit) <= 0) ((THcSignalHit*) frAdcErrorFlag->ConstructedAt(nrAdcHits))->Set(padnum, 1);
@@ -1132,7 +1132,7 @@ Int_t THcNPSArray::AccumulateHits(TClonesArray* rawhits, Int_t nexthit, Int_t tr
       ((THcSignalHit*) frAdcSampPulseAmpRaw->ConstructedAt(nrSampAdcHits))->Set(padnum, rawAdcHit.GetSampPulseAmpRaw(thit));
       ((THcSignalHit*) frAdcSampPulseAmp->ConstructedAt(nrSampAdcHits))->Set(padnum, rawAdcHit.GetSampPulseAmp(thit));
       ((THcSignalHit*) frAdcSampPulseTimeRaw->ConstructedAt(nrSampAdcHits))->Set(padnum, rawAdcHit.GetSampPulseTimeRaw(thit));
-      ((THcSignalHit*) frAdcSampPulseTime->ConstructedAt(nrSampAdcHits))->Set(padnum, rawAdcHit.GetSampPulseTime(thit)+fAdcTdcOffset);
+      ((THcSignalHit*) frAdcSampPulseTime->ConstructedAt(nrSampAdcHits))->Set(padnum, rawAdcHit.GetSampPulseTime(thit)+cal_arr_AdcTdcOffset[padnum]);
       //
       if ( rawAdcHit.GetNPulses() == 0 || fUseSampWaveform ==1 ) {
 	((THcSignalHit*) frAdcPedRaw->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetSampPedRaw());
@@ -1145,7 +1145,7 @@ Int_t THcNPSArray::AccumulateHits(TClonesArray* rawhits, Int_t nexthit, Int_t tr
 	((THcSignalHit*) frAdcPulseAmp->ConstructedAt(nrAdcHits))->Set(padnum,rawAdcHit.GetSampPulseAmp(thit) );
 	
 	((THcSignalHit*) frAdcPulseTimeRaw->ConstructedAt(nrAdcHits))->Set(padnum,rawAdcHit.GetSampPulseTimeRaw(thit) );
-	((THcSignalHit*) frAdcPulseTime->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetSampPulseTime(thit)+fAdcTdcOffset);
+	((THcSignalHit*) frAdcPulseTime->ConstructedAt(nrAdcHits))->Set(padnum, rawAdcHit.GetSampPulseTime(thit)+cal_arr_AdcTdcOffset[padnum]);
 
 	((THcSignalHit*) frAdcErrorFlag->ConstructedAt(nrAdcHits))->Set(padnum, 3);  
 	if (fUseSampWaveform ==1) ((THcSignalHit*) frAdcErrorFlag->ConstructedAt(nrAdcHits))->Set(padnum, 0);  

--- a/src/THcNPSArray.cxx
+++ b/src/THcNPSArray.cxx
@@ -306,9 +306,11 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
   // Pedestal limits per channel.
   fPedLimit = new Int_t [fNelem];
 
-  Double_t cal_arr_AdcTdcOffset[fNelem];
+  //Double_t cal_arr_AdcTdcOffset[fNelem];
   Double_t cal_arr_cal_const[fNelem];
   Double_t cal_arr_gain_cor[fNelem];
+
+  cal_arr_AdcTdcOffset = new Double_t [fNelem];
 
   fAdcTimeWindowMin = new Double_t [fNelem];
   fAdcTimeWindowMax = new Double_t [fNelem];
@@ -319,7 +321,7 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
   
   DBRequest list1[]={
     {"_cal_arr_ped_limit", fPedLimit, kInt, static_cast<UInt_t>(fNelem),1},
-    {"_cal_arr_AdcTdcOffset", cal_arr_AdcTdcOffset, kDouble, static_cast<UInt_t>(fNelem)},
+    {"_cal_arr_AdcTdcOffset", cal_arr_AdcTdcOffset, kDouble, static_cast<UInt_t>(fNelem),1},
     {"_cal_arr_cal_const", cal_arr_cal_const, kDouble, static_cast<UInt_t>(fNelem)},
     {"_cal_arr_gain_cor",  cal_arr_gain_cor,  kDouble, static_cast<UInt_t>(fNelem)},
     {"_cal_arr_AdcTimeWindowMin", fAdcTimeWindowMin, kDouble, static_cast<UInt_t>(fNelem),1},

--- a/src/THcNPSArray.cxx
+++ b/src/THcNPSArray.cxx
@@ -338,6 +338,7 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
   };
 
    for(Int_t ip=0;ip<fNelem;ip++) {
+    fAdcTdcOffset[ip] = 0.;
     fAdcTimeWindowMin[ip] = -1000.;
     fAdcTimeWindowMax[ip] = 1000.;
     fAdcPulseTimeMin[ip] = -1000.;

--- a/src/THcNPSArray.cxx
+++ b/src/THcNPSArray.cxx
@@ -304,7 +304,6 @@ Int_t THcNPSArray::ReadDatabase( const TDatime& date )
   // Pedestal limits per channel.
   fPedLimit = new Int_t [fNelem];
 
-  //Double_t cal_arr_AdcTdcOffset[fNelem];
   Double_t cal_arr_cal_const[fNelem];
   Double_t cal_arr_gain_cor[fNelem];
 

--- a/src/THcNPSArray.h
+++ b/src/THcNPSArray.h
@@ -189,8 +189,7 @@ protected:
   Double_t *fAdcTimeWindowMax ;
   Double_t fAdcThreshold;
   Double_t fAdcSampThreshold;
-  //Double_t fAdcTdcOffset;
-  Double_t *cal_arr_AdcTdcOffset;
+  Double_t *fAdcTdcOffset;
   Int_t *fPedDefault ;
 
   //C.Y. Feb 09, 2021: Added fAdcPulseTime window parameters to be used in

--- a/src/THcNPSArray.h
+++ b/src/THcNPSArray.h
@@ -189,7 +189,8 @@ protected:
   Double_t *fAdcTimeWindowMax ;
   Double_t fAdcThreshold;
   Double_t fAdcSampThreshold;
-  Double_t fAdcTdcOffset;
+  //Double_t fAdcTdcOffset;
+  Double_t *cal_arr_AdcTdcOffset;
   Int_t *fPedDefault ;
 
   //C.Y. Feb 09, 2021: Added fAdcPulseTime window parameters to be used in

--- a/src/THcNPSCalorimeter.cxx
+++ b/src/THcNPSCalorimeter.cxx
@@ -253,7 +253,7 @@ Int_t THcNPSCalorimeter::ReadDatabase( const TDatime& date )
     fdbg_sparsified_cal = 0;
     fdbg_clusters_cal = 0;
     fdbg_tracks_cal = 0;
-    fdbg_init_cal = 1;
+    fdbg_init_cal = 0;
     fAdcTdcOffset=0.0;
     fADCMode=kADCDynamicPedestal;
     gHcParms->LoadParmValues((DBRequest*)&list, fKwPrefix.c_str());

--- a/src/THcNPSCalorimeter.cxx
+++ b/src/THcNPSCalorimeter.cxx
@@ -253,7 +253,7 @@ Int_t THcNPSCalorimeter::ReadDatabase( const TDatime& date )
     fdbg_sparsified_cal = 0;
     fdbg_clusters_cal = 0;
     fdbg_tracks_cal = 0;
-    fdbg_init_cal = 0;
+    fdbg_init_cal = 1;
     fAdcTdcOffset=0.0;
     fADCMode=kADCDynamicPedestal;
     gHcParms->LoadParmValues((DBRequest*)&list, fKwPrefix.c_str());


### PR DESCRIPTION
Changed the fAdcTdcOffset variable into an array that allows the offset to be set for each calorimeter block.

Currently the offset is set to 0 for all blocks and is set up for the 32x28 block configuration.

The nps_cuts_eel108.param file in nps_replay/PARAM/NPS/CAL also needs to be updated with per-block information for the script to work.

Other scripts that use fAdcTdcOffset may also need to be adjusted; I haven't checked those.