### PR TITLE
Fix missing buffer length checks in THcConfigEvtHandler

### DIFF
--- a/cmake/hcanaConfig.cmake.in
+++ b/cmake/hcanaConfig.cmake.in
@@ -1,3 +1,5 @@
+# hcana CMake project configuration file. For use by subprojects/plugins.
+
 @PACKAGE_INIT@
 
 message(STATUS "Found @PROJECT_NAME@: @PACKAGE_CMAKE_INSTALL_PREFIX@ (found version @PROJECT_VERSION@@EXTVERS@)")
@@ -9,9 +11,13 @@ if(IS_DIRECTORY "@PACKAGE_INSTALL_CONFIGDIR@/Modules")
   list(APPEND CMAKE_MODULE_PATH "@PACKAGE_INSTALL_CONFIGDIR@/Modules")
 endif()
 
-include("@PACKAGE_TARGETS_FILE@")
+# Save PACKAGE_PREFIX_DIR. Dependencies may overwrite it.
+set(@PROJECT_NAME_UC@_SAVED_PACKAGE_PREFIX_DIR "${PACKAGE_PREFIX_DIR}")
 
 @FIND_DEPENDENCY_COMMANDS@
 
-check_required_components(@PROJECT_NAME_UC@)
+set(PACKAGE_PREFIX_DIR "${@PROJECT_NAME_UC@_SAVED_PACKAGE_PREFIX_DIR}")
+unset(@PROJECT_NAME_UC@_SAVED_PACKAGE_PREFIX_DIR)
+include("@PACKAGE_TARGETS_FILE@")
 
+check_required_components(@PROJECT_NAME_UC@)

--- a/src/THcConfigEvtHandler.h
+++ b/src/THcConfigEvtHandler.h
@@ -90,11 +90,11 @@ private:
   std::map<UInt_t, CrateConfig> fCrateInfoMap;  // roc -> crate info
   std::vector<std::string> fParms;  // names of parameters we've defined
 
-  UInt_t DecodeFADC250Config( THaEvData* evdata, UInt_t ip,
+  UInt_t DecodeFADC250Config( THaEvData* evdata, UInt_t ip, UInt_t len,
                               CrateConfig::FADC250_t& cfg );
-  UInt_t DecodeCAEN1190Config( THaEvData* evdata, UInt_t ip,
+  UInt_t DecodeCAEN1190Config( THaEvData* evdata, UInt_t ip, UInt_t len,
                                CrateConfig::CAEN1190_t& cfg );
-  UInt_t DecodeTIConfig( THaEvData* evdata, UInt_t ip,
+  UInt_t DecodeTIConfig( THaEvData* evdata, UInt_t ip, UInt_t len,
                          CrateConfig::TI_t& cfg );
 
   ClassDef(THcConfigEvtHandler,0)  // Hall C event type 125


### PR DESCRIPTION
This adds a couple of missing checks against the event length in the THcConfigEvtHandler that may in rare cases have led to a crash.

Also, improve the logic in hcana's CMake configuration file.
