### PR TITLE
THcHelicity: Reinitialize fEvNumCheck for the first replay event to support split replay

### DIFF
--- a/src/THcHelicity.cxx
+++ b/src/THcHelicity.cxx
@@ -341,6 +341,10 @@ Int_t THcHelicity::Decode( const THaEvData& evdata )
 
   fEvNumCheck++;
   Int_t evnum = evdata.GetEvNum();
+
+  // For split replay support
+  if(fEvNumCheck == 1) fEvNumCheck = evnum;
+    
   if(fEvNumCheck!=evnum) {
     cout << "THcHelicity: Missed " << evnum-fEvNumCheck << " events at event " << evnum << endl;
     cout << "             Disabling helicity decoding for rest of run." << endl;


### PR DESCRIPTION
THcHelicity checks event number mismatch assuming the replay starts with the actual first event of the data (event number = 1). For the split replay, it would fail the check and disable the helicity decoding for the rest of the replay unless the replay starts with the actual first event of the data from 0th segment file.
The added line basically forces the check to always pass for the first replay event by re-initializing the variable (fEvNumCheck) to be the same as that event number.