### PR TITLE
Always use the first entry of pedestal data for FADC

### DIFF
--- a/src/THcHitList.cxx
+++ b/src/THcHitList.cxx
@@ -568,7 +568,7 @@ Int_t THcHitList::DecodeToHitList( const THaEvData& evdata, Bool_t suppresswarni
           rawhit->SetDataTimePedestalPeak(signal,
               evdata.GetData(Decoder::kPulseIntegral, d->crate, d->slot, chan, ipulse),
               evdata.GetData(Decoder::kPulseTime, d->crate, d->slot, chan, ipulse) + 64 * timeshift,
-              evdata.GetData(Decoder::kPulsePedestal, d->crate, d->slot, chan, ipulse),
+	      evdata.GetData(Decoder::kPulsePedestal, d->crate, d->slot, chan, 0),
               evdata.GetData(Decoder::kPulsePeak, d->crate, d->slot, chan, ipulse));
 	}
         if( nsamples > 0 ) {


### PR DESCRIPTION
In the recent firmware versions, pedestal information is only reported only once for a channel with multiple hits. 
Because Fadc250Module::GetNumEvents will returns 1 in this case, when GetData method is called for the pedestal it returns 0 except for the first hit. In THcRawAdcHit, pedestal value for pulse data is overwritten when loop over all pulses and results in setting the pedestal to zero when there are multiple pulses. In the order firmware, pulse pedestal was reported for each identified pulse although the value would be the same.
This simple change is to always use the first entry of the pedestal data from the fadc decoder module.