### PR TITLE
THcBPM: Avoid using a hard-coded detector name when filling the detector map

### DIFF
--- a/src/THcBPM.cxx
+++ b/src/THcBPM.cxx
@@ -50,13 +50,11 @@ THaAnalysisObject::EStatus THcBPM::Init( const TDatime& date )
 {
   //  cout << "THcBPM::Init" << endl;
 
-  char EngineDID[] = "xBPM";
-  EngineDID[0] = toupper(GetApparatus()->GetName()[0]);
-  
-  if( gHcDetectorMap->FillMap(fDetMap, EngineDID) < 0 ) {
+  string EngineDID = string(GetApparatus()->GetName()).substr(0,1) + GetName();
+  std::transform(EngineDID.begin(), EngineDID.end(), EngineDID.begin(), ::toupper);
+  if( gHcDetectorMap->FillMap(fDetMap, EngineDID.c_str()) < 0 ) {
     static const char* const here = "Init()";
-    Error( Here(here), "Error filling detectormap for %s.", EngineDID);
-
+    Error( Here(here), "Error filling detectormap for %s.", EngineDID.c_str());
     return kInitError;
   }
 


### PR DESCRIPTION
The BPM detector module is using a hard-coded detector name when filling the detector map at Init process. This has been not an issue for most of the cases since we have only one type of each detector for each spectrometer. Since we are planning to add multiple BPM signals into the data, we need to pick up a unique detector name for different bpms.