### PR TITLE
add dockerfile and workflow. closes #510

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,41 @@
+name: Docker Image CI
+
+on:
+  push:
+    tags: '**'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: jeffersonlab/hallc-hcana
+
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}"
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            DOCKER_TAG=${{ steps.meta.outputs.tags }}
+            APP_VERSION=${{ github.ref_name}}
+            REPO_NAME=${{ github.event.repository.name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM centos:centos7
+
+ARG APP_VERSION
+ARG REPO_NAME
+
+RUN yum update -q -y
+
+RUN yum -y install epel-release &&\
+    yum -y install git && \
+    yum -y groupinstall 'Development Tools'&& \
+    yum -y install gcc-c++ && \
+    yum -y install make && \
+    yum install -y root && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8
+
+ADD https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2-linux-x86_64.tar.gz .
+RUN tar -xvf cmake-3.22.2-linux-x86_64.tar.gz
+RUN mv cmake-3.22.2-linux-x86_64 /usr/local/cmake
+RUN ls -l /usr/local/cmake/bin
+ENV PATH="/usr/local/cmake/bin:$PATH"
+ADD https://github.com/JeffersonLab/hcana/archive/refs/tags/${APP_VERSION}.tar.gz .
+RUN tar -xvf ${APP_VERSION}.tar.gz
+WORKDIR "/${REPO_NAME}-${APP_VERSION}"
+ADD podd podd/
+SHELL ["/bin/bash", "-c"]
+RUN cmake -DCMAKE_INSTALL_PREFIX=$HOME/local/hcana -B build  -S /${REPO_NAME}-${APP_VERSION}
+RUN cmake --build build -j8
+RUN cmake --install build
+ENV PATH="~/local/hcana/bin:$PATH"
+ENV LD_LIBRARY_PATH="~/local/hcana/lib64:$LD_LIBRARY_PATH"
+ENV ANALYZER=/${REPO_NAME}-${APP_VERSION}/podd
+ENV HCANALYZER=/${REPO_NAME}-${APP_VERSION}
+WORKDIR /${REPO_NAME}-${APP_VERSION}
+RUN mkdir myworkdir
+WORKDIR /${REPO_NAME}-${APP_VERSION}/myworkdir
+


### PR DESCRIPTION
Idea is to create the docker container for each tag created for hcana.
This uses the sumodule init/update to create a podd directory.
The gihub action will be troiggered and push the docker image to https://hub.docker.com/r/jeffersonlab/hallc-hcana/tags .
try a test beta docker image created : https://hub.docker.com/r/jeffersonlab/hallc-hcana/tags .
A test of docker image is already perfomed based on https://hallcweb.jlab.org/wiki/index.php/ROOT_Analyzer/Running 

- [ ] we need followung to github repository secret.
`DOCKERHUB_USERNAME`
`DOCKERHUB_TOKEN`