### PR TITLE
Add Event 137 handler

### DIFF
--- a/src/THcEvt137Handler.cxx
+++ b/src/THcEvt137Handler.cxx
@@ -16,6 +16,13 @@ using namespace std;
 //
 // Parse FADC250 and VTP config data (ev 137) -- regular text
 // 
+// Format: key value
+// FADC250 config is listed for all slots for the given roc
+// e.g. FADC250_SLOT 3
+// e.g. FADC250_ALLCH_PED 386.917 412.167 ... (for 16 channels)
+//
+// FADC250 parameters (NSA, NSB) are read in THcHitList
+// 
 /////////////////////////////////////////////////////////////////////
 
 //_______________________________________________________________
@@ -25,7 +32,7 @@ THcEvt137Handler::THcEvt137Handler( const char* name,
   fNDecoded(0),
   fConfigTree(nullptr),
   fMakeConfigTree(true),
-  fMakeParms(true),
+  fMakeParms(false),
   fCounter(0)
 {
 }
@@ -86,14 +93,12 @@ void THcEvt137Handler::MakeParms()
 
     int nval = vals.size();
 
-    // Define global variables
     gHcParms->RemoveName(Form("g_%s", keyname.data()));
     if(nval == 1)
       gHcParms->Define(Form("g_%s", keyname.data()), keyname.data(), vals[0]);
     else
       gHcParms->Define(Form("g_%s", keyname.data()), keyname.data(), vals); // vector type is supported
   }
-
 }
 
 //_______________________________________________________________
@@ -175,6 +180,7 @@ void THcEvt137Handler::SaveConfigData()
   UInt_t ivar = 0, iarr = 0; // counter
 
   // Init tree
+  fConfigTree->Branch("ROCNum", &fRoc);
   for( auto &cfg : fConfigDataMap ){
     string bname = cfg.first; // branch name
     auto bpars = cfg.second.pars; // 
@@ -200,32 +206,20 @@ void THcEvt137Handler::SaveConfigData()
 //_______________________________________________________________
 Int_t THcEvt137Handler::Analyze( THaEvData* evdata )
 {
-  UInt_t evtype = evdata->GetEvType();
-
   // Check event type
+  UInt_t evtype = evdata->GetEvType();
   if( std::find(fEvtTypes.begin(), fEvtTypes.end(), evtype) == fEvtTypes.end() )
     return -1;
 
-  UInt_t evlen = evdata->GetEvLength();
-  auto bankinfo = Decoder::CodaDecoder::GetBank(evdata->GetRawDataBuffer(), 0 , evlen);
-  if( bankinfo.status_ != Decoder::CodaDecoder::BankInfo::kOK ) {
-    ostringstream ostr;
-    ostr << "THcEv137Handler: CODA3 bank decoder error \""
-	 << bankinfo.Errtxt() << "\"";
-    throw Decoder::CodaDecoder::coda_format_error(ostr.str() );
-  }
-
-  UInt_t roc = bankinfo.tag_;
+  // ROC
+  UInt_t roc = gHaRun->GetDAQConfigTag(fNDecoded);
   fRoc.emplace_back(roc);
 
-  auto* ifo = DAQInfoExtra::GetFrom(evdata->GetExtra());
-  if( !ifo ) return -1;
-
+  auto cinfo = gHaRun->GetDAQConfig(fNDecoded);
+  istringstream ifstr(cinfo);
+  string line;
   string slot = "";
 
-  auto this_info = ifo->strings[fNDecoded];
-  istringstream ifstr(this_info);
-  string line;
   while( getline(ifstr, line) ) {
 
     // skip blank lines
@@ -239,7 +233,6 @@ Int_t THcEvt137Handler::Analyze( THaEvData* evdata )
       val.reserve(line.size());
 
       std::vector<Double_t> v_val;
-
       for( size_t j = 1, e = items.size(); j < e; ++j ) {
 	val.append(items[j]);
 	if( j + 1 != e )
@@ -248,19 +241,20 @@ Int_t THcEvt137Handler::Analyze( THaEvData* evdata )
 	//for simplicity make them all double vars
 	v_val.emplace_back(std::stod(items[j]));
       }
+
       // Per slot config for FADC250
       // This assumes that SLOT information is the first line for FADC250 config list
       if( key == "FADC250_SLOT" ){
 	slot.replace(0, slot.length(), val);
       }	  
 
-      // Define new key for Parm list
+      // Define new unique key for Parm list
       string new_key = key + "_" + std::to_string(roc);
       if( slot.length() > 0)
 	new_key = new_key + "_" + slot;
 
       // Remove the existing element if the key already exists
-      // and will override with new parameters
+      // and will overwrite with new parameters
       if( fConfigDataMap.find(new_key) != fConfigDataMap.end() )
 	fConfigDataMap.erase(new_key);
 
@@ -285,7 +279,7 @@ Int_t THcEvt137Handler::Analyze( THaEvData* evdata )
 
   fNDecoded++;
 
-  return 0;
+  return fNDecoded;
 }
 
 ClassImp(THcEvt137Handler)

--- a/src/THcEvt137Handler.cxx
+++ b/src/THcEvt137Handler.cxx
@@ -21,8 +21,11 @@ using namespace std;
 //_______________________________________________________________
 THcEvt137Handler::THcEvt137Handler( const char* name,
 				    const char* description ) :
-  THaEvtTypeHandler(name, description), fNDecoded(0),
-  fConfigTree(nullptr), fMakeConfigTree(true), fMakeParms(true),
+  THaEvtTypeHandler(name, description),
+  fNDecoded(0),
+  fConfigTree(nullptr),
+  fMakeConfigTree(true),
+  fMakeParms(true),
   fCounter(0)
 {
 }
@@ -56,9 +59,8 @@ THaAnalysisObject::EStatus THcEvt137Handler::Init( const TDatime& date )
 //_______________________________________________________________
 Int_t THcEvt137Handler::End( THaRunBase* )
 {
-  cout << "THcEvt137Handler::End" << endl;
 
-  // Save the tree into the output 
+  // Save the tree, write into the output 
   if(fMakeConfigTree) { SaveConfigData(); }
 
   return 0;
@@ -92,18 +94,6 @@ void THcEvt137Handler::MakeParms()
       gHcParms->Define(Form("g_%s", keyname.data()), keyname.data(), vals); // vector type is supported
   }
 
-  /*
-  const auto* pvar = gHcParms->Find("g_FADC250_ALLCH_PED_2_9");
-  if(pvar){
-    if(pvar->IsVector()){
-      auto v1 = pvar->GetValues();
-      cout << pvar->GetLen() << endl;
-      cout << v1[0] << endl;
-      cout << v1[1] << endl;
-      cout << v1[15] << endl;
-    }
-  }
-  */
 }
 
 //_______________________________________________________________

--- a/src/THcEvt137Handler.cxx
+++ b/src/THcEvt137Handler.cxx
@@ -1,0 +1,216 @@
+#include "THcEvt137Handler.h"
+#include "CodaDecoder.h"
+#include "THaGlobals.h"
+#include "THcGlobals.h"
+#include "THaRunBase.h"
+#include "THaEvData.h"
+#include "DAQconfig.h"
+#include "THcParmList.h"
+#include <iostream>
+#include <sstream>
+
+using namespace std;
+
+/////////////////////////////////////////////////////////////////////
+//
+// Parse FADC250 and VTP config data (ev 137) -- regular text
+// 
+/////////////////////////////////////////////////////////////////////
+
+//_______________________________________________________________
+THcEvt137Handler::THcEvt137Handler( const char* name,
+				    const char* description ) :
+  THaEvtTypeHandler(name, description), fNDecoded(0)
+{
+}
+
+//_______________________________________________________________
+THcEvt137Handler::~THcEvt137Handler()
+{
+  for( auto& cfg : fConfigParmList ) {
+    gHcParms->RemoveString(cfg.par);
+  }
+}
+
+//_______________________________________________________________
+THaAnalysisObject::EStatus THcEvt137Handler::Init( const TDatime& date )
+{
+
+  // default event type 
+  if( fEvtTypes.empty() ) {
+    fEvtTypes.push_back(137);
+  }
+
+  return THaEvtTypeHandler::Init(date);
+}
+
+//_______________________________________________________________
+void THcEvt137Handler::AddEvtType( UInt_t evtype )
+{
+  // We don't want to add this event type to the evt type list of THaEvtTypeHandler
+  // eventtypes from THaEvtTypeHandler is looked up by all inherited EvtTypeHandler classes
+  // Instead, we set the event types only relevant for this class
+  
+  if( std::find(fEvtTypes.begin(), fEvtTypes.end(), evtype ) == fEvtTypes.end() )
+    fEvtTypes.push_back(evtype);
+}
+
+//_______________________________________________________________
+void THcEvt137Handler::AddParameter(std::string parname, std::string keyname)
+{
+  fConfigParmList.push_back( {Form("g_%s", parname.data()), keyname} );
+}
+ 
+//_______________________________________________________________
+void THcEvt137Handler::MakeParms()
+{
+  // all data parsed as a single string varaible 
+
+  for( auto& cfg : fConfigParmList ) {
+    if( !GetInfo(cfg.key.data()).empty() ) {
+      gHcParms->RemoveString(cfg.par);
+      gHcParms->AddString(cfg.par, GetInfo(cfg.key.data()) );
+    }
+  }      
+}
+
+//_______________________________________________________________
+std::string THcEvt137Handler::GetInfo(const char* keyname )
+{
+  auto it = fConfigData.find(keyname);
+  if( it != fConfigData.end() )
+    return it->second;
+  else
+    return "";
+}
+
+//_______________________________________________________________
+UInt_t THcEvt137Handler::GetNSA( UInt_t crate, UInt_t slot )
+{
+  int nsa = 0;
+  string keyname = "FADC250_NSA_" + std::to_string(crate) + "_" + std::to_string(slot);
+  string val = GetInfo(keyname.data());
+  if( val.length() > 0 )
+    nsa = std::stoi(val);
+
+  return nsa;
+}
+
+//_______________________________________________________________
+UInt_t THcEvt137Handler::GetNSB( UInt_t crate, UInt_t slot )
+{
+  int nsb = 0;
+  string keyname = "FADC250_NSB_" + std::to_string(crate) + "_" + std::to_string(slot);
+  string val = GetInfo(keyname.data());
+  if( val.length() > 0 )
+    nsb = std::stoi(val);
+ 
+  return nsb;
+}
+
+
+//_______________________________________________________________
+UInt_t THcEvt137Handler::GetNPED( UInt_t crate, UInt_t slot )
+{
+  int nped = 0;
+  string keyname = "FADC250_NPED_" + std::to_string(crate) + "_" + std::to_string(slot);
+  string val = GetInfo(keyname.data());
+  if( val.length() > 0 )
+    nped = std::stoi(val);
+ 
+  return nped;
+}
+
+//_______________________________________________________________
+Double_t THcEvt137Handler::GetPED( UInt_t crate, UInt_t slot, UInt_t ch )
+{
+  vector<Double_t> v_ped;
+
+  string keyname = "FADC250_ALLCH_PED_" + std::to_string(crate) + "_" + std::to_string(slot);
+  string val = GetInfo(keyname.data());
+
+  if( val.length() > 0 ) {
+    istringstream ifstr(val);
+    Double_t ped;
+    while(ifstr >> ped) {
+      v_ped.push_back(ped);      
+    }      
+  }
+
+  if( ch+1 > v_ped.size() )
+    return 0;
+  else
+    return v_ped[ch];
+}
+
+//_______________________________________________________________
+Int_t THcEvt137Handler::Analyze( THaEvData* evdata )
+{
+
+  UInt_t evtype = evdata->GetEvType();
+
+  // Check event type
+  if( std::find(fEvtTypes.begin(), fEvtTypes.end(), evtype) == fEvtTypes.end() )
+    return -1;
+
+  UInt_t evlen = evdata->GetEvLength();
+  auto bankinfo = Decoder::CodaDecoder::GetBank(evdata->GetRawDataBuffer(), 0 , evlen);
+  if( bankinfo.status_ != Decoder::CodaDecoder::BankInfo::kOK ) {
+    ostringstream ostr;
+    ostr << "THcEv137Handler: CODA3 bank decoder error \""
+	 << bankinfo.Errtxt() << "\"";
+    throw Decoder::CodaDecoder::coda_format_error(ostr.str() );
+  }
+
+  UInt_t roc = bankinfo.tag_;
+
+  auto* ifo = DAQInfoExtra::GetFrom(evdata->GetExtra());
+  if( !ifo ) return -1;
+
+  string slot = "";
+
+  auto this_info = ifo->strings[fNDecoded];
+  istringstream ifstr(this_info);
+  string line;
+  while( getline(ifstr, line) ) {
+
+    // skip blank lines
+    if( line.find_first_not_of(" \t") == string::npos ) 
+      continue;
+
+    cout << line << endl;
+    auto items = Podd::vsplit(line);
+    if( !items.empty() ) {
+      string& key = items[0];
+      string val;
+      val.reserve(line.size());
+
+      for( size_t j = 1, e = items.size(); j < e; ++j ) {
+	val.append(items[j]);
+	if( j + 1 != e )
+	  val.append(" ");
+      }
+
+      // Per slot config for FADC250
+      if( key == "FADC250_SLOT" ){
+	slot.replace(0, slot.length(), val);
+      }	  
+
+      // Define new key for Parm list
+      string new_key = key + "_" + std::to_string(roc) + "_" + slot;
+
+      // Add Parameters
+      fConfigParmList.push_back( {Form("g_%s", new_key.data()), new_key} );
+      fConfigData.emplace( std::move(new_key), std::move(val) );
+    }
+  }// getline
+
+  // Add to the gHcParm list
+  MakeParms();
+
+  fNDecoded++;
+
+  return 0;
+}
+
+ClassImp(THcEvt137Handler)

--- a/src/THcEvt137Handler.cxx
+++ b/src/THcEvt137Handler.cxx
@@ -6,6 +6,7 @@
 #include "THaEvData.h"
 #include "DAQconfig.h"
 #include "THcParmList.h"
+#include "TROOT.h"
 #include <iostream>
 #include <sstream>
 
@@ -20,16 +21,24 @@ using namespace std;
 //_______________________________________________________________
 THcEvt137Handler::THcEvt137Handler( const char* name,
 				    const char* description ) :
-  THaEvtTypeHandler(name, description), fNDecoded(0)
+  THaEvtTypeHandler(name, description), fNDecoded(0),
+  fConfigTree(nullptr), fMakeConfigTree(true), fMakeParms(true),
+  fCounter(0)
 {
 }
 
 //_______________________________________________________________
 THcEvt137Handler::~THcEvt137Handler()
 {
-  for( auto& cfg : fConfigParmList ) {
-    gHcParms->RemoveString(cfg.par);
+  if(fMakeParms) {
+    for( auto& cfg : fConfigDataMap )
+      gHcParms->RemoveName(Form("g_%s", cfg.first.data()));
   }
+
+  if( !TROOT::Initialized()) {
+    delete fConfigTree;
+  }
+  
 }
 
 //_______________________________________________________________
@@ -38,10 +47,21 @@ THaAnalysisObject::EStatus THcEvt137Handler::Init( const TDatime& date )
 
   // default event type 
   if( fEvtTypes.empty() ) {
-    fEvtTypes.push_back(137);
+    fEvtTypes.emplace_back(137);
   }
 
   return THaEvtTypeHandler::Init(date);
+}
+
+//_______________________________________________________________
+Int_t THcEvt137Handler::End( THaRunBase* )
+{
+  cout << "THcEvt137Handler::End" << endl;
+
+  // Save the tree into the output 
+  if(fMakeConfigTree) { SaveConfigData(); }
+
+  return 0;
 }
 
 //_______________________________________________________________
@@ -52,101 +72,144 @@ void THcEvt137Handler::AddEvtType( UInt_t evtype )
   // Instead, we set the event types only relevant for this class
   
   if( std::find(fEvtTypes.begin(), fEvtTypes.end(), evtype ) == fEvtTypes.end() )
-    fEvtTypes.push_back(evtype);
+    fEvtTypes.emplace_back(evtype);
 }
 
-//_______________________________________________________________
-void THcEvt137Handler::AddParameter(std::string parname, std::string keyname)
-{
-  fConfigParmList.push_back( {Form("g_%s", parname.data()), keyname} );
-}
- 
 //_______________________________________________________________
 void THcEvt137Handler::MakeParms()
 {
-  // all data parsed as a single string varaible 
+  for(auto &cfg : fConfigDataMap ) {
+    string keyname = cfg.first;
+    const auto &vals = cfg.second.pars;
 
-  for( auto& cfg : fConfigParmList ) {
-    if( !GetInfo(cfg.key.data()).empty() ) {
-      gHcParms->RemoveString(cfg.par);
-      gHcParms->AddString(cfg.par, GetInfo(cfg.key.data()) );
+    int nval = vals.size();
+
+    // Define global variables
+    gHcParms->RemoveName(Form("g_%s", keyname.data()));
+    if(nval == 1)
+      gHcParms->Define(Form("g_%s", keyname.data()), keyname.data(), vals[0]);
+    else
+      gHcParms->Define(Form("g_%s", keyname.data()), keyname.data(), vals); // vector type is supported
+  }
+
+  /*
+  const auto* pvar = gHcParms->Find("g_FADC250_ALLCH_PED_2_9");
+  if(pvar){
+    if(pvar->IsVector()){
+      auto v1 = pvar->GetValues();
+      cout << pvar->GetLen() << endl;
+      cout << v1[0] << endl;
+      cout << v1[1] << endl;
+      cout << v1[15] << endl;
     }
-  }      
+  }
+  */
 }
 
 //_______________________________________________________________
 std::string THcEvt137Handler::GetInfo(const char* keyname )
 {
-  auto it = fConfigData.find(keyname);
-  if( it != fConfigData.end() )
-    return it->second;
+  // return parameters as a single string 
+  auto it = fConfigDataMap.find(keyname);
+  if( it != fConfigDataMap.end() )
+    return it->second.pars_str;
   else
     return "";
 }
 
 //_______________________________________________________________
-UInt_t THcEvt137Handler::GetNSA( UInt_t crate, UInt_t slot )
+int THcEvt137Handler::GetNSA( UInt_t crate, UInt_t slot )
 {
-  int nsa = 0;
+  int val = -1;
   string keyname = "FADC250_NSA_" + std::to_string(crate) + "_" + std::to_string(slot);
-  string val = GetInfo(keyname.data());
-  if( val.length() > 0 )
-    nsa = std::stoi(val);
 
-  return nsa;
+  auto it = fConfigDataMap.find(keyname);
+  if( it != fConfigDataMap.end() ) {
+    val = static_cast<int>(it->second.pars[0])/4;
+  }
+  return val;
 }
 
 //_______________________________________________________________
-UInt_t THcEvt137Handler::GetNSB( UInt_t crate, UInt_t slot )
+int THcEvt137Handler::GetNSB( UInt_t crate, UInt_t slot )
 {
-  int nsb = 0;
+  int val = -1;
   string keyname = "FADC250_NSB_" + std::to_string(crate) + "_" + std::to_string(slot);
-  string val = GetInfo(keyname.data());
-  if( val.length() > 0 )
-    nsb = std::stoi(val);
- 
-  return nsb;
+
+  auto it = fConfigDataMap.find(keyname);
+  if( it != fConfigDataMap.end() ) {
+    val = static_cast<int>(it->second.pars[0])/4;
+  }
+  return val;
 }
 
 
 //_______________________________________________________________
-UInt_t THcEvt137Handler::GetNPED( UInt_t crate, UInt_t slot )
+int THcEvt137Handler::GetNPED( UInt_t crate, UInt_t slot )
 {
-  int nped = 0;
+  int val = -1;
   string keyname = "FADC250_NPED_" + std::to_string(crate) + "_" + std::to_string(slot);
-  string val = GetInfo(keyname.data());
-  if( val.length() > 0 )
-    nped = std::stoi(val);
- 
-  return nped;
+
+  auto it = fConfigDataMap.find(keyname);
+  if( it != fConfigDataMap.end() ) {
+    val = static_cast<int>(it->second.pars[0]);
+  }
+  return val;
 }
 
 //_______________________________________________________________
 Double_t THcEvt137Handler::GetPED( UInt_t crate, UInt_t slot, UInt_t ch )
 {
-  vector<Double_t> v_ped;
-
+  Double_t ped = 0;
   string keyname = "FADC250_ALLCH_PED_" + std::to_string(crate) + "_" + std::to_string(slot);
-  string val = GetInfo(keyname.data());
+  auto it = fConfigDataMap.find(keyname);
+  if( it != fConfigDataMap.end() ) {
+    ped = it->second.pars[ch];
+  }
+  return ped;
+}
 
-  if( val.length() > 0 ) {
-    istringstream ifstr(val);
-    Double_t ped;
-    while(ifstr >> ped) {
-      v_ped.push_back(ped);      
-    }      
+//_______________________________________________________________
+void THcEvt137Handler::SaveConfigData()
+{
+  // Init output tree
+  if( fMakeConfigTree && !fConfigTree ) {
+      fConfigTree = new TTree("THC", "Config parameter tree");
+  }    
+
+  vector<Double_t> fVars;
+  vector<vector<Double_t>> fArrays;
+
+  fVars.resize(fCounter);
+  fArrays.resize(fCounter);
+  UInt_t ivar = 0, iarr = 0; // counter
+
+  // Init tree
+  for( auto &cfg : fConfigDataMap ){
+    string bname = cfg.first; // branch name
+    auto bpars = cfg.second.pars; // 
+
+    int npar = bpars.size();
+
+    if(npar == 1) {
+      fConfigTree->Branch(Form("%s", bname.data()), &fVars[ivar]);
+      fVars[ivar] = bpars[0];
+      ivar++;
+    }
+    else {
+      fConfigTree->Branch(Form("%s", bname.data()), &fArrays[iarr]);
+      fArrays[iarr] = bpars;
+      iarr++;
+    }
   }
 
-  if( ch+1 > v_ped.size() )
-    return 0;
-  else
-    return v_ped[ch];
+  fConfigTree->Fill();
+  fConfigTree->Write();
 }
 
 //_______________________________________________________________
 Int_t THcEvt137Handler::Analyze( THaEvData* evdata )
 {
-
   UInt_t evtype = evdata->GetEvType();
 
   // Check event type
@@ -163,6 +226,7 @@ Int_t THcEvt137Handler::Analyze( THaEvData* evdata )
   }
 
   UInt_t roc = bankinfo.tag_;
+  fRoc.emplace_back(roc);
 
   auto* ifo = DAQInfoExtra::GetFrom(evdata->GetExtra());
   if( !ifo ) return -1;
@@ -184,28 +248,50 @@ Int_t THcEvt137Handler::Analyze( THaEvData* evdata )
       string val;
       val.reserve(line.size());
 
+      std::vector<Double_t> v_val;
+
       for( size_t j = 1, e = items.size(); j < e; ++j ) {
 	val.append(items[j]);
 	if( j + 1 != e )
 	  val.append(" ");
-      }
 
+	//for simplicity make them all double vars
+	v_val.emplace_back(std::stod(items[j]));
+      }
       // Per slot config for FADC250
+      // This assumes that SLOT information is the first line for FADC250 config list
       if( key == "FADC250_SLOT" ){
 	slot.replace(0, slot.length(), val);
       }	  
 
       // Define new key for Parm list
-      string new_key = key + "_" + std::to_string(roc) + "_" + slot;
+      string new_key = key + "_" + std::to_string(roc);
+      if( slot.length() > 0)
+	new_key = new_key + "_" + slot;
 
-      // Add Parameters
-      fConfigParmList.push_back( {Form("g_%s", new_key.data()), new_key} );
-      fConfigData.emplace( std::move(new_key), std::move(val) );
+      // Remove the existing element if the key already exists
+      // and will override with new parameters
+      if( fConfigDataMap.find(new_key) != fConfigDataMap.end() )
+	fConfigDataMap.erase(new_key);
+
+      // Add to the container
+      ConfigData config_data;
+      config_data.roc = roc;
+      config_data.slot = -1;
+      if( slot.length() > 0 )
+	config_data.slot = std::stoi(slot);
+      config_data.parname = key;
+      config_data.pars = v_val;
+      config_data.pars_str = val;
+      fConfigDataMap.emplace(std::move(new_key), std::move(config_data));
+
+      fCounter++;
     }
   }// getline
 
-  // Add to the gHcParm list
-  MakeParms();
+  // Add to the Parm List
+  if(fMakeParms)
+    MakeParms();
 
   fNDecoded++;
 

--- a/src/THcEvt137Handler.cxx
+++ b/src/THcEvt137Handler.cxx
@@ -178,7 +178,6 @@ Int_t THcEvt137Handler::Analyze( THaEvData* evdata )
     if( line.find_first_not_of(" \t") == string::npos ) 
       continue;
 
-    cout << line << endl;
     auto items = Podd::vsplit(line);
     if( !items.empty() ) {
       string& key = items[0];

--- a/src/THcEvt137Handler.h
+++ b/src/THcEvt137Handler.h
@@ -1,0 +1,50 @@
+#ifndef ROOT_THcEvt137Handler
+#define ROOT_THcEvt137Handler
+
+#include "THaEvtTypeHandler.h"
+#include <vector>
+#include <string>
+#include <map>
+
+class THcEvt137Handler : public THaEvtTypeHandler {
+ public:
+
+  THcEvt137Handler( const char* name, const char* description = "" );
+  virtual ~THcEvt137Handler();
+  
+  virtual Int_t   Analyze( THaEvData *evdata );
+  virtual EStatus Init( const TDatime& date );
+  virtual void    AddEvtType( UInt_t evtype );
+  virtual void    AddParameter(std::string parname, std::string keyname);
+
+  std::vector<UInt_t> GetEvtTypes() { return fEvtTypes; }
+  std::string GetInfo( const char* keyname );
+
+  // Some useful getter functions for FADC250
+  UInt_t GetNSA( UInt_t crate, UInt_t slot );
+  UInt_t GetNSB( UInt_t crate, UInt_t slot );
+  UInt_t GetNPED( UInt_t crate, UInt_t slot );
+  Double_t GetPED( UInt_t crate, UInt_t slot, UInt_t ch );
+
+ private:
+
+  Int_t fNDecoded; // Counter for decoded type 137 event
+  const int NTHR = 16;
+
+  std::vector<UInt_t> fEvtTypes;
+
+  // General parm and key pairs
+  struct ConfigParms {
+      std::string par;
+      std::string key;
+  };
+
+  std::vector<ConfigParms> fConfigParmList;
+  std::map<std::string, std::string> fConfigData;
+
+  virtual void MakeParms();
+
+  ClassDef(THcEvt137Handler,0)
+};
+
+#endif

--- a/src/THcEvt137Handler.h
+++ b/src/THcEvt137Handler.h
@@ -29,7 +29,6 @@ class THcEvt137Handler : public THaEvtTypeHandler {
  private:
 
   Int_t fNDecoded; // Counter for decoded type 137 event
-  const int NTHR = 16;
 
   std::vector<UInt_t> fEvtTypes;
 

--- a/src/THcEvt137Handler.h
+++ b/src/THcEvt137Handler.h
@@ -21,23 +21,21 @@ class THcEvt137Handler : public THaEvtTypeHandler {
   std::vector<UInt_t> GetEvtTypes() { return fEvtTypes; }
   std::string GetInfo( const char* keyname );
 
-  void MakeConfigTree(bool make_tree) { fMakeConfigTree = make_tree; } // default is true
-  void MakeParms(bool make_parms ) { fMakeParms = make_parms; } // default is true
-
+  void     MakeConfigTree(bool make_tree) { fMakeConfigTree = make_tree; } // default is true
+  void     MakeParms(bool make_parms ) { fMakeParms = make_parms; } // default is true
   // Some useful getter functions for FADC250
-  int GetNSA( UInt_t crate, UInt_t slot );
-  int GetNSB( UInt_t crate, UInt_t slot );
-  int GetNPED( UInt_t crate, UInt_t slot );
+  Int_t    GetNSA( UInt_t crate, UInt_t slot );
+  Int_t    GetNSB( UInt_t crate, UInt_t slot );
+  Int_t    GetNPED( UInt_t crate, UInt_t slot );
   Double_t GetPED( UInt_t crate, UInt_t slot, UInt_t ch );
 
  private:
 
-  Int_t fNDecoded; // Counter for decoded type 137 event
-
-  TTree* fConfigTree; // Output tree for config information
-  bool fMakeConfigTree; // default is true
-  bool fMakeParms;
-  UInt_t fCounter; // rough counter of the number of parameters to save
+  Int_t  fNDecoded;       // Counter for decoded type 137 event
+  TTree* fConfigTree;     // Output tree for config information
+  bool   fMakeConfigTree; // default is true
+  bool   fMakeParms;      // default is false
+  UInt_t fCounter;        // rough counter of the number of parameters to save
 
   struct ConfigData {
     int roc;
@@ -47,7 +45,7 @@ class THcEvt137Handler : public THaEvtTypeHandler {
     std::vector<Double_t> pars;
   };
 
-  // with a uinque keyname
+  // With a uinque keyname for gHcParms
   std::map<std::string, ConfigData> fConfigDataMap;
 
   std::vector<UInt_t> fRoc; // List of rocs with config info

--- a/src/THcEvt137Handler.h
+++ b/src/THcEvt137Handler.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include "TTree.h"
 
 class THcEvt137Handler : public THaEvtTypeHandler {
  public:
@@ -14,34 +15,46 @@ class THcEvt137Handler : public THaEvtTypeHandler {
   
   virtual Int_t   Analyze( THaEvData *evdata );
   virtual EStatus Init( const TDatime& date );
+  virtual Int_t   End( THaRunBase* r=nullptr );
   virtual void    AddEvtType( UInt_t evtype );
-  virtual void    AddParameter(std::string parname, std::string keyname);
 
   std::vector<UInt_t> GetEvtTypes() { return fEvtTypes; }
   std::string GetInfo( const char* keyname );
 
+  void MakeConfigTree(bool make_tree) { fMakeConfigTree = make_tree; } // default is true
+  void MakeParms(bool make_parms ) { fMakeParms = make_parms; } // default is true
+
   // Some useful getter functions for FADC250
-  UInt_t GetNSA( UInt_t crate, UInt_t slot );
-  UInt_t GetNSB( UInt_t crate, UInt_t slot );
-  UInt_t GetNPED( UInt_t crate, UInt_t slot );
+  int GetNSA( UInt_t crate, UInt_t slot );
+  int GetNSB( UInt_t crate, UInt_t slot );
+  int GetNPED( UInt_t crate, UInt_t slot );
   Double_t GetPED( UInt_t crate, UInt_t slot, UInt_t ch );
 
  private:
 
   Int_t fNDecoded; // Counter for decoded type 137 event
 
-  std::vector<UInt_t> fEvtTypes;
+  TTree* fConfigTree; // Output tree for config information
+  bool fMakeConfigTree; // default is true
+  bool fMakeParms;
+  UInt_t fCounter; // rough counter of the number of parameters to save
 
-  // General parm and key pairs
-  struct ConfigParms {
-      std::string par;
-      std::string key;
+  struct ConfigData {
+    int roc;
+    int slot;
+    std::string parname;
+    std::string pars_str; // data in a single string format
+    std::vector<Double_t> pars;
   };
 
-  std::vector<ConfigParms> fConfigParmList;
-  std::map<std::string, std::string> fConfigData;
+  // with a uinque keyname
+  std::map<std::string, ConfigData> fConfigDataMap;
 
-  virtual void MakeParms();
+  std::vector<UInt_t> fRoc; // List of rocs with config info
+  std::vector<UInt_t> fEvtTypes;
+
+  void SaveConfigData();
+  void MakeParms();
 
   ClassDef(THcEvt137Handler,0)
 };

--- a/src/THcHitList.cxx
+++ b/src/THcHitList.cxx
@@ -42,6 +42,7 @@ THcHitList::THcHitList()
   , fNSA(-1)
   , fNSB(-1)
   , fNPED(-1)
+  , fPSE137(nullptr)
   , fNTDCRef_miss(0)
   , fNADCRef_miss(0)
   , fMap(nullptr)
@@ -175,11 +176,15 @@ void THcHitList::InitHitList(THaDetMap* detmap,
   TObjLink *lnk = gHaEvtHandlers->FirstLink();
   while (lnk) {
     if(strcmp(lnk->GetObject()->ClassName(),"THcConfigEvtHandler")==0) {
-      break;
+      fPSE125 = lnk ? dynamic_cast<THcConfigEvtHandler*>(lnk->GetObject()) : nullptr;
     }
+
+    if(strcmp(lnk->GetObject()->ClassName(),"THcEvt137Handler")==0) {
+      fPSE137 = lnk ? dynamic_cast<THcEvt137Handler*>(lnk->GetObject()) : nullptr;
+    }      
+
     lnk = lnk->Next();
   }
-  fPSE125 = lnk ? dynamic_cast<THcConfigEvtHandler*>(lnk->GetObject()) : nullptr;
   if( !fPSE125 ) {
     cout << "THcHitList::InitHitList : Prestart event 125 not found." << endl;
   }
@@ -187,6 +192,10 @@ void THcHitList::InitHitList(THaDetMap* detmap,
 
   fNTDCRef_miss = 0;
   fNADCRef_miss = 0;
+
+  if( !fPSE137 ) {
+    cout << "THcHitList::InitHitList : Prestart event 137 not found." << endl;
+  }
 
   //  DisableSlipCorrection();
 }
@@ -312,10 +321,17 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
         Int_t ref_fNSA = 0;
         Int_t ref_fNSB = 0;
         Int_t ref_fNPED = 0;
-        if( fPSE125 ) {
+        if( fPSE125->IsPresent(theMap.crate) ) {
           ref_fNSA = fPSE125->GetNSA(theMap.crate);
           ref_fNSB = fPSE125->GetNSB(theMap.crate);
           ref_fNPED = fPSE125->GetNPED(theMap.crate);
+          if( ref_fNSA == -1 ) ref_fNSA = 26;
+          if( ref_fNSB == -1 ) ref_fNSB = 3;
+          if( ref_fNPED == -1 ) ref_fNPED = 4;
+	} else if ( fPSE137 ) {
+          ref_fNSA = fPSE137->GetNSA(theMap.crate, theMap.slot);
+          ref_fNSB = fPSE137->GetNSB(theMap.crate, theMap.slot);
+          ref_fNPED = fPSE137->GetNPED(theMap.crate, theMap.slot);
           if( ref_fNSA == -1 ) ref_fNSA = 26;
           if( ref_fNSB == -1 ) ref_fNSB = 3;
           if( ref_fNPED == -1 ) ref_fNPED = 4;
@@ -324,6 +340,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
           ref_fNSB = 3;
           ref_fNPED = 4;
         }
+
         // Set F250 parameters.
         auto* refrawhit = new THcRawAdcHit();  // large object, better on the heap
         refrawhit->SetF250Params(ref_fNSA, ref_fNSB, ref_fNPED);
@@ -490,10 +507,10 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
               }
             }
           }
-        }
+	}
       } else {                        // This is a Flash ADC
 
-        if( fPSE125 ) {
+        if( fPSE125->IsPresent(d->crate) ) {
           if( !fHaveFADCInfo ) {
             fNSA = fPSE125->GetNSA(d->crate);
             fNSB = fPSE125->GetNSB(d->crate);
@@ -503,12 +520,23 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
             if( fNPED == -1 ) fNPED = 4;
             fHaveFADCInfo = kTRUE;
           }
+	} else if( fPSE137 ) {
+          if( !fHaveFADCInfo ) {
+	    fNSA = fPSE137->GetNSA(d->crate, d->slot);
+	    fNSB = fPSE137->GetNSB(d->crate, d->slot);
+	    fNPED = fPSE137->GetNPED(d->crate, d->slot);
+            if( fNSA == -1 ) fNSA = 26;
+            if( fNSB == -1 ) fNSB = 3;
+            if( fNPED == -1 ) fNPED = 4;
+            fHaveFADCInfo = kTRUE;
+	  }
         } else if( !fHaveFADCInfo ) {
           fNSA = 26;
           fNSB = 3;
           fNPED = 4;
           fHaveFADCInfo = kTRUE;
         }
+
         rawhit->SetF250Params(fNSA, fNSB, fNPED);
 
 	// Copy the samples

--- a/src/THcHitList.h
+++ b/src/THcHitList.h
@@ -9,6 +9,7 @@
 #include "Decoder.h"
 #include "THaCrateMap.h"
 #include "Fadc250Module.h"
+#include "THcEvt137Handler.h"
 
 #include <iomanip>
 #include <map>
@@ -77,6 +78,8 @@ protected:
   Int_t fNSA;
   Int_t fNSB;
   Int_t fNPED;
+
+  THcEvt137Handler* fPSE137;
 
   Int_t fNTDCRef_miss;
   Int_t fNADCRef_miss;


### PR DESCRIPTION
Adding a new config handler for event type 137. 

With the new firmware update, this event now contains FADC configuration information in a regular text format instead of event 125. For a simple backward compatibility, THcHitList has been updated to first check the existing THcConfigEvtHander and then THcEvt137Handler to get the FADC config parameters (NSA, NSB, NPED).

It also saves the data into a new tree (THC). Making the parameters to global variables or writing tree is optional; default is true for both, but can be turned off in a replay script. 