### PR TITLE
Add JSON Export Infrastructure for THcParmList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,3 +40,42 @@ if(HCANA_BUILTIN_PODD)
 endif()
 add_subdirectory(src)
 add_subdirectory(cmake)
+
+#----------------------------------------------------------------------------
+# Optional features: JSON export and CCDB
+
+include(CheckIncludeFileCXX)
+
+option(HCANA_WITH_JSON "Enable JSON export of THcParmList (gHcParms)" ON)
+option(HCANA_JSON_EXPORT_STRINGS
+       "Export Textvars strings in JSON (requires newer Podd Textvars API)" OFF)
+option(HCANA_WITH_CCDB "Enable CCDB support in THcParmList" OFF)
+
+# If ROOT (or your system) exposes nlohmann/json.hpp via the include path,
+# this check will succeed. ROOT 6.x vendors nlohmann::json internally, and
+# many builds install <nlohmann/json.hpp> in the standard include path.
+
+# Let the check see the same includes as normal code; ROOT_INCLUDE_DIRS is
+# set by ROOT/Podd CMake.
+if(DEFINED ROOT_INCLUDE_DIRS)
+  set(CMAKE_REQUIRED_INCLUDES "${ROOT_INCLUDE_DIRS}")
+endif()
+
+if(HCANA_WITH_JSON)
+  check_include_file_cxx("nlohmann/json.hpp" HCANA_HAVE_NLOHMANN_JSON)
+  if(NOT HCANA_HAVE_NLOHMANN_JSON)
+    message(WARNING
+      "HCANA_WITH_JSON=ON but <nlohmann/json.hpp> not found. "
+      "Disabling JSON export of THcParmList.")
+    set(HCANA_WITH_JSON OFF)
+  endif()
+endif()
+
+# These are the actual preprocessor symbols your code uses
+if(HCANA_WITH_JSON)
+  add_compile_definitions(WITH_JSON)
+endif()
+
+if(HCANA_WITH_CCDB)
+  add_compile_definitions(WITH_CCDB)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,22 @@ if(WITH_DEBUG)
   target_compile_definitions(${LIBNAME} PUBLIC WITH_DEBUG)
 endif()
 
+# Enable JSON export (THcParmList::ExportJSON)
+if(HCANA_WITH_JSON)
+  message(STATUS "HCANA: Enabling JSON export (WITH_JSON)")
+  target_compile_definitions(${LIBNAME} PRIVATE WITH_JSON)
+endif()
+
+if(HCANA_JSON_EXPORT_STRINGS)
+  target_compile_definitions(${LIBNAME} PUBLIC HCANA_JSON_EXPORT_STRINGS)
+endif()
+
+# Enable CCDB support
+if(HCANA_WITH_CCDB)
+  message(STATUS "HCANA: Enabling CCDB support (WITH_CCDB)")
+  target_compile_definitions(${LIBNAME} PRIVATE WITH_CCDB)
+endif()
+
 target_link_libraries(${LIBNAME}
   PUBLIC
     Podd::Podd

--- a/src/THcParmList.cxx
+++ b/src/THcParmList.cxx
@@ -58,6 +58,11 @@ An instance of Podd::Textvars is created to hold the string parameters.
 #include <stdexcept>
 #include <memory>
 
+#ifdef WITH_JSON
+#include <iomanip>
+#include <nlohmann/json.hpp>
+#endif
+
 using namespace std;
 Int_t  fDebug   = 1;  // Keep this at one while we're working on the code
 
@@ -692,6 +697,178 @@ void THcParmList::PrintFull( Option_t* option ) const
   THaVarList::PrintFull(option);
   TextList->Print();
 }
+
+#ifdef WITH_JSON
+
+/**
+ * \brief Export all parameters in this THcParmList to a JSON file.
+ *
+ * This writes:
+ *  - numeric parameters stored in the underlying THaVarList
+ *    (Hall C calibration/configuration numbers), and
+ *  - optionally, text parameters stored in TextList (Podd::Textvars),
+ *    if HCANA_JSON_EXPORT_STRINGS is defined and the required Textvars
+ *    API is available.
+ *
+ * Only scalar and 1D-array parameters of types kInt and kDouble are exported.
+ * Any THaVar entries with other VarType codes are skipped and reported via
+ * Warning("ExportJSON", ...).
+ *
+ * The resulting JSON has the structure:
+ *
+ * \code{.json}
+ * {
+ *   "parameters": {
+ *     "name": {
+ *       "description": "...",
+ *       "type": "int" | "double",
+ *       "length": N,
+ *       "value": 123            // or [1,2,3,...]
+ *     },
+ *     ...
+ *   },
+ *   "strings": {                // only if HCANA_JSON_EXPORT_STRINGS is defined
+ *     "name": "value",          // scalar textvar
+ *     "other": ["v1","v2",...]  // multi-valued textvar
+ *   }
+ * }
+ * \endcode
+ *
+ * \param filename  Path of the JSON file to write.
+ * \param indent    If < 0, emit compact JSON (no extra whitespace).
+ *                  If > 0, pretty-print with the given number of spaces.
+ *
+ * \return 0 on success, -1 if the file cannot be opened.
+ */
+Int_t THcParmList::ExportJSON( const char* filename, Int_t indent ) const
+{
+  nlohmann::json jroot;
+  nlohmann::json jparams = nlohmann::json::object();
+#ifdef HCANA_JSON_EXPORT_STRINGS
+  nlohmann::json jstrings = nlohmann::json::object();
+#endif
+
+  // =======================
+  // Numeric parameters (THaVarList entries)
+  // =======================
+  TIter next( const_cast<THcParmList*>(this) );
+  TObject* obj = nullptr;
+
+  while( (obj = next()) ) {
+    THaVar* var = dynamic_cast<THaVar*>( obj );
+    if( !var )
+      continue;
+
+    VarType t = var->GetType();
+
+    // THcParmList only creates kInt and kDouble via Load/CCDB.
+    bool is_int = false;
+    bool is_double = false;
+    const char* type_str = "unknown";
+
+    switch( t ) {
+    case kInt:
+      is_int = true;
+      type_str = "int";
+      break;
+    case kDouble:
+      is_double = true;
+      type_str = "double";
+      break;
+    default:
+      Warning( "ExportJSON",
+               "Skipping variable '%s' with unsupported VarType %d",
+               var->GetName(), static_cast<int>(t) );
+      continue;
+    }
+
+    nlohmann::json entry = nlohmann::json::object();
+
+    const char* title = var->GetTitle();
+    entry["description"] = title ? std::string(title) : std::string();
+    entry["type"] = type_str;
+
+    Int_t len = var->GetLen();
+    entry["length"] = len;
+
+    (void)is_int; // Suppress unused warning
+    if( len <= 1 ) {
+      // scalar
+      if( is_double )
+        entry["value"] = var->GetValue();
+      else
+        entry["value"] = var->GetValueInt();
+    } else {
+      // 1D array
+      nlohmann::json arr = nlohmann::json::array();
+      for( Int_t i = 0; i < len; ++i ) {
+        if( is_double )
+          arr.push_back( var->GetValue(i) );
+        else
+          arr.push_back( var->GetValueInt(i) );
+      }
+      entry["value"] = arr;
+    }
+
+    jparams[ var->GetName() ] = entry;
+  }
+
+  jroot["parameters"] = jparams;
+
+#ifndef HCANA_JSON_EXPORT_STRINGS
+  Warning("ExportJSON",
+          "Compiled without HCANA_JSON_EXPORT_STRINGS: text variables "
+          "(Podd::Textvars) will NOT be included in this JSON output.");
+#endif
+
+#ifdef HCANA_JSON_EXPORT_STRINGS
+  // =======================
+  // Text parameters (Podd::Textvars)
+  // =======================
+  //
+  // This block assumes that Textvars has been extended with a method:
+  //
+  //   const Textvars_t& GetAllStringsMap() const;
+  //
+  // where Textvars_t is:
+  //   typedef std::map<std::string,std::vector<std::string>> Textvars_t;
+  //
+  if( TextList ) {
+    const auto& all_text = TextList->GetAllStringsMap();
+
+    for( const auto& kv : all_text ) {
+      const std::string& name = kv.first;
+      const std::vector<std::string>& vals = kv.second;
+
+      if( vals.empty() ) {
+        jstrings[name] = "";
+      } else if( vals.size() == 1 ) {
+        jstrings[name] = vals[0];
+      } else {
+        jstrings[name] = vals;  // JSON array of strings
+      }
+    }
+    jroot["strings"] = jstrings;
+  }
+#endif // HCANA_JSON_EXPORT_STRINGS
+
+  std::ofstream out( filename );
+  if( !out ) {
+    Error( "ExportJSON", "Cannot open %s for writing", filename );
+    return -1;
+  }
+
+  // Compact vs pretty-print controlled by indent
+  if( indent < 0 )
+    out << jroot.dump() << '\n';       // compact
+  else
+    out << jroot.dump(indent) << '\n'; // pretty
+
+  return 0;
+}
+
+#endif // WITH_JSON
+
 #ifdef WITH_CCDB
 //_____________________________________________________________________________
 Int_t THcParmList::OpenCCDB(Int_t runnum)

--- a/src/THcParmList.h
+++ b/src/THcParmList.h
@@ -39,6 +39,10 @@ public:
     return(TextList->Get(name, 0));
   }
 
+  #ifdef WITH_JSON
+    Int_t ExportJSON(const char* filename, Int_t indent = -1) const;
+  #endif
+
   Int_t AddString(const std::string& name, const std::string& value) {
     return(TextList->Add(name, value));
   }


### PR DESCRIPTION
This commit introduces optional JSON export capabilities to `THcParmList`.

## CMake Additions

At the top-level `CMakeLists.txt`, three new options are added:

* `HCANA_WITH_JSON`
* `HCANA_WITH_CCDB`
* `HCANA_JSON_EXPORT_STRINGS`

JSON export requires `nlohmann::json`, which is typically provided through CERN ROOT. If the dependency is not found, a warning is emitted and JSON export is disabled. This allows the feature to fail quietly for users who do not require it.

The corresponding compile definitions are propagated into `src/CMakeLists.txt` so they can control the code paths in `THcParmList.cxx`.

## Purpose

The intention of this change is to produce a structured JSON representation of the effective configuration parameters used by the Hall C analyzer. This is needed for:

* constructing CCDB entries from legacy parameter repositories
* preserving FAIR-compliant metadata about analysis configurations
* tracking run-by-run parameter provenance

## Textvars Limitation and Future Work

`THcParmList` also stores string parameters via Podd’s `Textvars` system. However, Podd currently lacks a non-destructive accessor that exposes all string variables as the underlying:

```cpp
std::map<std::string, std::vector<std::string>>
```

The existing interfaces perform destructive moves or only provide element-level access.

To avoid breaking Podd, this commit introduces a compile-time option (`HCANA_JSON_EXPORT_STRINGS`) that enables or suppresses string export until the required API is available upstream.

A Pull Request will be submitted to Podd proposing a new method (`GetAllStringsMap()` or similar) so that future versions expose this data safely. Once Podd incorporates this API, the conditional compile guard in `THcParmList` can be simplified or removed.