### PR TITLE
add two header files to fix compilation error against ROOT 6.38 

### DIFF
--- a/src/THcEvt137Handler.cxx
+++ b/src/THcEvt137Handler.cxx
@@ -9,7 +9,7 @@
 #include "TROOT.h"
 #include <iostream>
 #include <sstream>
-#include <bits/stdc++.h>
+#include <algorithm>
 
 using namespace std;
 

--- a/src/THcEvt137Handler.cxx
+++ b/src/THcEvt137Handler.cxx
@@ -9,6 +9,7 @@
 #include "TROOT.h"
 #include <iostream>
 #include <sstream>
+#include <bits/stdc++.h>
 
 using namespace std;
 

--- a/src/THcRawAdcHit.cxx
+++ b/src/THcRawAdcHit.cxx
@@ -186,6 +186,7 @@ Returns 0 if no signal pedestal is set.
 
 #include "THcRawAdcHit.h"
 #include "TString.h"
+#include "TMath.h"
 #include <iostream>
 
 using namespace std;


### PR DESCRIPTION
My container image has automatically update its ROOT version to 6.38 and now hcana would not compile. It seems something changed between ROOT 6.36 and 6.38, meaning that we now need to include two header files by hand 

The first error is in THcEvt137Handler. The error is related to `std::find`
```
HcEvt137Handler.cxx:211:16: error: no matching function for call to 'find(std::vector<unsigned int>::iterator,std::vector<unsigned int>::iterator, UInt_t&)'
211 |   if( std::find(fEvtTypes.begin(), fEvtTypes.end(), evtype) == fEvtTypes.end() )
```
with similar error message for line 83.
Including bits/stdc++.h seems to resolve this issue

The first error is in THcRawAdcHit, where the compiler complains TMath is not declared.

The PR added those two headers, and should not affect compiling hcana against previous versions of ROOT. I have tested it against ROOT 6.36.